### PR TITLE
[CHORE] adding slog support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,6 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
-          push: true
+          push: false
           tags: |
             prom-analytics-proxy:main

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,62 @@
+// Copyright 2024 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"errors"
+	"flag"
+	"log/slog"
+	"os"
+)
+
+var (
+	logLevel  string
+	logFormat string
+)
+
+func RegisterFlags(flagSet *flag.FlagSet) {
+	flagSet.StringVar(&logLevel, "log-level", slog.LevelInfo.String(), "Log level")
+	flagSet.StringVar(&logFormat, "log-format", "text", "Log format (text, json)")
+}
+
+func parseLogLevel() (*slog.Level, error) {
+	level := slog.Level(1)
+	err := level.UnmarshalText([]byte(logLevel))
+	if err != nil {
+		return nil, err
+	}
+	return &level, nil
+}
+
+func NewLogger() (*slog.Logger, error) {
+	level, err := parseLogLevel()
+	if err != nil {
+		return nil, err
+	}
+
+	var handler slog.Handler
+	handlerOptions := &slog.HandlerOptions{
+		Level: *level,
+	}
+	switch {
+	case logFormat == "text":
+		handler = slog.NewTextHandler(os.Stdout, handlerOptions)
+	case logFormat == "json":
+		handler = slog.NewJSONHandler(os.Stdout, handlerOptions)
+	default:
+		return nil, errors.New("unknown log format")
+	}
+	return slog.New(handler), nil
+}


### PR DESCRIPTION
This pull request focuses on replacing the standard `log` package with the `slog` package for improved logging capabilities across the codebase. Additionally, it introduces a new logging utility to handle log levels and formats and resolve #16 

### Logging Enhancements:

* **Standard Logging Replacement:**
  * Replaced the `log` package with `slog` in `api/routes/routes.go` for better structured logging. [[1]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL9) [[2]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL160-R164) [[3]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL176-R175) [[4]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL291-R297) [[5]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL313-R312) [[6]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL338-R337) [[7]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL350-R349) [[8]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL390-R389)
  * Updated `internal/ingester/queryIngester.go` to use `slog` for logging errors and debug information. [[1]](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fL7-R7) [[2]](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fL41-R48) [[3]](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fL70-R77) [[4]](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fL98-R98)

* **New Logging Utility:**
  * Added `internal/log/log.go` to manage log levels and formats, allowing for flexible and configurable logging.

### Main Application Updates:

* **Integration of New Logging Utility:**
  * Integrated the new logging utility in `main.go`, replacing `log` with `slog` and setting up default logging configurations. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R8-L9) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R25) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R47-R48) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R58-R88) [[5]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L86-R100) [[6]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L98-R112) [[7]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L110-R125) [[8]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L125-R159) [[9]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L155-R174)