### PR TITLE
[CI] adding running package write permission

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a small but important change to the CI workflow configuration. The change grants write permissions to the `packages` scope within the `build-and-push` job.

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR11-R12): Added write permissions to the `packages` scope in the `build-and-push` job to ensure the workflow can push packages.