### PR TITLE
[FIX] metrics usage table

### DIFF
--- a/scripts/query_loop.sh
+++ b/scripts/query_loop.sh
@@ -9,5 +9,23 @@ while true; do
         --data-urlencode 'query=sum(rate(node_cpu_seconds_total{job="node",mode!="idle"}[2m])) by (instance)'
     
     echo -e "\n--- $(date) ---\n"  # Add timestamp between requests
+
+    curl -X POST \
+        'http://localhost:9091/api/v1/query' \
+        --header 'Accept: */*' \
+        --header 'User-Agent: Thunder Client (https://www.thunderclient.com)' \
+        --header 'Content-Type: application/x-www-form-urlencoded' \
+        --data-urlencode 'query=sum without (status, instance) (rate(demo_api_request_duration_seconds_count{job="demo",status=~"5.."}[1m])) / sum without (status, instance) (rate(demo_api_request_duration_seconds_count{job="demo"}[1m])) * 100 > 0.5'
+    
+    echo -e "\n--- $(date) ---\n"  # Add timestamp between requests
+
+    curl -X POST \
+        'http://localhost:9091/api/v1/query' \
+        --header 'Accept: */*' \
+        --header 'User-Agent: Thunder Client (https://www.thunderclient.com)' \
+        --header 'Content-Type: application/x-www-form-urlencoded' \
+        --data-urlencode 'query=sum without (instance) (up{job="demo"}) == 0'
+    
+    echo -e "\n--- $(date) ---\n"  # Add timestamp between requests
     sleep 10
 done

--- a/ui/src/components/metrics-explorer/metric-usage.tsx
+++ b/ui/src/components/metrics-explorer/metric-usage.tsx
@@ -89,10 +89,11 @@ function useTabState(initialPage = 1, initialSortBy = 'avgDuration', initialSort
 const getQueriesColumns = (): ExtendedColumnDef<ExpressionDataItem, unknown>[] => [
   {
     accessorKey: "query",
+    maxWidth: 600,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Query" />
     ),
-    cell: ({ row }) => <span className="font-mono text-sm">{row.getValue("query")}</span>,
+    cell: ({ row }) => String(row.getValue("query")),
   },
   {
     accessorKey: "avgDuration",
@@ -135,10 +136,11 @@ const getAlertsColumns = (): ExtendedColumnDef<MetricUsageItem, unknown>[] => [
   },
   {
     accessorKey: "expression",
+    maxWidth: 600,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Expression" />
     ),
-    cell: ({ row }) => <span className="font-mono text-sm">{row.getValue("expression")}</span>,
+    cell: ({ row }) => String(row.getValue("expression")),
   },
 ];
 
@@ -151,10 +153,11 @@ const getRecordingColumns = (): ExtendedColumnDef<MetricUsageItem, unknown>[] =>
   },
   {
     accessorKey: "expression",
+    maxWidth: 600,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Expression" />
     ),
-    cell: ({ row }) => <span className="font-mono text-sm">{row.getValue("expression")}</span>,
+    cell: ({ row }) => String(row.getValue("expression")),
   },
 ];
 


### PR DESCRIPTION
This pull request introduces enhancements to the Prometheus query loop script and refactors the metrics explorer UI component. The changes aim to improve query handling in the script and standardize table rendering in the UI.

### Enhancements to Prometheus query loop:

* [`scripts/query_loop.sh`](diffhunk://#diff-8b8e0d9246322cf6022417bfaebb1df8a45f6f0f806706df3f812d9788c3260eR11-R28): Added two new Prometheus queries to monitor API error rates and service availability. Each query is followed by a timestamp for better log readability.

### Refactoring of metrics explorer UI:

* `ui/src/components/metrics-explorer/metric-usage.tsx`:
  - Updated the `query`, `expression`, and `recording` column definitions to include a `maxWidth` property of 600 for better table layout. [[1]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eR92-R96) [[2]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eR139-R143) [[3]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eR156-R160)
  - Replaced the `cell` rendering logic for these columns to convert values to strings directly, removing the use of `font-mono` and `text-sm` classes for a simplified and consistent rendering approach. [[1]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eR92-R96) [[2]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eR139-R143) [[3]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eR156-R160)