### PR TITLE
[CHORE] adding ctx cancellation

### DIFF
--- a/internal/ingester/queryIngester.go
+++ b/internal/ingester/queryIngester.go
@@ -1,0 +1,79 @@
+package ingester
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"log"
+	"time"
+)
+
+type QueryIngester struct {
+	db      *sql.DB
+	queries chan Query
+}
+
+type Query struct {
+	TS            time.Time
+	QueryParam    string
+	TimeParam     time.Time
+	LabelMatchers []map[string]string
+	Duration      time.Duration
+	Fingerprint   string
+}
+
+func NewQueryIngester(db *sql.DB, bufferSize int) *QueryIngester {
+	return &QueryIngester{
+		db:      db,
+		queries: make(chan Query, bufferSize),
+	}
+}
+
+func (i *QueryIngester) Ingest(ctx context.Context, query Query) {
+	select {
+	case i.queries <- query:
+	case <-ctx.Done():
+		log.Printf("Ingestion stopped, closing queries channel")
+		close(i.queries)
+	default:
+		//TODO:(nicolastakashi) expose this to a metric
+		log.Printf("dropping query: %v", query)
+	}
+}
+
+const insertQuery = `INSERT INTO queries VALUES (?, ?, ?, ?, ?, ?)`
+
+func (i *QueryIngester) Run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("stopping query ingester")
+			return
+		case query, ok := <-i.queries:
+			if !ok {
+				log.Printf("channel closed, stopping query ingester")
+				return
+			}
+
+			labelMatchersBlob, err := json.Marshal(query.LabelMatchers)
+			if err != nil {
+				log.Printf("unable to marshal label matchers: %v", err)
+				continue
+			}
+
+			_, err = i.db.ExecContext(
+				ctx,
+				insertQuery,
+				query.TS,
+				query.Fingerprint,
+				query.QueryParam,
+				query.TimeParam,
+				labelMatchersBlob,
+				query.Duration.Milliseconds())
+
+			if err != nil {
+				log.Printf("unable to insert query: %v", err)
+			}
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,9 @@ import (
 	"net/url"
 	"os"
 	"syscall"
+	"time"
 
+	"github.com/MichaHoffmann/prom-analytics-proxy/internal/ingester"
 	"github.com/oklog/run"
 
 	_ "github.com/marcboeker/go-duckdb"
@@ -26,16 +28,18 @@ func main() {
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	flagset.StringVar(&insecureListenAddress, "insecure-listen-address", "", "The address the prom-analytics-proxy proxy HTTP server should listen on.")
+	flagset.StringVar(&insecureListenAddress, "insecure-listen-address", ":9090", "The address the prom-analytics-proxy proxy HTTP server should listen on.")
 	flagset.StringVar(&upstream, "upstream", "", "The URL of the upstream prometheus API.")
 	flagset.StringVar(&dbPath, "db-path", "prom-analytics.db", "The path to the duckdb file.")
 	flagset.IntVar(&bufSize, "buf-size", 100, "Buffer size for the insert channel.")
 	flagset.Parse(os.Args[1:])
 
 	upstreamURL, err := url.Parse(upstream)
+
 	if err != nil {
 		log.Fatalf("unable to parse upstream: %v", err)
 	}
+
 	if upstreamURL.Scheme != "http" && upstreamURL.Scheme != "https" {
 		log.Fatalf("Invalid scheme for upstream URL %q, only 'http' and 'https' are supported", upstream)
 	}
@@ -49,17 +53,29 @@ func main() {
 	if err := db.Ping(); err != nil {
 		log.Fatalf("unable to ping DB: %v", err)
 	}
-	if _, err = db.Exec(`
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if _, err = db.ExecContext(ctx, `
     CREATE TABLE IF NOT EXISTS queries (ts TIMESTAMP, fingerprint VARCHAR, query_param VARCHAR, time_param TIMESTAMP, label_matchers_list STRING, duration_ms BIGINT)
 `); err != nil {
 		log.Fatal(err)
 	}
 
+	queryIngester := ingester.NewQueryIngester(db, bufSize)
+
 	var g run.Group
+
+	g.Add(func() error {
+		queryIngester.Run(ctx)
+		return nil
+	}, func(error) {
+		cancel()
+	})
 
 	// Register proxy HTTP Server
 	{
-		routes, err := newRoutes(upstreamURL, db, bufSize)
+		routes, err := newRoutes(upstreamURL, *queryIngester)
 		if err != nil {
 			log.Fatalf("unable to create routes: %v", err)
 		}
@@ -69,7 +85,12 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to listen on address: %v", err)
 		}
-		srv := &http.Server{Handler: mux}
+		srv := &http.Server{
+			Handler: mux,
+			BaseContext: func(_ net.Listener) context.Context {
+				return ctx
+			},
+		}
 
 		g.Add(func() error {
 			log.Printf("Listening insecurely on %v", l.Addr())
@@ -80,13 +101,36 @@ func main() {
 			return nil
 		}, func(error) {
 			srv.Close()
+			cancel()
 		})
 	}
 
 	// Register Signal Handler
 	{
-		g.Add(run.SignalHandler(context.Background(), syscall.SIGINT, syscall.SIGTERM))
+		g.Add(run.SignalHandler(ctx, syscall.SIGINT, syscall.SIGTERM))
 	}
+
+	// Goroutine to enforce a timeout after receiving SIGTERM
+	g.Add(func() error {
+		<-ctx.Done()
+		log.Printf("Received signal. Waiting up to 30 seconds to finish processing...")
+
+		timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer timeoutCancel()
+
+		select {
+		case <-timeoutCtx.Done():
+			if timeoutCtx.Err() == context.DeadlineExceeded {
+				log.Printf("Timeout reached. Forcing shutdown.")
+				os.Exit(1)
+			}
+		case <-ctx.Done():
+			// This case might never be selected since ctx.Done() has already been triggered.
+		}
+		return nil
+	}, func(error) {
+		cancel()
+	})
 
 	if err := g.Run(); err != nil {
 		if !errors.As(err, &run.SignalError{}) {


### PR DESCRIPTION
This pull request includes significant changes to improve the efficiency and structure of the codebase. The changes mainly revolve around the creation of a new `QueryIngester` in the `internal/ingester/queryIngester.go` file and the subsequent modifications in the `main.go` and `routes.go` files to accommodate this new structure. 

Here are the top five most important changes:

Creation of `QueryIngester`:

* [`internal/ingester/queryIngester.go`](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fR1-R79): A new file was created to define the `QueryIngester` struct and its associated methods. This struct is responsible for ingesting queries and storing them in a database. It includes methods for creating a new `QueryIngester`, ingesting a query, and running the ingester.

Changes in `main.go`:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R14-R16): Imported the `ingester` package and created a new `QueryIngester` instance in the `main` function. The `QueryIngester` instance is then used in the `Run` method and the `newRoutes` function. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R14-R16) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L29-R42) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L52-R78)
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L72-R93): Updated the `http.Server` struct to include a `BaseContext` method that returns the context created earlier.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R104-R134): Added a goroutine to enforce a timeout after receiving a SIGTERM signal.

Changes in `routes.go`:

* [`routes.go`](diffhunk://#diff-d6c18da6d533ae648d3ae7766cfafd9f873c51db02ecb1d92fc93730035aea48L5-R11): Removed the `queryC` channel and `db` field from the `routes` struct and replaced them with a `QueryIngester` field. The `newRoutes` function was updated to accept a `QueryIngester` as a parameter instead of a database and buffer size. [[1]](diffhunk://#diff-d6c18da6d533ae648d3ae7766cfafd9f873c51db02ecb1d92fc93730035aea48L5-R11) [[2]](diffhunk://#diff-d6c18da6d533ae648d3ae7766cfafd9f873c51db02ecb1d92fc93730035aea48L22-L49)
* [`routes.go`](diffhunk://#diff-d6c18da6d533ae648d3ae7766cfafd9f873c51db02ecb1d92fc93730035aea48L74-R67): Updated the `query` method to use the `Ingest` method of `QueryIngester` instead of sending the query to the `queryC` channel. The `recordQueries` method was removed as it's no longer needed.