### PR TITLE
[FIX] setting max witdh column

### DIFF
--- a/ui/src/components/query-table.tsx
+++ b/ui/src/components/query-table.tsx
@@ -26,6 +26,7 @@ interface QueryTableProps {
 const columns: ColumnDef<RecentQuery>[] = [
   {
     accessorKey: "queryParam",
+    maxSize: 200,
     header: ({ column }) => {
       return (
         <div
@@ -83,7 +84,17 @@ const columns: ColumnDef<RecentQuery>[] = [
   },
   {
     accessorKey: "status",
-    header: "Status",
+    header: ({ column }) => {
+      return (
+        <div
+          className="flex items-center cursor-pointer"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Status
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </div>
+      )
+    },
     cell: ({ row }) => {
       const status = row.getValue("status") as number
       return (


### PR DESCRIPTION
This pull request updates the `query-table` component to enhance the user interface and improve functionality. The changes include adding a maximum size for a column and making the "Status" column header interactive to allow sorting.

### User interface improvements:

* [`ui/src/components/query-table.tsx`](diffhunk://#diff-dfba85537d6055406ae2716d67f9aad4e14d01722a64006e3baccf3008887033R29): Added a `maxSize` property with a value of `200` to the "queryParam" column to restrict its maximum width.

### Functionality enhancements:

* [`ui/src/components/query-table.tsx`](diffhunk://#diff-dfba85537d6055406ae2716d67f9aad4e14d01722a64006e3baccf3008887033L86-R97): Updated the "Status" column header to be interactive, allowing users to toggle sorting by clicking on it. The header now includes an arrow icon (`ArrowUpDown`) to indicate sorting direction.