### PR TITLE
Feature/query time range distribution

### DIFF
--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -88,6 +88,14 @@ type QueryErrorAnalysisResult struct {
 	Value float64 `json:"value"`
 }
 
+// QueryTimeRangeDistributionResult represents a bucketed count of range query window sizes.
+// Label corresponds to human-friendly bucket labels like "<24h", "24h", "7d", "30d", "60d", "90d+".
+type QueryTimeRangeDistributionResult struct {
+	Label   string  `json:"label"`
+	Count   int     `json:"count"`
+	Percent float64 `json:"percent"`
+}
+
 type MetricProducersResult struct {
 	Job    string `json:"job"`
 	Series int    `json:"series"`

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -45,6 +45,7 @@ type Provider interface {
 	GetQueryLatencyTrends(ctx context.Context, tr TimeRange, metricName string) ([]QueryLatencyTrendsResult, error)
 	GetQueryThroughputAnalysis(ctx context.Context, tr TimeRange) ([]QueryThroughputAnalysisResult, error)
 	GetQueryErrorAnalysis(ctx context.Context, tr TimeRange) ([]QueryErrorAnalysisResult, error)
+	GetQueryTimeRangeDistribution(ctx context.Context, tr TimeRange) ([]QueryTimeRangeDistributionResult, error)
 	GetRecentQueries(ctx context.Context, params RecentQueriesParams) (PagedResult, error)
 	GetMetricStatistics(ctx context.Context, metricName string, tr TimeRange) (MetricUsageStatics, error)
 	GetMetricQueryPerformanceStatistics(ctx context.Context, metricName string, tr TimeRange) (MetricQueryPerformanceStatistics, error)

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -583,11 +583,11 @@ func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params Dashboard
         SELECT COUNT(DISTINCT id)
         FROM DashboardUsage
         WHERE serie = ? 
-        AND strftime('%Y-%m-%d %H:%M:%S', first_seen_at) <= strftime('%Y-%m-%d %H:%M:%S', ?)
-        AND strftime('%Y-%m-%d %H:%M:%S', last_seen_at) >= strftime('%Y-%m-%d %H:%M:%S', ?)
+        AND first_seen_at <= datetime(?)
+        AND last_seen_at  >= datetime(?)
         AND CASE 
             WHEN ? != '' THEN 
-                (name LIKE '%' || ? || '%' OR url LIKE '%' || ? || '%')
+                (name LIKE '%' || ? || '%' COLLATE NOCASE OR url LIKE '%' || ? || '%' COLLATE NOCASE)
             ELSE 
                 1=1
             END;
@@ -616,11 +616,11 @@ func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params Dashboard
                 ) AS rank
             FROM DashboardUsage
             WHERE serie = ? 
-            AND strftime('%Y-%m-%d %H:%M:%S', first_seen_at) <= strftime('%Y-%m-%d %H:%M:%S', ?)
-            AND strftime('%Y-%m-%d %H:%M:%S', last_seen_at) >= strftime('%Y-%m-%d %H:%M:%S', ?)
+            AND first_seen_at <= datetime(?)
+            AND last_seen_at  >= datetime(?)
             AND CASE 
                 WHEN ? != '' THEN 
-                    (name LIKE '%' || ? || '%' OR url LIKE '%' || ? || '%')
+                    (name LIKE '%' || ? || '%' COLLATE NOCASE OR url LIKE '%' || ? || '%' COLLATE NOCASE)
                 ELSE 
                     1=1
                 END

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -356,3 +356,161 @@ func TestSQLite_DashboardUsage(t *testing.T) {
 		})
 	}
 }
