### PR TITLE
[CHORE] ingest in batches

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -43,6 +43,9 @@ jobs:
           version: v1.60.3
           args: --timeout 10m0s --go ${{ env.golang-version }}
 
+      - name: Test Golang Code
+        run: make tests
+
   format:
     runs-on: ubuntu-latest
     name: Documentation Formatting Check

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/prometheus v0.54.1
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
 	github.com/ClickHouse/ch-go v0.61.5 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -19,8 +21,10 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -8,7 +8,7 @@ import (
 
 type Provider interface {
 	WithDB(func(db *sql.DB))
-	Insert(ctx context.Context, q Query) error
+	Insert(ctx context.Context, queries []Query) error
 	Query(ctx context.Context, query string) (*QueryResult, error)
 	Close() error
 }

--- a/internal/ingester/queryingester_test.go
+++ b/internal/ingester/queryingester_test.go
@@ -1,0 +1,123 @@
+package ingester
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/MichaHoffmann/prom-analytics-proxy/internal/db"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockDBProvider struct {
+	mock.Mock
+}
+
+func (m *MockDBProvider) Insert(ctx context.Context, queries []db.Query) error {
+	args := m.Called(ctx, queries)
+	return args.Error(0)
+}
+
+func (m *MockDBProvider) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockDBProvider) Query(ctx context.Context, query string) (*db.QueryResult, error) {
+	args := m.Called(ctx, query)
+	return args.Get(0).(*db.QueryResult), args.Error(1)
+}
+
+func (p *MockDBProvider) WithDB(f func(db *sql.DB)) {
+}
+
+func TestQueryIngester_Run(t *testing.T) {
+	mockDB := new(MockDBProvider)
+	queriesC := make(chan db.Query, 10)
+	ingester := &QueryIngester{
+		dbProvider:          mockDB,
+		queriesC:            queriesC,
+		shutdownGracePeriod: 1 * time.Second,
+		ingestTimeout:       1 * time.Second,
+		batchSize:           2,
+		batchFlushInterval:  500 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go ingester.Run(ctx)
+
+	query1 := db.Query{QueryParam: "up"}
+	query2 := db.Query{QueryParam: "node_cpu_seconds_total"}
+
+	mockDB.On("Insert", mock.Anything, mock.Anything).Return(nil).Once()
+
+	ingester.Ingest(query1)
+	ingester.Ingest(query2)
+
+	time.Sleep(1 * time.Second)
+
+	mockDB.AssertExpectations(t)
+}
+
+func TestQueryIngester_Run_ShutdownGracePeriod(t *testing.T) {
+	mockDB := new(MockDBProvider)
+	queriesC := make(chan db.Query, 10)
+	ingester := &QueryIngester{
+		dbProvider:          mockDB,
+		queriesC:            queriesC,
+		shutdownGracePeriod: 1 * time.Second,
+		ingestTimeout:       1 * time.Second,
+		batchSize:           2,
+		batchFlushInterval:  500 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go ingester.Run(ctx)
+
+	query1 := db.Query{QueryParam: "up"}
+	query2 := db.Query{QueryParam: "node_cpu_seconds_total"}
+
+	mockDB.On("Insert", mock.Anything, mock.Anything).Return(nil).Once()
+
+	ingester.Ingest(query1)
+	ingester.Ingest(query2)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	time.Sleep(1 * time.Second)
+
+	mockDB.AssertExpectations(t)
+}
+
+func TestQueryIngester_Run_BatchFlushInterval(t *testing.T) {
+	mockDB := new(MockDBProvider)
+	queriesC := make(chan db.Query, 10)
+	ingester := &QueryIngester{
+		dbProvider:          mockDB,
+		queriesC:            queriesC,
+		shutdownGracePeriod: 1 * time.Second,
+		ingestTimeout:       1 * time.Second,
+		batchSize:           10,
+		batchFlushInterval:  500 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go ingester.Run(ctx)
+
+	query1 := db.Query{QueryParam: "up"}
+
+	mockDB.On("Insert", mock.Anything, mock.Anything).Return(nil).Once()
+
+	ingester.Ingest(query1)
+
+	time.Sleep(1 * time.Second)
+
+	mockDB.AssertExpectations(t)
+}


### PR DESCRIPTION
This pull request introduces several important changes to enhance the functionality and performance of the query ingestion system. The changes include adding batch processing for database inserts, updating the `QueryIngester` to support configurable options, and adding unit tests for the new functionality.

### Enhancements to Query Ingestion:

* [`internal/ingester/queryIngester.go`](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fR24-R69): Refactored `QueryIngester` to support batch processing of queries and added configurable options for buffer size, ingest timeout, shutdown grace period, batch size, and batch flush interval. [[1]](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fR24-R69) [[2]](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fR90-R93) [[3]](diffhunk://#diff-faa95625a931d345fb45498da503f2158c10d6a2cc23b7ee3698f7de1b354b0fL61-R143)

### Database Insert Improvements:

* [`internal/db/clickhouse.go`](diffhunk://#diff-c56e815abf28fb2c2e8156ebe6a80c82ed2a0c4ea6db9512a6bde2c423191c57L104-R122): Modified the `Insert` method to handle batch inserts using transactions. [[1]](diffhunk://#diff-c56e815abf28fb2c2e8156ebe6a80c82ed2a0c4ea6db9512a6bde2c423191c57L104-R122) [[2]](diffhunk://#diff-c56e815abf28fb2c2e8156ebe6a80c82ed2a0c4ea6db9512a6bde2c423191c57L116-R131) [[3]](diffhunk://#diff-c56e815abf28fb2c2e8156ebe6a80c82ed2a0c4ea6db9512a6bde2c423191c57R148-R160)
* [`internal/db/postgresql.go`](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL101-R126): Updated the `Insert` method to support batch inserts with transactions. [[1]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL101-R126) [[2]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL124-R154)
* [`internal/db/provider.go`](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4L11-R11): Changed the `Insert` method signature in the `Provider` interface to accept a slice of queries.

### Dependency Additions:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R10-R27): Added several new dependencies, including `github.com/stretchr/testify` for testing and `github.com/davecgh/go-spew` for debugging.

### Testing Enhancements:

* [`internal/ingester/queryingester_test.go`](diffhunk://#diff-092a36fd76709a49eaf18c08efa6ed4b34679987b443cfc7348b40cd1991aa51R1-R123): Added unit tests for the `QueryIngester` to verify the new batch processing and configurable options.

### Configuration Updates:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R46-R47): Updated the main function to include new flags for batch size and flush interval, and to initialize `QueryIngester` with the new configurable options. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R46-R47) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R57-R58) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L101-R112)