### PR TITLE
[CHORE] changing test report format

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -129,13 +129,16 @@ jobs:
           path: ui/dist
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.12.0
-      - name: Run unit tests with JUnit report
+      - name: Install go-ctrf-json-reporter
+        run: go install github.com/ctrf-io/go-ctrf-json-reporter/cmd/go-ctrf-json-reporter@latest
+      - name: Run unit tests and produce CTRF JSON
         run: |
-          mkdir -p test-results
+          mkdir -p ctrf
           $(go env GOPATH)/bin/gotestsum \
             --format=short-verbose \
-            --junitfile test-results/unit-tests.xml \
+            --jsonfile gotestsum.json \
             -- -race -cover -covermode=atomic -coverprofile=coverage.out ./...
+          $(go env GOPATH)/bin/go-ctrf-json-reporter < gotestsum.json -output ctrf/ctrf-report.json
       - name: Coverage Summary
         if: always()
         run: |
@@ -143,12 +146,14 @@ jobs:
             echo "### Coverage" >> $GITHUB_STEP_SUMMARY
             echo "$(go tool cover -func=coverage.out | tail -n 1 | awk '{print $3}')" >> $GITHUB_STEP_SUMMARY
           fi
-      - name: Upload unit test report
+      - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: unit-test-report
-          path: test-results
+          name: test-reports
+          path: |
+            gotestsum.json
+            ctrf/ctrf-report.json
           retention-days: 7
       - name: Upload coverage report
         if: always()
@@ -157,11 +162,22 @@ jobs:
           name: coverage
           path: coverage.out
           retention-days: 7
-      - name: Publish Unit Test Results
+      - name: Publish Test Report (Visual Overview)
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: ctrf-io/github-test-reporter@v1
         with:
-          files: test-results/**/*.xml
+          report-path: './ctrf/*.json'
+          summary-report: true
+          failed-report: true
+          flaky-rate-report: true
+          insights-report: true
+          test-report: true
+          report-order: 'summary-report,failed-report,flaky-rate-report,insights-report,test-report'
+          pull-request: true
+          status-check: true
+          status-check-name: 'Go Tests'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   format:
     needs: [build-ui, changes]


### PR DESCRIPTION
This pull request updates the CI workflow to improve the reporting and visualization of Go test results. The main changes include switching from JUnit XML to CTRF JSON format for test reports, introducing new tooling for report generation, and updating the publishing step to use a more feature-rich test reporter.

**Test report generation and format changes:**

* Replaced JUnit XML report generation with CTRF JSON format by installing `go-ctrf-json-reporter` and using it to convert `gotestsum` output to CTRF JSON.
* Updated artifact upload to include both `gotestsum.json` and `ctrf/ctrf-report.json` files under the new `test-reports` artifact name.

**Test report publishing and visualization:**

* Switched from `EnricoMi/publish-unit-test-result-action` to `ctrf-io/github-test-reporter` for publishing test results, enabling summary, failed, flaky rate, insights, and full test reports, with enhanced pull request integration and status checks.