### PR TITLE
[CHORE] adding push to github registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,11 +20,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # - name: Log in to Docker Hub
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v6
@@ -34,6 +35,6 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
-          push: false
+          push: true
           tags: |
             prom-analytics-proxy:main


### PR DESCRIPTION
This pull request includes changes to the CI workflow configuration in `.github/workflows/ci.yaml` to enhance the Docker build and push process. The most important changes include updating the Docker Hub login credentials and enabling the push of Docker images.

CI workflow improvements:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL23-R28): Updated the Docker Hub login step to use GitHub Container Registry (GHCR) credentials instead of Docker Hub credentials. (`[.github/workflows/ci.yamlL23-R28](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL23-R28)`)
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL37-R38): Enabled the push of Docker images by setting the `push` parameter to `true`. (`[.github/workflows/ci.yamlL37-R38](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL37-R38)`)