### PR TITLE
[FIX] avoiding sql injection common patterns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 )
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/ClickHouse/ch-go v0.61.5/go.mod h1:s1LJW/F/LcFs5HJnuogFMta50kKDO0lf9z
 github.com/ClickHouse/clickhouse-go/v2 v2.29.0 h1:Dj1w59RssRyLgGHXtYaWU0eIM1pJsu9nGPi/btmvAqw=
 github.com/ClickHouse/clickhouse-go/v2 v2.29.0/go.mod h1:bLookq6qZJ4Ush/6tOAnJGh1Sf3Sa/nQoMn71p7ZCUE=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -83,6 +85,7 @@ github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=

--- a/internal/db/clickhouse.go
+++ b/internal/db/clickhouse.go
@@ -147,6 +147,10 @@ func (c *ClickHouseProvider) Query(ctx context.Context, query string) (*QueryRes
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	if err := ValidateSQLQuery(query); err != nil {
+		return nil, fmt.Errorf("query not allowed: %w", err)
+	}
+
 	rows, err := c.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("unable to query clickhouse: %w", err)

--- a/internal/db/clickhouse_test.go
+++ b/internal/db/clickhouse_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClickhouseProvider_Query(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		expectedError bool
+		setupFunc     func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:          "valid query",
+			query:         "SELECT 1",
+			expectedError: false,
+			setupFunc: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT 1").WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			},
+		},
+		{
+			name:          "sql injection attempt",
+			query:         "SELECT * FROM users WHERE username = 'admin' --' AND password = 'password'",
+			expectedError: true,
+			setupFunc: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM users WHERE username = 'admin' --' AND password = 'password'").WillReturnError(fmt.Errorf("query not allowed"))
+			},
+		},
+		{
+			name:          "query with special characters",
+			query:         "SELECT * FROM users WHERE username = 'admin'; DROP TABLE users;",
+			expectedError: true,
+			setupFunc: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM users WHERE username = 'admin'; DROP TABLE users;").WillReturnError(fmt.Errorf("query not allowed"))
+			},
+		},
+		{
+			name:          "query with valid parameters",
+			query:         "SELECT * FROM queries WHERE statusCode = 200",
+			expectedError: false,
+			setupFunc: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM queries WHERE statusCode = 200").WillReturnRows(sqlmock.NewRows([]string{"ts", "queryParam", "statusCode"}).AddRow(time.Now(), "query1", 200))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			provider := &ClickHouseProvider{db: db}
+			tt.setupFunc(mock)
+
+			result, err := provider.Query(ctx, tt.query)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -154,6 +154,10 @@ func (p *PostGreSQLProvider) Insert(ctx context.Context, queries []Query) error 
 }
 
 func (p *PostGreSQLProvider) Query(ctx context.Context, query string) (*QueryResult, error) {
+	if err := ValidateSQLQuery(query); err != nil {
+		return nil, fmt.Errorf("query not allowed: %w", err)
+	}
+
 	rows, err := p.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostGreSQLProvider_Query(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		expectedError bool
+		setupFunc     func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:          "valid query",
+			query:         "SELECT 1",
+			expectedError: false,
+			setupFunc: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT 1").WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+			},
+		},
+		{
+			name:          "sql injection attempt",
+			query:         "SELECT * FROM users WHERE username = 'admin' --' AND password = 'password'",
+			expectedError: true,
+			setupFunc: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM users WHERE username = 'admin' --' AND password = 'password'").WillReturnError(fmt.Errorf("query not allowed"))
+			},
+		},
+		{
+			name:          "query with special characters",
+			query:         "SELECT * FROM users WHERE username = 'admin'; DROP TABLE users;",
+			expectedError: true,
+			setupFunc: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM users WHERE username = 'admin'; DROP TABLE users;").WillReturnError(fmt.Errorf("query not allowed"))
+			},
+		},
+		{
+			name:          "query with valid parameters",
+			query:         "SELECT * FROM queries WHERE statusCode = 200",
+			expectedError: false,
+			setupFunc: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM queries WHERE statusCode = 200").WillReturnRows(sqlmock.NewRows([]string{"ts", "queryParam", "statusCode"}).AddRow(time.Now(), "query1", 200))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			provider := &PostGreSQLProvider{db: db}
+			tt.setupFunc(mock)
+
+			result, err := provider.Query(ctx, tt.query)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 type Provider interface {
@@ -27,4 +28,40 @@ func GetDbProvider(ctx context.Context, dbProvider DatabaseProvider) (Provider, 
 	default:
 		return nil, fmt.Errorf("invalid database type %q, only 'clickhouse' and 'postgresql' are supported", dbProvider)
 	}
+}
+
+var deniedKeywords = []string{"DROP", "DELETE", "UPDATE", "INSERT", "ALTER", "TRUNCATE", "EXEC", "--", ";"}
+
+func containsDeniedKeyword(query string) bool {
+	upperQuery := strings.ToUpper(query) // Normalize to upper case for comparison
+	for _, keyword := range deniedKeywords {
+		if strings.Contains(upperQuery, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+var deniedPatterns = []string{"--", ";"}
+
+func containsDeniedPattern(query string) bool {
+	for _, pattern := range deniedPatterns {
+		if strings.Contains(query, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func ValidateSQLQuery(query string) error {
+	if containsDeniedKeyword(query) {
+		return fmt.Errorf("query contains disallowed keyword")
+	}
+
+	if containsDeniedPattern(query) {
+		return fmt.Errorf("query contains dangerous pattern")
+	}
+
+	// Add more checks if needed (e.g., length, specific sub-queries)
+	return nil
 }


### PR DESCRIPTION
This pull request enhances SQL query validation and adds comprehensive tests for the `ClickHouseProvider` and `PostGreSQLProvider` query methods. The main changes include adding a validation function for SQL queries, integrating this validation into the query methods, and creating test cases to ensure the validation works correctly.

### SQL Query Validation Enhancements:

* [`internal/db/provider.go`](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4R32-R67): Introduced `ValidateSQLQuery`, `containsDeniedKeyword`, and `containsDeniedPattern` functions to validate SQL queries against a list of denied keywords and patterns.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R35): Added `github.com/DATA-DOG/go-sqlmock` to the project dependencies to facilitate SQL mocking in tests.

### Integration of Validation:

* [`internal/db/clickhouse.go`](diffhunk://#diff-c56e815abf28fb2c2e8156ebe6a80c82ed2a0c4ea6db9512a6bde2c423191c57R150-R153): Integrated `ValidateSQLQuery` into the `ClickHouseProvider`'s `Query` method to prevent execution of disallowed queries.
* [`internal/db/postgresql.go`](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dR157-R160): Integrated `ValidateSQLQuery` into the `PostGreSQLProvider`'s `Query` method to prevent execution of disallowed queries.

### Test Cases for Validation:

* [`internal/db/clickhouse_test.go`](diffhunk://#diff-23aa4d373d919ad3b4351482b8c9a692195fb5293efebee18250f44f9e506f7dR1-R75): Added tests for `ClickHouseProvider`'s `Query` method to verify that valid queries execute successfully and disallowed queries are blocked.
* [`internal/db/postgresql_test.go`](diffhunk://#diff-aa505ee5ecf26172ca4b4a7a705fa2de7b27a9ff5a5b712f02180a06445664daR1-R75): Added tests for `PostGreSQLProvider`'s `Query` method to verify that valid queries execute successfully and disallowed queries are blocked.