### PR TITLE
[REFACTORY] changing query endpoint

### DIFF
--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -8,6 +8,11 @@ import (
 type Provider interface {
 	WithDB(func(db *sql.DB))
 	Insert(ctx context.Context, q Query) error
-	Query(ctx context.Context, query string) (*sql.Rows, error)
+	Query(ctx context.Context, query string) (*QueryResult, error)
 	Close() error
+}
+
+type QueryResult struct {
+	Columns []string                 `json:"columns"`
+	Data    []map[string]interface{} `json:"data"`
 }

--- a/ui/src/fetch/index.ts
+++ b/ui/src/fetch/index.ts
@@ -5,7 +5,7 @@ const fetchAnalyticsData = async (query: string) => {
     params.append('query', query);
 
     try {
-        const response = await axios.get('http://localhost:9091/api/v1/analytics', { params });
+        const response = await axios.get('http://localhost:9091/api/v1/queries', { params });
         return response.data;
     } catch (error) {
         throw error;


### PR DESCRIPTION
This pull request includes several important changes to improve the handling of query results and update API endpoints. The changes include refactoring the query handling logic, updating API endpoint paths, and introducing a new `QueryResult` type for better data management.

### Refactoring and Data Handling:

* [`internal/db/clickhouse.go`](diffhunk://#diff-c56e815abf28fb2c2e8156ebe6a80c82ed2a0c4ea6db9512a6bde2c423191c57L136-R189): The `Query` method in `ClickHouseProvider` now returns a `QueryResult` instead of `*sql.Rows`. This change includes handling the rows and columns within the method and returning a structured result.
* [`internal/db/provider.go`](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4L11-R18): Introduced a new `QueryResult` type, which includes `Columns` and `Data` fields, to standardize the query results across the application. The `Query` method signature in the `Provider` interface was updated accordingly.

### API Endpoint Updates:

* [`api/routes/routes.go`](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL80-R80): The endpoint for analytics queries was updated from `/api/v1/analytics` to `/api/v1/queries` to better reflect its purpose.
* [`ui/src/fetch/index.ts`](diffhunk://#diff-7333d221d914db11c96fa3ba2865b07d64c6ccf3653ca17955b3a940b3aed969L8-R8): Updated the frontend to match the new API endpoint path for fetching analytics data.

### Minor Changes:

* [`internal/db/clickhouse.go`](diffhunk://#diff-c56e815abf28fb2c2e8156ebe6a80c82ed2a0c4ea6db9512a6bde2c423191c57R7): Added the `fmt` import to handle error formatting.