### PR TITLE
[REFACTORY] renaming details page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -27,7 +27,7 @@ export default function App() {
                   <Link to="/">Explore</Link>
                 </Button>
                 <Button variant="ghost" asChild className="text-muted-foreground hover:text-foreground">
-                  <Link to="/metrics">Metrics</Link>
+                  <Link to="/series">Metrics</Link>
                 </Button>
               </div>
             </div>
@@ -42,8 +42,8 @@ export default function App() {
         <div className="flex flex-col min-h-[calc(100vh-3.5rem)]">
           <Routes>
             <Route path="/" element={<Explore />} />
-            <Route path="/metrics" element={<Metrics />} />
-            <Route path="/metrics/:id" element={<MetricDetails />} />
+            <Route path="/series" element={<Metrics />} />
+            <Route path="/series/:id" element={<MetricDetails />} />
           </Routes>
         </div>
       </div>

--- a/ui/src/pages/metrics/detail.tsx
+++ b/ui/src/pages/metrics/detail.tsx
@@ -47,7 +47,7 @@ interface ExpressionTableProps {
 const ExpressionTable: React.FC<ExpressionTableProps> = ({ expressions, currentPage, onPageChange }) => {
     const { theme } = useTheme();
     const startIndex = (currentPage - 1) * 1 + 1;
-    const endIndex = Math.min(startIndex + (expressions?.data.length ?? 0) - 1, expressions?.data.length ?? 0);
+    const endIndex = Math.min(startIndex + (expressions?.data?.length ?? 0) - 1, expressions?.data?.length ?? 0);
 
     return (
         <TabsContent value="expressions" className="p-4">
@@ -61,7 +61,7 @@ const ExpressionTable: React.FC<ExpressionTableProps> = ({ expressions, currentP
                     </TableRow>
                 </TableHeader>
                 <TableBody>
-                    {expressions?.data.map((expr, index) => (
+                    {expressions?.data?.map((expr, index) => (
                         <TableRow key={index}>
                             <TableCell className="font-mono text-sm">
                                 <CodeMirror
@@ -108,7 +108,7 @@ const ExpressionTable: React.FC<ExpressionTableProps> = ({ expressions, currentP
                     totalPages={expressions?.totalPages || 0}
                     startIndex={startIndex}
                     endIndex={endIndex}
-                    totalItems={expressions?.data.length || 0}
+                    totalItems={expressions?.data?.length || 0}
                     onPageChange={onPageChange}
                 />
             </div>
@@ -202,7 +202,7 @@ export default function Component() {
                                     <Clock className="mr-2 h-4 w-4" />
                                     <span className="hidden sm:inline">Expressions</span>
                                     <Badge variant="secondary" className="ml-2">
-                                        {expressions?.data.length}
+                                        {expressions?.data?.length}
                                     </Badge>
                                 </TabsTrigger>
                             </TabsList>

--- a/ui/src/pages/metrics/index.tsx
+++ b/ui/src/pages/metrics/index.tsx
@@ -48,7 +48,7 @@ const Component = () => {
     const truncateDescription = (description: string) => description.length > MAX_DESCRIPTION_LENGTH ? description.slice(0, MAX_DESCRIPTION_LENGTH) + '...' : description;
 
     const navigateToMetricDetails = (metric: SeriesMetadata) => {
-        navigate(`/metrics/${metric.name}`, { state: { metric } });
+        navigate(`/series/${metric.name}`, { state: { metric } });
     }
 
     return (


### PR DESCRIPTION
This pull request includes several changes to the `ui/src` directory, primarily involving the renaming of routes and adding optional chaining to handle potential null or undefined values. The most important changes include updating the routes from `/metrics` to `/series` and improving the handling of `expressions` data in the `ExpressionTable` component.

Route updates:

* [`ui/src/App.tsx`](diffhunk://#diff-3550a8c8813bc37aef982dcb8f241c1756429b859b5ffc0ab9190cc2e3fdb522L30-R30): Changed the `Link` and `Route` paths from `/metrics` to `/series` to reflect the updated routing structure. [[1]](diffhunk://#diff-3550a8c8813bc37aef982dcb8f241c1756429b859b5ffc0ab9190cc2e3fdb522L30-R30) [[2]](diffhunk://#diff-3550a8c8813bc37aef982dcb8f241c1756429b859b5ffc0ab9190cc2e3fdb522L45-R46)
* [`ui/src/pages/metrics/index.tsx`](diffhunk://#diff-fc1e35247201da8184033989371d04a411f323aff7818033a48e007c44997723L51-R51): Updated the navigation path in the `navigateToMetricDetails` function from `/metrics` to `/series`.

Optional chaining improvements:

* [`ui/src/pages/metrics/detail.tsx`](diffhunk://#diff-1e2d4e5b72ddb0691bd8ca1fd9712908f117760ae247ad85f7658f9e78cf97f5L50-R50): Added optional chaining to handle potential null or undefined values in the `expressions` data throughout the `ExpressionTable` component. [[1]](diffhunk://#diff-1e2d4e5b72ddb0691bd8ca1fd9712908f117760ae247ad85f7658f9e78cf97f5L50-R50) [[2]](diffhunk://#diff-1e2d4e5b72ddb0691bd8ca1fd9712908f117760ae247ad85f7658f9e78cf97f5L64-R64) [[3]](diffhunk://#diff-1e2d4e5b72ddb0691bd8ca1fd9712908f117760ae247ad85f7658f9e78cf97f5L111-R111) [[4]](diffhunk://#diff-1e2d4e5b72ddb0691bd8ca1fd9712908f117760ae247ad85f7658f9e78cf97f5L205-R205)