### PR TITLE
[FEATURE] adding metric job index

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [![Prometheus Analytics Proxy Introduction](https://img.youtube.com/vi/8PX4FwgxUd8/0.jpg)](https://www.youtube.com/watch?v=8PX4FwgxUd8)
 
-_Learn how prom-analytics-proxy can help you gain insights into your Prometheus queries and optimize your monitoring setup._
+*Learn how prom-analytics-proxy can help you gain insights into your Prometheus queries and optimize your monitoring setup.*
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [![Prometheus Analytics Proxy Introduction](https://img.youtube.com/vi/8PX4FwgxUd8/0.jpg)](https://www.youtube.com/watch?v=8PX4FwgxUd8)
 
-*Learn how prom-analytics-proxy can help you gain insights into your Prometheus queries and optimize your monitoring setup.*
+_Learn how prom-analytics-proxy can help you gain insights into your Prometheus queries and optimize your monitoring setup._
 
 ## Quick Start
 
@@ -206,4 +206,112 @@ The `prom-analytics-proxy` application integrates with Perses Metrics Usage to g
 
 Because Metrics Usage is a separate project, you must deploy it alongside `prom-analytics-proxy` to enable this feature. Once configured, `prom-analytics-proxy` sends the collected data to the Metrics Usage backend, which is then displayed in the Metrics Usage UI. For more information, see the [Metrics Usage repository](https://github.com/perses/metrics-usage).
 
-You can find a sample configuration file for the Metrics Usage integration in the `config` directory. The file includes the following options, assuming the `prom-analytics-proxy` is running on `
+You can find a sample configuration file for the Metrics Usage integration in the `config` directory.
+
+### Inventory Configuration
+
+The inventory syncer maintains a catalog of metrics and their usage patterns. It uses concurrent processing to handle large numbers of jobs efficiently. It can be configured with the following options:
+
+```yaml
+inventory:
+  enabled: true # Enable inventory syncing (default: true)
+  sync_interval: 10m # How often to sync inventory (default: 10m)
+  time_window: 720h # Time window for usage analysis (default: 30 days)
+  run_timeout: 30s # Timeout for entire sync run (default: 30s)
+  metadata_step_timeout: 15s # Timeout for metadata fetch (default: 15s)
+  summary_step_timeout: 10s # Timeout for usage summary refresh (default: 10s)
+  job_index_label_timeout: 10s # Timeout for job label fetch (default: 10s)
+  job_index_per_job_timeout: 5s # Timeout per job for series fetch (default: 5s)
+  job_index_workers: 10 # Number of concurrent workers for job processing (default: 10)
+```
+
+**Performance Notes:**
+
+- For environments with hundreds of jobs (500+), increase `job_index_workers` to 20-50 for faster processing
+- Increase `run_timeout` proportionally when processing many jobs (e.g., 300s for 1000+ jobs)
+- Each worker processes one job at a time, so more workers = faster job index building
+
+## API Reference
+
+The proxy provides several API endpoints for accessing query analytics and metrics inventory data:
+
+### Query Analytics
+
+- `GET /api/v1/queries` - Retrieve query analytics data with pagination and filtering
+
+### Series Metadata
+
+- `GET /api/v1/seriesMetadata` - Retrieve metrics catalog and usage information
+
+#### Parameters
+
+- `page` (int): Page number for pagination (default: 1)
+- `pageSize` (int): Number of items per page (default: 10, max: 100)
+- `sortBy` (string): Sort field - `name`, `type`, `alertCount`, `recordCount`, `dashboardCount`, `queryCount` (default: `name`)
+- `sortOrder` (string): Sort direction - `asc` or `desc` (default: `asc`)
+- `filter` (string): Filter metrics by name or help text
+- `type` (string): Filter by metric type - `counter`, `gauge`, `histogram`, `summary`, etc.
+- `unused` (boolean): Filter to show only unused metrics (no alerts, recording rules, dashboards, or queries)
+- `job` (string): Filter to show metrics produced by a specific job
+
+#### Examples
+
+```bash
+# Get all metrics with pagination
+curl "http://localhost:9091/api/v1/seriesMetadata?page=1&pageSize=20"
+
+# Find unused metrics
+curl "http://localhost:9091/api/v1/seriesMetadata?unused=true"
+
+# Find unused metrics for a specific job
+curl "http://localhost:9091/api/v1/seriesMetadata?unused=true&job=myapp"
+
+# Search for HTTP-related metrics
+curl "http://localhost:9091/api/v1/seriesMetadata?filter=http&type=counter"
+```
+
+#### Response Format
+
+```json
+{
+  "data": [
+    {
+      "name": "http_requests_total",
+      "type": "counter",
+      "help": "Total number of HTTP requests",
+      "unit": "",
+      "alertCount": 2,
+      "recordCount": 1,
+      "dashboardCount": 3,
+      "queryCount": 45,
+      "lastQueriedAt": "2024-01-15T10:30:00Z",
+      "seriesCount": 12
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "pageSize": 20,
+    "total": 150,
+    "totalPages": 8
+  }
+}
+```
+
+### Metrics Discovery
+
+The inventory system automatically discovers metrics from your Prometheus server and tracks their usage across:
+
+- **Alerting rules**: Metrics used in alert expressions
+- **Recording rules**: Metrics used in recording rule expressions
+- **Dashboards**: Metrics queried by dashboard panels (when integrated with dashboard usage tracking)
+- **Ad-hoc queries**: Direct PromQL queries through the proxy
+
+### Job-Based Usage Analysis
+
+When the `job` parameter is provided with `unused=true`, the system:
+
+1. Filters metrics to only those produced by the specified job (using the job index)
+2. Applies the global "unused" criteria (no usage in alerts, recording rules, dashboards, or queries)
+3. Returns the series count for that specific job
+
+This helps identify metrics that are being produced by a service but aren't being actively monitored or used.

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.65.0 // indirect
+	github.com/prometheus/common v0.65.0
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rs/cors v1.11.1
 	github.com/thanos-io/thanos v0.39.2

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,9 +70,15 @@ type CORSConfig struct {
 }
 
 type InventoryConfig struct {
-	Enabled      bool          `yaml:"enabled,omitempty"`
-	SyncInterval time.Duration `yaml:"sync_interval,omitempty"`
-	TimeWindow   time.Duration `yaml:"time_window,omitempty"`
+	Enabled               bool          `yaml:"enabled,omitempty"`
+	SyncInterval          time.Duration `yaml:"sync_interval,omitempty"`
+	TimeWindow            time.Duration `yaml:"time_window,omitempty"`
+	RunTimeout            time.Duration `yaml:"run_timeout,omitempty"`
+	MetadataStepTimeout   time.Duration `yaml:"metadata_step_timeout,omitempty"`
+	SummaryStepTimeout    time.Duration `yaml:"summary_step_timeout,omitempty"`
+	JobIndexLabelTimeout  time.Duration `yaml:"job_index_label_timeout,omitempty"`
+	JobIndexPerJobTimeout time.Duration `yaml:"job_index_per_job_timeout,omitempty"`
+	JobIndexWorkers       int           `yaml:"job_index_workers,omitempty"`
 }
 
 var DefaultConfig = &Config{
@@ -87,9 +93,15 @@ var DefaultConfig = &Config{
 		IncludeQueryStats: true,
 	},
 	Inventory: InventoryConfig{
-		Enabled:      true,
-		SyncInterval: 10 * time.Minute,
-		TimeWindow:   30 * 24 * time.Hour,
+		Enabled:               true,
+		SyncInterval:          10 * time.Minute,
+		TimeWindow:            30 * 24 * time.Hour,
+		RunTimeout:            300 * time.Second,
+		MetadataStepTimeout:   30 * time.Second,
+		SummaryStepTimeout:    30 * time.Second,
+		JobIndexLabelTimeout:  30 * time.Second,
+		JobIndexPerJobTimeout: 30 * time.Second,
+		JobIndexWorkers:       10,
 	},
 }
 

--- a/internal/db/migrations/postgresql/0008_metrics_job_index.sql
+++ b/internal/db/migrations/postgresql/0008_metrics_job_index.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- Metrics job index table for PostgreSQL
+
+CREATE TABLE IF NOT EXISTS metrics_job_index (
+  name TEXT NOT NULL,
+  job TEXT NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  PRIMARY KEY (name, job)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_job_index_job ON metrics_job_index(job);
+CREATE INDEX IF NOT EXISTS idx_metrics_job_index_name ON metrics_job_index(name);
+
+-- +goose Down
+DROP TABLE IF EXISTS metrics_job_index;
+

--- a/internal/db/migrations/sqlite/0005_metrics_job_index.sql
+++ b/internal/db/migrations/sqlite/0005_metrics_job_index.sql
@@ -1,0 +1,17 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Metrics job index table for SQLite
+
+CREATE TABLE IF NOT EXISTS metrics_job_index (
+  name TEXT NOT NULL,
+  job TEXT NOT NULL,
+  updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (name, job)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_job_index_job ON metrics_job_index(job);
+CREATE INDEX IF NOT EXISTS idx_metrics_job_index_name ON metrics_job_index(name);
+
+-- +goose Down
+DROP TABLE IF EXISTS metrics_job_index;
+

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -34,6 +34,8 @@ type Provider interface {
 	GetSeriesMetadata(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error)
 	UpsertMetricsCatalog(ctx context.Context, items []MetricCatalogItem) error
 	RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error
+	UpsertMetricsJobIndex(ctx context.Context, items []MetricJobIndexItem) error
+	ListJobs(ctx context.Context) ([]string, error)
 
 	GetQueryTypes(ctx context.Context, tr TimeRange) (*QueryTypesResult, error)
 	GetAverageDuration(ctx context.Context, tr TimeRange) (*AverageDurationResult, error)
@@ -246,6 +248,7 @@ type SeriesMetadataParams struct {
 	Filter    string
 	Type      string
 	Unused    bool
+	Job       string
 }
 
 type MetricCatalogItem struct {
@@ -253,6 +256,11 @@ type MetricCatalogItem struct {
 	Type string
 	Help string
 	Unit string
+}
+
+type MetricJobIndexItem struct {
+	Name string
+	Job  string
 }
 
 type TimeRange struct {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -724,9 +724,13 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                 SELECT 1 FROM queries q
                 WHERE json_extract(q.labelMatchers, '$[0].__name__') = c.name
               ) ELSE 1 END)
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
     `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter, params.Filter, params.Filter, params.Type, params.Type, boolToInt(params.Unused), boolToInt(params.Unused)).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter, params.Filter, params.Filter, params.Type, params.Type, boolToInt(params.Unused), boolToInt(params.Unused), params.Job, params.Job).Scan(&total); err != nil {
 		return nil, fmt.Errorf("failed to count catalog: %w", err)
 	}
 
@@ -747,6 +751,10 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                 SELECT 1 FROM queries q
                 WHERE json_extract(q.labelMatchers, '$[0].__name__') = c.name
               ) ELSE 1 END)
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
     `
 	// Build complete query with safe ORDER BY clause to prevent SQL injection
 	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "name")
@@ -755,6 +763,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type,
 		boolToInt(params.Unused), boolToInt(params.Unused),
+		params.Job, params.Job,
 		params.PageSize, (params.Page-1)*params.PageSize,
 	)
 	if err != nil {
@@ -786,6 +795,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 		if r.last.Valid {
 			mm.LastQueriedAt = r.last.Time.UTC().Format(time.RFC3339)
 		}
+
 		results = append(results, mm)
 	}
 	if err := rows.Err(); err != nil {
@@ -830,6 +840,61 @@ func (p *SQLiteProvider) UpsertMetricsCatalog(ctx context.Context, items []Metri
 		return fmt.Errorf("commit: %w", err)
 	}
 	return nil
+}
+
+func (p *SQLiteProvider) UpsertMetricsJobIndex(ctx context.Context, items []MetricJobIndexItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO metrics_job_index(name, job, updated_at)
+		VALUES(?, ?, datetime('now'))
+		ON CONFLICT(name, job) DO UPDATE SET
+			updated_at = excluded.updated_at
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("prepare: %w", err)
+	}
+	defer CloseResource(stmt)
+	for _, it := range items {
+		if _, err := stmt.ExecContext(ctx, it.Name, it.Job); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("exec: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// ListJobs returns the distinct list of jobs from metrics_job_index
+func (p *SQLiteProvider) ListJobs(ctx context.Context) ([]string, error) {
+	rows, err := ExecuteQuery(ctx, p.db, `SELECT DISTINCT job FROM metrics_job_index ORDER BY job`)
+	if err != nil {
+		return nil, err
+	}
+	defer CloseResource(rows)
+
+	var jobs []string
+	for rows.Next() {
+		var job string
+		if err := rows.Scan(&job); err != nil {
+			return nil, fmt.Errorf("scan job: %w", err)
+		}
+		jobs = append(jobs, job)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iter jobs: %w", err)
+	}
+	return jobs, nil
 }
 
 func (p *SQLiteProvider) RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error {

--- a/internal/ingester/queryingester_test.go
+++ b/internal/ingester/queryingester_test.go
@@ -18,6 +18,11 @@ type MockDBProvider struct {
 // Ensure MockDBProvider implements db.Provider
 var _ db.Provider = (*MockDBProvider)(nil)
 
+// Satisfy new Provider method; tests don't use it
+func (m *MockDBProvider) ListJobs(ctx context.Context) ([]string, error) {
+	return []string{}, nil
+}
+
 func (m *MockDBProvider) GetSeriesMetadata(ctx context.Context, params db.SeriesMetadataParams) (*db.PagedResult, error) {
 	args := m.Called(ctx, params)
 	if v := args.Get(0); v != nil {
@@ -27,6 +32,11 @@ func (m *MockDBProvider) GetSeriesMetadata(ctx context.Context, params db.Series
 }
 
 func (m *MockDBProvider) UpsertMetricsCatalog(ctx context.Context, items []db.MetricCatalogItem) error {
+	args := m.Called(ctx, items)
+	return args.Error(0)
+}
+
+func (m *MockDBProvider) UpsertMetricsJobIndex(ctx context.Context, items []db.MetricJobIndexItem) error {
 	args := m.Called(ctx, items)
 	return args.Error(0)
 }

--- a/internal/inventory/syncer.go
+++ b/internal/inventory/syncer.go
@@ -2,9 +2,11 @@ package inventory
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math/rand"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
@@ -13,6 +15,7 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/model"
 )
 
 type Syncer struct {
@@ -21,6 +24,14 @@ type Syncer struct {
 	timeWindow  time.Duration
 	interval    time.Duration
 	metadataLim string
+
+	runTimeout            time.Duration
+	metadataStepTimeout   time.Duration
+	summaryStepTimeout    time.Duration
+	jobIndexLabelTimeout  time.Duration
+	jobIndexPerJobTimeout time.Duration
+
+	jobIndexWorkers int
 
 	syncDuration prometheus.Histogram
 	syncSuccess  prometheus.Counter
@@ -37,14 +48,19 @@ func NewSyncer(dbp db.Provider, upstream string, cfg *config.Config, reg prometh
 		lim = strconv.FormatUint(cfg.MetadataLimit, 10)
 	}
 	s := &Syncer{
-		dbProvider:  dbp,
-		promAPI:     v1.NewAPI(client),
-		timeWindow:  cfg.Inventory.TimeWindow,
-		interval:    cfg.Inventory.SyncInterval,
-		metadataLim: lim,
+		dbProvider:            dbp,
+		promAPI:               v1.NewAPI(client),
+		timeWindow:            cfg.Inventory.TimeWindow,
+		interval:              cfg.Inventory.SyncInterval,
+		metadataLim:           lim,
+		runTimeout:            cfg.Inventory.RunTimeout,
+		metadataStepTimeout:   cfg.Inventory.MetadataStepTimeout,
+		summaryStepTimeout:    cfg.Inventory.SummaryStepTimeout,
+		jobIndexLabelTimeout:  cfg.Inventory.JobIndexLabelTimeout,
+		jobIndexPerJobTimeout: cfg.Inventory.JobIndexPerJobTimeout,
+		jobIndexWorkers:       cfg.Inventory.JobIndexWorkers,
 	}
 
-	// Metrics
 	if reg == nil {
 		reg = prometheus.DefaultRegisterer
 	}
@@ -66,12 +82,10 @@ func NewSyncer(dbp db.Provider, upstream string, cfg *config.Config, reg prometh
 }
 
 func (s *Syncer) RunLeaderless(ctx context.Context) {
-	// For SQLite or when leader election is not required
 	s.runLoop(ctx)
 }
 
 func (s *Syncer) RunWithLeader(ctx context.Context, isLeader func(context.Context) bool) {
-	// Poll for leadership; when leader, run loop until context done or leadership lost
 	backoff := time.Second
 	for {
 		if ctx.Err() != nil {
@@ -80,7 +94,6 @@ func (s *Syncer) RunWithLeader(ctx context.Context, isLeader func(context.Contex
 		if isLeader(ctx) {
 			s.runLoop(ctx)
 		} else {
-			// sleep with jitter before retrying leadership
 			j := time.Duration(rand.Int63n(int64(backoff)))
 			select {
 			case <-time.After(backoff + j):
@@ -98,7 +111,6 @@ func (s *Syncer) runLoop(ctx context.Context) {
 	ticker := time.NewTicker(s.interval + time.Duration(rand.Int63n(int64(s.interval/5))))
 	defer ticker.Stop()
 
-	// Run immediately on start
 	s.runOnce(ctx)
 
 	for {
@@ -113,101 +125,178 @@ func (s *Syncer) runLoop(ctx context.Context) {
 
 func (s *Syncer) runOnce(ctx context.Context) {
 	start := time.Now()
-	deadline, cancel := context.WithTimeout(ctx, 30*time.Second)
+	runCtx, cancel := context.WithTimeout(ctx, s.runTimeout)
 	defer cancel()
 
-	// 1) Fetch metadata
-	meta, err := s.promAPI.Metadata(deadline, "", s.metadataLim)
-	if err != nil {
-		slog.Error("inventory: fetch metadata", "err", err)
+	if err := s.syncCatalogAndSummary(runCtx); err != nil {
 		s.syncFailure.Inc()
 		s.syncDuration.Observe(time.Since(start).Seconds())
 		return
 	}
 
-	// 2) Upsert catalog
-	items := make([]db.MetricCatalogItem, 0, len(meta)*2) // Pre-allocate more space for histogram/summary sub-metrics
-	for name, infos := range meta {
-		if len(infos) == 0 {
-			continue
-		}
-		// Prom returns slice; use the first entry's type/help/unit
-		info := infos[0]
-		metricType := string(info.Type)
-
-		// Handle histogram and summary metrics by generating their sub-metrics
-		switch metricType {
-		case "histogram":
-			// For histograms, replace base name with _bucket, _count, _sum variants
-			items = append(items,
-				db.MetricCatalogItem{
-					Name: name + "_bucket",
-					Type: "histogram_bucket",
-					Help: info.Help + " (histogram buckets)",
-					Unit: info.Unit,
-				},
-				db.MetricCatalogItem{
-					Name: name + "_count",
-					Type: "histogram_count",
-					Help: info.Help + " (histogram count)",
-					Unit: "",
-				},
-				db.MetricCatalogItem{
-					Name: name + "_sum",
-					Type: "histogram_sum",
-					Help: info.Help + " (histogram sum)",
-					Unit: info.Unit,
-				},
-			)
-		case "summary":
-			// For summaries, keep base name (for quantiles) and add _count, _sum variants
-			items = append(items,
-				db.MetricCatalogItem{
-					Name: name,
-					Type: metricType,
-					Help: info.Help,
-					Unit: info.Unit,
-				},
-				db.MetricCatalogItem{
-					Name: name + "_count",
-					Type: "summary_count",
-					Help: info.Help + " (summary count)",
-					Unit: "",
-				},
-				db.MetricCatalogItem{
-					Name: name + "_sum",
-					Type: "summary_sum",
-					Help: info.Help + " (summary sum)",
-					Unit: info.Unit,
-				},
-			)
-		default:
-			// For counter, gauge, and other types, keep as-is
-			items = append(items, db.MetricCatalogItem{
-				Name: name,
-				Type: metricType,
-				Help: info.Help,
-				Unit: info.Unit,
-			})
-		}
-	}
-	if err := s.dbProvider.UpsertMetricsCatalog(deadline, items); err != nil {
-		slog.Error("inventory: upsert catalog", "err", err)
-		s.syncFailure.Inc()
-		s.syncDuration.Observe(time.Since(start).Seconds())
-		return
-	}
-
-	// 3) Refresh usage summary for configured window
 	tr := db.TimeRange{From: time.Now().UTC().Add(-s.timeWindow), To: time.Now().UTC()}
-	if err := s.dbProvider.RefreshMetricsUsageSummary(deadline, tr); err != nil {
-		slog.Error("inventory: refresh summary", "err", err)
-		s.syncFailure.Inc()
-		s.syncDuration.Observe(time.Since(start).Seconds())
-		return
+	if err := s.syncJobIndex(runCtx, tr); err != nil {
+		slog.Error("inventory: job index", "err", err)
 	}
 
 	slog.Info("inventory: sync complete")
 	s.syncSuccess.Inc()
 	s.syncDuration.Observe(time.Since(start).Seconds())
+}
+
+func (s *Syncer) syncCatalogAndSummary(ctx context.Context) error {
+	metaCtx, cancelMeta := context.WithTimeout(ctx, s.metadataStepTimeout)
+	defer cancelMeta()
+	meta, err := s.promAPI.Metadata(metaCtx, "", s.metadataLim)
+	if err != nil {
+		slog.Error("inventory: fetch metadata", "err", err)
+		return err
+	}
+
+	items := make([]db.MetricCatalogItem, 0, len(meta)*2)
+	for name, infos := range meta {
+		if len(infos) == 0 {
+			continue
+		}
+		info := infos[0]
+		metricType := string(info.Type)
+		switch metricType {
+		case "histogram":
+			items = append(items,
+				db.MetricCatalogItem{Name: name + "_bucket", Type: "histogram_bucket", Help: info.Help + " (histogram buckets)", Unit: info.Unit},
+				db.MetricCatalogItem{Name: name + "_count", Type: "histogram_count", Help: info.Help + " (histogram count)", Unit: ""},
+				db.MetricCatalogItem{Name: name + "_sum", Type: "histogram_sum", Help: info.Help + " (histogram sum)", Unit: info.Unit},
+			)
+		case "summary":
+			items = append(items,
+				db.MetricCatalogItem{Name: name, Type: metricType, Help: info.Help, Unit: info.Unit},
+				db.MetricCatalogItem{Name: name + "_count", Type: "summary_count", Help: info.Help + " (summary count)", Unit: ""},
+				db.MetricCatalogItem{Name: name + "_sum", Type: "summary_sum", Help: info.Help + " (summary sum)", Unit: info.Unit},
+			)
+		default:
+			items = append(items, db.MetricCatalogItem{Name: name, Type: metricType, Help: info.Help, Unit: info.Unit})
+		}
+	}
+	if err := s.dbProvider.UpsertMetricsCatalog(metaCtx, items); err != nil {
+		slog.Error("inventory: upsert catalog", "err", err)
+		return err
+	}
+
+	sumCtx, cancelSum := context.WithTimeout(ctx, s.summaryStepTimeout)
+	defer cancelSum()
+	tr := db.TimeRange{From: time.Now().UTC().Add(-s.timeWindow), To: time.Now().UTC()}
+	if err := s.dbProvider.RefreshMetricsUsageSummary(sumCtx, tr); err != nil {
+		slog.Error("inventory: refresh summary", "err", err)
+		return err
+	}
+	return nil
+}
+
+func (s *Syncer) syncJobIndex(ctx context.Context, tr db.TimeRange) error {
+	labelCtx, cancelLabels := context.WithTimeout(ctx, s.jobIndexLabelTimeout)
+	defer cancelLabels()
+	jobs, _, err := s.promAPI.LabelValues(labelCtx, "job", []string{}, tr.From, tr.To)
+	if err != nil {
+		// Handle 404 gracefully - it means no series with job label exist or endpoint not supported
+		slog.Warn("failed to fetch job label values", "err", err, "msg", "job index will be empty - this is normal if no series have job labels")
+		return nil
+	}
+
+	if len(jobs) == 0 {
+		slog.Debug("no job labels found in time range", "from", tr.From, "to", tr.To)
+		return nil
+	}
+
+	slog.Info("syncing job index", "jobs_found", len(jobs), "workers", s.jobIndexWorkers, "time_range", tr)
+
+	jobChan := make(chan string, len(jobs))
+	errorChan := make(chan error, len(jobs))
+
+	var wg sync.WaitGroup
+	for i := 0; i < s.jobIndexWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for job := range jobChan {
+				err := s.processJob(ctx, job, tr, workerID)
+				errorChan <- err
+			}
+		}(i)
+	}
+
+	jobsProcessed := 0
+	for _, jobLabel := range jobs {
+		job := string(jobLabel)
+		if job != "" {
+			jobChan <- job
+			jobsProcessed++
+		}
+	}
+	close(jobChan)
+
+	go func() {
+		wg.Wait()
+		close(errorChan)
+	}()
+
+	var successCount, failureCount int
+	for err := range errorChan {
+		if err != nil {
+			failureCount++
+		} else {
+			successCount++
+		}
+	}
+
+	slog.Info("job index sync complete",
+		"jobs_processed", jobsProcessed,
+		"successful", successCount,
+		"failed", failureCount)
+
+	if failureCount > 0 && failureCount > successCount/2 {
+		return fmt.Errorf("job index sync failed: %d failures out of %d jobs", failureCount, jobsProcessed)
+	}
+
+	return nil
+}
+
+func (s *Syncer) processJob(ctx context.Context, job string, tr db.TimeRange, workerID int) error {
+	jobCtx, cancelJob := context.WithTimeout(ctx, s.jobIndexPerJobTimeout)
+	defer cancelJob()
+
+	query := fmt.Sprintf(`group({job="%s", __name__=~".+"}) by (__name__)`, job)
+	result, _, err := s.promAPI.Query(jobCtx, query, tr.To)
+	if err != nil {
+		slog.Warn("failed to query metrics for job", "job", job, "worker", workerID, "query", query, "err", err)
+		return err
+	}
+
+	metricNames := make(map[string]struct{})
+
+	// Extract metric names from the query result
+	switch v := result.(type) {
+	case model.Vector:
+		for _, sample := range v {
+			if metricName, ok := sample.Metric["__name__"]; ok {
+				metricNames[string(metricName)] = struct{}{}
+			}
+		}
+	default:
+		slog.Debug("unexpected query result type", "job", job, "worker", workerID, "type", fmt.Sprintf("%T", result))
+	}
+
+	var items []db.MetricJobIndexItem
+	for name := range metricNames {
+		items = append(items, db.MetricJobIndexItem{Name: name, Job: job})
+	}
+
+	if len(items) > 0 {
+		if err := s.dbProvider.UpsertMetricsJobIndex(ctx, items); err != nil {
+			slog.Error("failed to upsert metrics for job", "job", job, "worker", workerID, "metrics", len(items), "err", err)
+			return fmt.Errorf("upsert job %s: %w", job, err)
+		}
+		slog.Debug("processed job", "job", job, "worker", workerID, "metrics", len(items))
+	}
+
+	return nil
 }

--- a/ui/src/app/metrics/index.tsx
+++ b/ui/src/app/metrics/index.tsx
@@ -10,6 +10,7 @@ export default function MetricsExplorer() {
   const [searchQuery, setSearchQuery] = useState("")
   const [typeFilter, setTypeFilter] = useState("all")
   const [usageFilter, setUsageFilter] = useState<"all" | "unused">("all")
+  const [jobFilter, setJobFilter] = useState<string>("")
   const [tableState, setTableState] = useState<TableState>({
     page: 1,
     pageSize: 10,
@@ -22,7 +23,7 @@ export default function MetricsExplorer() {
   // Increase debounce delay to 750ms for better performance
   const debouncedSearchQuery = useDebounce(searchQuery, 750)
 
-  const { data, isLoading, error } = useSeriesMetadataTable(tableState, debouncedSearchQuery, usageFilter === "unused")
+  const { data, isLoading, error } = useSeriesMetadataTable(tableState, debouncedSearchQuery, usageFilter === "unused", jobFilter)
 
   if (isLoading) {
     return <LoadingState />
@@ -50,6 +51,9 @@ export default function MetricsExplorer() {
         onTypeFilterChange={handleTypeFilterChange}
         usageFilter={usageFilter}
         onUsageFilterChange={setUsageFilter}
+        jobs={data.jobs}
+        jobFilter={jobFilter}
+        onJobFilterChange={setJobFilter}
       />
       <MetricsTable 
         metrics={data.metrics}

--- a/ui/src/app/metrics/use-metrics-data.ts
+++ b/ui/src/app/metrics/use-metrics-data.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { getMetricQueryPerformanceStatistics, getMetricStatistics, getSeriesMetadata, getSerieExpressions, getMetricUsage } from "@/api/metrics";
+import { getMetricQueryPerformanceStatistics, getMetricStatistics, getSeriesMetadata, getSerieExpressions, getMetricUsage, getJobs } from "@/api/metrics";
 import { PagedResult, TableState, MetricMetadata, MetricStatistics, MetricQueryPerformanceStatistics, QueryLatencyTrendsResult, DateRange } from "@/lib/types";
 import { getQueryLatencyTrends } from "@/api/queries";
 
 interface MetricsData {
   metrics: PagedResult<MetricMetadata> | undefined;
+  jobs: string[] | undefined;
 }
 
 interface MetricStatisticsData {
@@ -23,13 +24,13 @@ interface MetricUsageResponse {
   }>;
 }
 
-export function useSeriesMetadataTable(tableState?: TableState, searchQuery?: string, unused?: boolean) {
+export function useSeriesMetadataTable(tableState?: TableState, searchQuery?: string, unused?: boolean, job?: string) {
   const {
     data: metrics,
     isLoading,
     error
   } = useQuery<PagedResult<MetricMetadata>>({
-    queryKey: ['metrics', tableState, searchQuery, unused],
+    queryKey: ['metrics', tableState, searchQuery, unused, job],
     queryFn: () => getSeriesMetadata(
       tableState?.page || 1,
       tableState?.pageSize || 10,
@@ -38,12 +39,19 @@ export function useSeriesMetadataTable(tableState?: TableState, searchQuery?: st
       searchQuery || '',
       tableState?.type || 'all',
       unused || false,
+      job,
     ),
+  });
+
+  const { data: jobs } = useQuery<string[]>({
+    queryKey: ['jobs'],
+    queryFn: getJobs,
   });
 
   return {
     data: {
       metrics,
+      jobs,
     } as MetricsData,
     isLoading,
     error,

--- a/ui/src/components/layout.tsx
+++ b/ui/src/components/layout.tsx
@@ -32,7 +32,7 @@ interface LayoutProps {
 
 export default function Layout({ children, breadcrumb }: LayoutProps) {
     const [location] = useLocation()
-    const showFilterPanel = location !== '/metrics' && location !== '/settings'
+    const showFilterPanel = location !== '/metrics-explorer' && location !== '/settings'
 
     return (
         <ErrorBoundaryWithToast>

--- a/ui/src/components/metrics-explorer/metric-detail-header.tsx
+++ b/ui/src/components/metrics-explorer/metric-detail-header.tsx
@@ -13,7 +13,7 @@ export function MetricDetailHeader({ metricName }: MetricDetailHeaderProps) {
     <div className="space-y-6">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/metrics">
+          <Link href="/metrics-explorer">
             <ArrowLeft className="h-4 w-4" />
             <span className="sr-only">Back</span>
           </Link>

--- a/ui/src/components/metrics-explorer/metrics-explorer-header.tsx
+++ b/ui/src/components/metrics-explorer/metrics-explorer-header.tsx
@@ -9,6 +9,9 @@ interface MetricsExplorerHeaderProps {
   onTypeFilterChange: (value: string) => void
   usageFilter?: "all" | "unused"
   onUsageFilterChange?: (value: "all" | "unused") => void
+  jobs?: string[]
+  jobFilter?: string
+  onJobFilterChange?: (value: string) => void
 }
 
 export function MetricsExplorerHeader({ 
@@ -18,7 +21,12 @@ export function MetricsExplorerHeader({
   onTypeFilterChange,
   usageFilter = "all",
   onUsageFilterChange,
+  jobs = [],
+  jobFilter = "",
+  onJobFilterChange,
 }: MetricsExplorerHeaderProps) {
+  const jobOptions = (jobs ?? []).filter((j) => !!j && j.trim().length > 0)
+  const currentJobValue = jobOptions.includes(jobFilter) ? jobFilter : "__all__"
   return (
     <div className="flex flex-col gap-2">
       <div>
@@ -41,12 +49,28 @@ export function MetricsExplorerHeader({
               <SelectValue placeholder="All Types" />
             </div>
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent className="max-w-[90vw] sm:max-w-[600px] whitespace-normal break-words">
             <SelectItem value="all">All Types</SelectItem>
             <SelectItem value="counter">Counter</SelectItem>
             <SelectItem value="gauge">Gauge</SelectItem>
             <SelectItem value="histogram">Histogram</SelectItem>
             <SelectItem value="summary">Summary</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={currentJobValue} onValueChange={(v) => onJobFilterChange?.(v === "__all__" ? "" : v)}>
+          <SelectTrigger className="w-[220px] sm:w-[240px] md:w-[280px] lg:w-[320px] text-left">
+            <div className="flex items-center gap-2 min-w-0">
+              <Filter className="h-4 w-4 shrink-0" />
+              <span className="truncate" title={jobFilter || "All Jobs"}>
+                <SelectValue placeholder="All Jobs" />
+              </span>
+            </div>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All Jobs</SelectItem>
+            {jobOptions.map(j => (
+              <SelectItem key={j} value={j}>{j}</SelectItem>
+            ))}
           </SelectContent>
         </Select>
         <Select value={usageFilter} onValueChange={(v) => onUsageFilterChange?.(v as "all" | "unused") }>


### PR DESCRIPTION
This pull request introduces a comprehensive job-based metrics inventory system, allowing users to analyze and filter Prometheus metrics by the producing job. It adds new API endpoints, configuration options, and database structures to support efficient inventory syncing, job-based filtering, and job discovery. The main changes are grouped below.

**Job-based Metrics Inventory and Filtering**

* Added a new `metrics_job_index` table (with migrations for both PostgreSQL and SQLite) to track which jobs produce which metrics, enabling efficient job-based filtering and analysis. [[1]](diffhunk://#diff-fe7eb8a2b46c480d043ea8dc960dc632bc0f7489468dff85ade8b55a6bbb4ad5R1-R16) [[2]](diffhunk://#diff-226d39889ef8964ff48b2a77667b2f5d4df1467df70494dfbc158f9c500064beR1-R17)
* Extended the `SeriesMetadataParams` struct and related database queries to support filtering metrics by a specific job, and updated both the PostgreSQL and SQLite providers to use this filter in queries. [[1]](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4R251) [[2]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dR704-R710) [[3]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dR729-R737) [[4]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caR727-R733) [[5]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caR754-R757) [[6]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caR766)
* Implemented methods for upserting job-metric relationships and listing all known jobs in both database providers, and exposed these methods in the `Provider` interface. [[1]](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4R37-R38) [[2]](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4R261-R265) [[3]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dR853-R905) [[4]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caR845-R899)

**API and Configuration Enhancements**

* Added a new API endpoint `GET /api/v1/jobs` to list all known jobs, and extended the `/api/v1/seriesMetadata` endpoint to accept a `job` parameter for job-based filtering. [[1]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR100) [[2]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR523-R526) [[3]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR875-R888)
* Expanded the configuration options for inventory syncing, introducing parameters for concurrency and timeouts to better handle large environments. Updated the default configuration accordingly. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR76-R81) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR99-R104)

**Documentation Improvements**

* Updated the README with detailed documentation on inventory configuration, job-based usage analysis, API reference, and performance tuning for large-scale metric inventories.
* Minor formatting fix in the README for consistency.

**Testing Support**

* Updated the mock database provider in tests to satisfy the new `ListJobs` method in the provider interface.