### PR TITLE
[CI] adding dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    rebase-strategy: "auto"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    rebase-strategy: "auto"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yaml` file to automate dependency updates for different package ecosystems. The most important changes involve setting up the update schedules and rebase strategies for `gomod`, `npm`, and `github-actions`.

Dependency update automation:

* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR1-R18): Added configuration for `gomod` with a weekly update schedule and auto rebase strategy.
* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR1-R18): Added configuration for `npm` in the `/ui` directory with a weekly update schedule and auto rebase strategy.
* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR1-R18): Added configuration for `github-actions` with a daily update schedule.