### PR TITLE
[FIX] query shortcut title

### DIFF
--- a/ui/src/components/CodeEditor/index.tsx
+++ b/ui/src/components/CodeEditor/index.tsx
@@ -126,7 +126,7 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
             </div>
 
             {/* Modal Component */}
-            <Modal isLoading={isLoading} isOpen={isModalOpen} onClose={closeModal} title="Common Queries">
+            <Modal isLoading={isLoading} isOpen={isModalOpen} onClose={closeModal} title="Query Shortcuts">
                 {data?.map((query) => (
                     <QueryCard
                         key={query.title}


### PR DESCRIPTION
This pull request includes a small change to the `CodeEditor` component in the `ui/src/components/CodeEditor/index.tsx` file. The change updates the title of the `Modal` component from "Common Queries" to "Query Shortcuts".

* [`ui/src/components/CodeEditor/index.tsx`](diffhunk://#diff-59ecd9bf8c5644109d7dbfd71d36e77e0217b5b8d77237561b8468f18b948dc0L129-R129): Updated the `Modal` component's title from "Common Queries" to "Query Shortcuts".