### PR TITLE
[FIX] using milliseconds on postgress for duration

### DIFF
--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -129,7 +129,7 @@ func (p *PostGreSQLProvider) Insert(ctx context.Context, queries []Query) error 
 			q.TS,
 			q.QueryParam,
 			q.TimeParam,
-			q.Duration,
+			q.Duration.Milliseconds(),
 			q.StatusCode,
 			q.BodySize,
 			q.Fingerprint,


### PR DESCRIPTION
This pull request includes a small but important change to the `Insert` method in the `PostGreSQLProvider` class within the `internal/db/postgresql.go` file. The change ensures that the `Duration` field is stored in milliseconds rather than its previous unit.

* [`internal/db/postgresql.go`](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL132-R132): Modified the `Insert` method to store the `Duration` field in milliseconds by using the `Milliseconds()` method.