### PR TITLE
[CHORE] adding docker and make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.23.0 AS build
+
+WORKDIR /go/src/github.com/MichaHoffmann/prom-analytics-proxy
+
+RUN apt-get update
+RUN useradd -ms /bin/bash cole
+
+COPY --chown=cole:cole . .
+
+RUN make all
+
+FROM gcr.io/distroless/static:latest-amd64
+
+WORKDIR /prom-analytics-proxy
+
+COPY --from=build /go/src/github.com/MichaHoffmann/prom-analytics-proxy/bin/* /bin/
+
+USER nobody
+
+ENTRYPOINT [ "/bin/prom-analytics-proxy" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+REVISION ?= $(shell git rev-parse HEAD)
+BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+
+RELEASE_VERSION ?=$(shell git describe --tags --abbrev=0 2>/dev/null || echo $(REVISION))
+BINARY_FOLDER=bin
+BINARY_NAME=prom-analytics-proxy
+ARTIFACT_NAME=coralogix/$(BINARY_NAME)
+GOCMD=go
+GOMAIN=main.go
+GOBUILD=$(GOCMD) build
+GOOS?=$(shell go env GOOS)
+ENVVARS=GOOS=$(GOOS) CGO_ENABLED=0
+
+LDFLAGS=-w -extldflags "-static" \
+		-X github.com/prometheus/common/version.Version=$(RELEASE_VERSION) \
+		-X github.com/prometheus/common/version.Revision=$(REVISION) \
+		-X github.com/prometheus/common/version.Branch=$(BRANCH) \
+		-X github.com/prometheus/common/version.BuildUser=$(shell whoami) \
+		-X "github.com/prometheus/common/version.BuildDate=$(shell date -u)"
+
+.PHONY: docker-build
+docker-build:
+	@DOCKER_BUILDKIT=1 docker build -t ${ARTIFACT_NAME}:${RELEASE_VERSION} -f Dockerfile --progress=plain .
+
+.PHONY: build
+build:
+	$(ENVVARS) $(GOCMD) build -ldflags '$(LDFLAGS)' -o $(BINARY_FOLDER)/$(BINARY_NAME) -v $(GOMAIN)
+
+.PHONY: deps
+deps:
+	$(ENVVARS) $(GOCMD) mod download
+
+.PHONY: fmt
+fmt:
+	$(ENVVARS) $(GOCMD) fmt -x ./...
+
+.PHONY: vet
+vet:
+	$(ENVVARS) $(GOCMD) vet ./...
+
+.PHONY: tests
+tests:
+	$(ENVVARS) $(GOCMD) test ./...
+
+all: fmt vet tests deps build
+
+.PHONY: build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MichaHoffmann/prom-analytics-proxy
 
-go 1.21.10
+go 1.23.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.26.0


### PR DESCRIPTION
This pull request includes significant updates to the build and deployment process for the `prom-analytics-proxy` project. The changes involve creating a new Dockerfile, updating the Makefile to streamline build commands, and updating the Go module version.

### Dockerfile and Build Process:

* **New Dockerfile**: Added a Dockerfile to build the project using a multi-stage build process, which includes setting up a Go environment, copying the source code, and running the build. The final image is based on `distroless` for security and efficiency. (`Dockerfile`)

### Makefile Enhancements:

* **Makefile Updates**: Added various targets to the Makefile for building, formatting, testing, and creating Docker images. This includes setting environment variables and using `ldflags` for embedding version information into the binary. (`Makefile`)

### Dependency Management:

* **Go Module Version Update**: Updated the Go version in the `go.mod` file from 1.21.10 to 1.23.0 to ensure compatibility with the latest features and improvements. (`go.mod`)