+
+// TestSQLite_QueryTimeRangeDistribution verifies bucketed counts and percents for range queries
+func TestSQLite_QueryTimeRangeDistribution(t *testing.T) {
+	ctx := context.Background()
+	provider, err := newSqliteProvider(ctx)
+	if err != nil {
+		t.Fatalf("newSqliteProvider: %v", err)
+	}
+	defer func() { _ = provider.Close() }()
+
+	now := time.Now().UTC()
+
+	// Helper to create a range query with the given window duration
+	mkRange := func(window time.Duration) Query {
+		return Query{
+			TS:            now.Add(-5 * time.Minute),
+			QueryParam:    "up",
+			TimeParam:     now.Add(-5 * time.Minute),
+			Duration:      5 * time.Millisecond,
+			StatusCode:    200,
+			BodySize:      1,
+			LabelMatchers: LabelMatchers{{"__name__": "up"}},
+			Type:          QueryTypeRange,
+			Step:          15,
+			Start:         now.Add(-5 * time.Minute).Add(-window),
+			End:           now.Add(-5 * time.Minute),
+		}
+	}
+
+	// Seed queries across buckets
+	var qs []Query
+	for i := 0; i < 5; i++ { // <24h
+		qs = append(qs, mkRange(5*time.Minute))
+	}
+	for i := 0; i < 3; i++ { // 24h–<7d
+		qs = append(qs, mkRange(48*time.Hour))
+	}
+	for i := 0; i < 2; i++ { // 7d–<30d
+		qs = append(qs, mkRange(8*24*time.Hour))
+	}
+	qs = append(qs, mkRange(31*24*time.Hour))  // 30d–<60d
+	qs = append(qs, mkRange(65*24*time.Hour))  // 60d–<90d
+	qs = append(qs, mkRange(100*24*time.Hour)) // 90d+
+
+	// Insert a few instant queries that must be ignored
+	qs = append(qs, Query{
+		TS:            now.Add(-2 * time.Minute),
+		QueryParam:    "up",
+		TimeParam:     now.Add(-2 * time.Minute),
+		Duration:      3 * time.Millisecond,
+		StatusCode:    200,
+		BodySize:      1,
+		LabelMatchers: LabelMatchers{{"__name__": "up"}},
+		Type:          QueryTypeInstant,
+	})
+
+	if err := provider.Insert(ctx, qs); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// Query distribution within a window that includes TS
+	out, err := provider.GetQueryTimeRangeDistribution(ctx, TimeRange{From: now.Add(-24 * time.Hour), To: now})
+	if err != nil {
+		t.Fatalf("GetQueryTimeRangeDistribution: %v", err)
+	}
+
+	// Build result map for easy assertions
+	got := map[string]int{}
+	total := 0
+	for _, b := range out {
+		got[b.Label] = b.Count
+		total += b.Count
+	}
+
+	// Expect 5+3+2+1+1+1 = 13
+	if total != 13 {
+		t.Fatalf("unexpected total count %d", total)
+	}
+
+	if got["<24h"] != 5 || got["24h"] != 3 || got["7d"] != 2 || got["30d"] != 1 || got["60d"] != 1 || got["90d+"] != 1 {
+		t.Fatalf("unexpected bucket counts: %#v", got)
+	}
+
+	// Percent sanity check (rounded); ensure first bucket ~38.46%
+	var firstPct float64
+	for _, b := range out {
+		if b.Label == "<24h" {
+			firstPct = b.Percent
+			break
+		}
+	}
+	if firstPct < 38.4 || firstPct > 38.5 { // 5/13 ~= 38.46%
+		t.Fatalf("unexpected percent for <24h: %v", firstPct)
+	}
+}
+
+func TestSQLite_TimeRangeDistribution_ISO_TZ(t *testing.T) {
+	ctx := context.Background()
+	provider, err := newSqliteProvider(ctx)
+	if err != nil {
+		t.Fatalf("newSqliteProvider: %v", err)
+	}
+	defer func() { _ = provider.Close() }()
+
+	// Manually insert a few range queries with ISO timestamps (T/Z) to simulate proxy inserts
+	provider.(*SQLiteProvider).db.ExecContext(ctx, `DELETE FROM queries`)
+
+	now := time.Now().UTC().Truncate(time.Minute)
+	from := now.Add(-15 * time.Minute)
+
+	insert := `INSERT INTO queries (ts, queryParam, timeParam, duration, statusCode, bodySize, fingerprint, labelMatchers, type, step, start, "end", totalQueryableSamples, peakSamples)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	// Three ranges: 5m, 2h, 9d
+	ranges := []struct{ start, end time.Time }{
+		{now.Add(-10 * time.Minute), now.Add(-5 * time.Minute)},
+		{now.Add(-3 * time.Hour), now.Add(-1 * time.Hour)},
+		{now.Add(-9 * 24 * time.Hour), now},
+	}
+	for _, r := range ranges {
+		_, err := provider.(*SQLiteProvider).db.ExecContext(ctx, insert,
+			now.Format(time.RFC3339), // ts
+			"up",                     // queryParam
+			now.Format(time.RFC3339), // timeParam
+			int64(100),               // duration ms
+			200,                      // statusCode
+			0,                        // bodySize
+			"fp",                     // fingerprint
+			`[{"__name__":"up"}]`,    // labelMatchers
+			"range",                  // type
+			15.0,                     // step
+			r.start.Format(time.RFC3339),
+			r.end.Format(time.RFC3339),
+			0,
+			0,
+		)
+		if err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	out, err := provider.GetQueryTimeRangeDistribution(ctx, TimeRange{From: from, To: now})
+	if err != nil {
+		t.Fatalf("GetQueryTimeRangeDistribution: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("no buckets returned")
+	}
+
+	// Sum should be 3
+	sum := 0
+	for _, b := range out {
+		sum += b.Count
+	}
+	if sum == 0 {
+		t.Fatalf("expected non-zero distribution, got %#v", out)
+	}
+}

--- a/internal/ingester/queryingester_test.go
+++ b/internal/ingester/queryingester_test.go
@@ -122,6 +122,11 @@ func (m *MockDBProvider) GetQueryErrorAnalysis(ctx context.Context, tr db.TimeRa
 	return args.Get(0).([]db.QueryErrorAnalysisResult), args.Error(1)
 }
 
+func (m *MockDBProvider) GetQueryTimeRangeDistribution(ctx context.Context, tr db.TimeRange) ([]db.QueryTimeRangeDistributionResult, error) {
+	args := m.Called(ctx, tr)
+	return args.Get(0).([]db.QueryTimeRangeDistributionResult), args.Error(1)
+}
+
 func (m *MockDBProvider) GetRecentQueries(ctx context.Context, params db.RecentQueriesParams) (db.PagedResult, error) {
 	args := m.Called(ctx, params)
 	return args.Get(0).(db.PagedResult), args.Error(1)

--- a/ui/src/api/queries.ts
+++ b/ui/src/api/queries.ts
@@ -1,4 +1,4 @@
-import { AverageDurationResponse, PagedResult, QueryErrorAnalysisResult, QueryLatencyTrendsResult, QueryRateResponse, QueryStatusDistributionResult, QueryThroughputAnalysisResult, QueryTypesResponse, RecentQuery } from "@/lib/types"
+import { AverageDurationResponse, PagedResult, QueryErrorAnalysisResult, QueryLatencyTrendsResult, QueryRateResponse, QueryStatusDistributionResult, QueryThroughputAnalysisResult, QueryTypesResponse, RecentQuery, QueryTimeRangeDistributionResult } from "@/lib/types"
 import { ConfigResponse } from "@/types/config"
 import { toUTC } from "@/lib/utils/date-utils"
 
@@ -12,6 +12,7 @@ interface ApiConfig {
     queryLatencyTrends: string;
     queryThroughputAnalysis: string;
     queryErrorAnalysis: string;
+    queryTimeRangeDistribution: string;
     recentQueries: string;
     configs: string;
   };
@@ -39,6 +40,7 @@ const API_CONFIG: ApiConfig = {
     queryLatencyTrends: '/api/v1/query/latency',
     queryThroughputAnalysis: '/api/v1/query/throughput',
     queryErrorAnalysis: '/api/v1/query/errors',
+    queryTimeRangeDistribution: '/api/v1/query/time_range_distribution',
     recentQueries: '/api/v1/query/recent_queries',
     configs: '/api/v1/configs',
   }
@@ -81,7 +83,7 @@ type EmptyObject = Record<string, never>;
 
 type ApiResponse = QueryTypesResponse | QueryRateResponse | AverageDurationResponse | 
   QueryStatusDistributionResult[] | QueryLatencyTrendsResult[] | 
-  QueryThroughputAnalysisResult[] | QueryErrorAnalysisResult[] | 
+  QueryThroughputAnalysisResult[] | QueryErrorAnalysisResult[] | QueryTimeRangeDistributionResult[] | 
   PagedResult<RecentQuery> | ConfigResponse | string | EmptyObject;
 
 async function fetchApiData<T extends ApiResponse>(
@@ -179,6 +181,13 @@ export async function getQueryThroughputAnalysis(from?: string, to?: string): Pr
 export async function getQueryErrorAnalysis(from?: string, to?: string): Promise<QueryErrorAnalysisResult[]> {
   return withErrorHandling(
     () => fetchApiData<QueryErrorAnalysisResult[]>(API_CONFIG.endpoints.queryErrorAnalysis, { from, to }),
+    []
+  );
+}
+
+export async function getQueryTimeRangeDistribution(from?: string, to?: string): Promise<QueryTimeRangeDistributionResult[]> {
+  return withErrorHandling(
+    () => fetchApiData<QueryTimeRangeDistributionResult[]>(API_CONFIG.endpoints.queryTimeRangeDistribution, { from, to }),
     []
   );
 }

--- a/ui/src/app/overview/index.tsx
+++ b/ui/src/app/overview/index.tsx
@@ -5,6 +5,7 @@ import { QueryThroughputAnalysis } from "@/components/query-performance-analysis
 import { QueryErrorAnalysis } from "@/components/query-error-analysis";
 import { QueryTable } from "@/components/query-table";
 import { TableProvider } from "@/contexts/table-context";
+import QueryTimeRangeDistribution from "@/components/query-time-range-distribution";
 
 function OverviewHeader() {
   return (
@@ -21,6 +22,7 @@ function OverviewContent() {
       <div className="grid gap-6">
         <KeyMetrics />
 
+        <QueryTimeRangeDistribution />
         {/* Charts */}
         <div className="grid gap-6 lg:grid-cols-2">
           <StatusBreakdown />

--- a/ui/src/components/query-time-range-distribution.tsx
+++ b/ui/src/components/query-time-range-distribution.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Clock } from "lucide-react"
+import { useQuery } from "@tanstack/react-query"
+import { useDateRange } from "@/contexts/date-range-context"
+import { getQueryTimeRangeDistribution } from "@/api/queries"
+import { QueryTimeRangeDistributionResult } from "@/lib/types"
+import { Skeleton } from "@/components/ui/skeleton"
+
+const BUCKET_ORDER = ["<24h", "24h", "7d", "30d", "60d", "90d+"] as const
+const BUCKET_COLORS: Record<string, string> = {
+  "<24h": "bg-blue-500",
+  "24h": "bg-green-500",
+  "7d": "bg-yellow-500",
+  "30d": "bg-orange-500",
+  "60d": "bg-red-500",
+  "90d+": "bg-purple-500",
+}
+
+export default function QueryTimeRangeDistribution() {
+  const { dateRange } = useDateRange()
+  const from = dateRange?.from?.toISOString()
+  const to = dateRange?.to?.toISOString()
+
+  const { data, isLoading } = useQuery<QueryTimeRangeDistributionResult[]>({
+    queryKey: ["queryTimeRangeDistribution", from, to],
+    queryFn: () => getQueryTimeRangeDistribution(from, to),
+    enabled: Boolean(from && to),
+  })
+
+  const buckets = BUCKET_ORDER.map((label) => {
+    const found = data?.find((b) => b.label === label)
+    return {
+      range: label,
+      percentage: found?.percent ?? 0,
+      queries: found?.count ?? 0,
+      color: BUCKET_COLORS[label],
+    }
+  })
+
+  // Calculate dynamic retention insights
+  const shortTerm = buckets.slice(0, 2).reduce((acc, b) => acc + b.percentage, 0) // <24h + 24h
+  const mediumTerm = buckets.slice(2, 4).reduce((acc, b) => acc + b.percentage, 0) // 7d + 30d
+  const longTerm = buckets.slice(4).reduce((acc, b) => acc + b.percentage, 0) // 60d + 90d+
+  
+  const getRetentionInsight = () => {
+    const total = buckets.reduce((acc, b) => acc + b.queries, 0)
+    if (total === 0) return null
+
+    if (shortTerm >= 70) {
+      return `${shortTerm.toFixed(0)}% of queries use ranges ≤24h, suggesting significant potential for shorter retention periods to optimize storage costs.`
+    } else if (shortTerm + mediumTerm >= 80) {
+      return `${(shortTerm + mediumTerm).toFixed(0)}% of queries use ranges ≤30d, indicating moderate optimization potential with 30-day retention.`
+    } else if (longTerm >= 40) {
+      return `${longTerm.toFixed(0)}% of queries require long-term data (60d+), suggesting current retention policies are well-aligned with usage patterns.`
+    } else {
+      return `Query ranges are well-distributed across time periods, indicating balanced retention requirements.`
+    }
+  }
+
+  const retentionInsight = getRetentionInsight()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Clock className="h-5 w-5" />
+          Query Time Range Distribution
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Skeleton className="h-4 w-10" />
+                  <Skeleton className="h-4 w-8" />
+                </div>
+                <div className="h-2 rounded-full overflow-hidden bg-foreground/10">
+                  <Skeleton className="h-2 w-full" />
+                </div>
+                <Skeleton className="h-3 w-20" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+              {buckets.map((item) => (
+                <div key={item.range} className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium">{item.range}</span>
+                    <span className="text-sm text-muted-foreground">{item.percentage.toFixed(0)}%</span>
+                  </div>
+                  <div className="h-2 rounded-full overflow-hidden bg-foreground/10">
+                    <div
+                      className={`h-full ${item.color} transition-all duration-300`}
+                      style={{ width: `${item.percentage}%` }}
+                    />
+                  </div>
+                  <div className="text-xs text-muted-foreground">{item.queries.toLocaleString()} queries</div>
+                </div>
+              ))}
+            </div>
+            {retentionInsight && (
+              <div className="mt-4 p-3 bg-foreground/5 rounded-lg ">
+                <p className="text-sm text-muted-foreground">
+                  <strong>Retention Insight:</strong> {retentionInsight}
+                </p>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+

--- a/ui/src/components/status-breakdown.tsx
+++ b/ui/src/components/status-breakdown.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from "recharts"
+import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, Tooltip, CartesianGrid } from "recharts"
 import { QueryStatusDistributionResult } from "@/lib/types"
 import { formatTimestampByGranularity } from "@/lib/utils/date-formatting"
 
@@ -46,7 +46,7 @@ export function StatusBreakdown() {
       <CardContent>
         <div className="h-[300px] w-full">
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={statusData} margin={{ top: 16, right: 0, left: 0 }} barGap={2}>
+            <BarChart data={statusData} margin={{ top: 0, right: 16, left: 0, bottom: 0 }} barGap={2}>
               <CartesianGrid strokeDasharray="3 3" stroke="#888888" opacity={0.2} />
               <XAxis
                 dataKey="time"
@@ -95,11 +95,6 @@ export function StatusBreakdown() {
                   return null
                 }}
               />
-              <Legend
-                verticalAlign="top"
-                height={36}
-                formatter={(value) => <span className="text-sm text-muted-foreground">{value}</span>}
-              />
               <Bar
                 dataKey="2xx"
                 name="Success"
@@ -120,6 +115,20 @@ export function StatusBreakdown() {
               />
             </BarChart>
           </ResponsiveContainer>
+        </div>
+        <div className="mt-4 flex items-center justify-center gap-4">
+          <div className="flex items-center gap-2">
+            <div className="h-3 w-3 rounded-full bg-[hsl(var(--primary))]" />
+            <span className="text-sm">Success</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-3 w-3 rounded-full bg-[hsl(var(--warning))]" />
+            <span className="text-sm">Client Error</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-3 w-3 rounded-full bg-[hsl(var(--destructive))]" />
+            <span className="text-sm">Server Error</span>
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -44,6 +44,12 @@ export interface QueryErrorAnalysisResult {
 	value: number;
 }
 
+export interface QueryTimeRangeDistributionResult {
+	label: string;
+	count: number;
+	percent: number;
+}
+
 export interface RecentQueriesParams {
 	Page: number
 	PageSize: number


### PR DESCRIPTION
This pull request introduces a new API endpoint and supporting backend/frontend logic to provide bucketed statistics on the time ranges of Prometheus range queries. It adds the `/api/v1/query/time_range_distribution` endpoint, implements the necessary database queries for both PostgreSQL and SQLite, and exposes the results in the UI. The changes also include comprehensive tests for the new functionality.

**New Query Time Range Distribution Feature:**

* Added a new API endpoint `/api/v1/query/time_range_distribution` to return bucketed counts and percentages of range queries by their window size (e.g., `<24h`, `24h`, `7d`, etc.) in `routes.go`, with a corresponding handler and route registration. [[1]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR94) [[2]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR431-R444)
* Implemented `GetQueryTimeRangeDistribution` in both PostgreSQL and SQLite providers, including SQL logic for bucketing by window size and calculating percentages. [[1]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dR1258-R1309) [[2]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caR1312-R1373)
* Added the `QueryTimeRangeDistributionResult` struct and updated the provider interface to support the new query. [[1]](diffhunk://#diff-c07ab267311177a15707351ed34b52ff8ef1d034f6bda1dd2065fd6aa2623c60R91-R98) [[2]](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4R48)
* Added unit and integration tests for the new distribution logic in both backend and database layers, including edge cases and ISO timestamp handling. [[1]](diffhunk://#diff-6c5e270953c61ceed22901222d56cea721d9c3ee2b517d515737e3586882dcafR44-R81) [[2]](diffhunk://#diff-e7fcd2c8f2ec52fc7c807a504d8445d376604402e750012e476cb4897621d23fR359-R516)
* Integrated the new endpoint and result type into the frontend API layer and UI, including a new `QueryTimeRangeDistribution` component on the overview page. [[1]](diffhunk://#diff-da69ad05a84137d5eb7ee2ec7455873badfc9a45aa12092bcb31fc1e832072d1L1-R1) [[2]](diffhunk://#diff-da69ad05a84137d5eb7ee2ec7455873badfc9a45aa12092bcb31fc1e832072d1R15) [[3]](diffhunk://#diff-da69ad05a84137d5eb7ee2ec7455873badfc9a45aa12092bcb31fc1e832072d1R43) [[4]](diffhunk://#diff-da69ad05a84137d5eb7ee2ec7455873badfc9a45aa12092bcb31fc1e832072d1L84-R86) [[5]](diffhunk://#diff-da69ad05a84137d5eb7ee2ec7455873badfc9a45aa12092bcb31fc1e832072d1R188-R194) [[6]](diffhunk://#diff-4d7a8343d7a8fa73d94e2b37db872d8ed6576b9c69cd6eee56536e4b7105fc13R8) [[7]](diffhunk://#diff-4d7a8343d7a8fa73d94e2b37db872d8ed6576b9c69cd6eee56536e4b7105fc13R25)

**Testing and Mocking:**

* Extended the mock DB provider to include the new `GetQueryTimeRangeDistribution` method for use in tests.

**Other Minor Improvements:**

* Improved SQL in dashboard usage queries to use case-insensitive matching and simplified datetime comparisons for SQLite. [[1]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL586-R590) [[2]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL619-R623)
* Added missing import for `time` in `routes_test.go`.