### PR TITLE
[CHORE] adding unused metric endpoint

### DIFF
--- a/api/models/unused.go
+++ b/api/models/unused.go
@@ -1,0 +1,14 @@
+package models
+
+type UnusedSummary struct {
+	AlertCount     int `json:"alert_count"`
+	RecordCount    int `json:"record_count"`
+	DashboardCount int `json:"dashboard_count"`
+	QueryCount     int `json:"query_count"`
+}
+
+type UnusedMetric struct {
+	Name    string        `json:"name"`
+	Unused  bool          `json:"unused"`
+	Summary UnusedSummary `json:"summary"`
+}

--- a/examples/promqlsmith/package-lock.json
+++ b/examples/promqlsmith/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "promqlsmith",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"strings"
 	"time"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
 )
 
 // Common time formats
@@ -53,6 +55,7 @@ type Provider interface {
 	GetMetricQueryPerformanceStatistics(ctx context.Context, metricName string, tr TimeRange) (MetricQueryPerformanceStatistics, error)
 	GetRulesUsage(ctx context.Context, params RulesUsageParams) (*PagedResult, error)
 	GetDashboardUsage(ctx context.Context, params DashboardUsageParams) (*PagedResult, error)
+	GetSeriesMetadataByNames(ctx context.Context, names []string, job string) ([]models.MetricMetadata, error)
 
 	Close() error
 }

--- a/internal/ingester/queryingester_test.go
+++ b/internal/ingester/queryingester_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -145,6 +146,11 @@ func (m *MockDBProvider) GetMetricStatistics(ctx context.Context, metricName str
 func (m *MockDBProvider) GetMetricQueryPerformanceStatistics(ctx context.Context, metricName string, tr db.TimeRange) (db.MetricQueryPerformanceStatistics, error) {
 	args := m.Called(ctx, metricName, tr)
 	return args.Get(0).(db.MetricQueryPerformanceStatistics), args.Error(1)
+}
+
+func (m *MockDBProvider) GetSeriesMetadataByNames(ctx context.Context, names []string, job string) ([]models.MetricMetadata, error) {
+	args := m.Called(ctx, names, job)
+	return args.Get(0).([]models.MetricMetadata), args.Error(1)
 }
 
 func TestQueryIngester_Run(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve unused metric information, along with supporting changes to the database providers and models. The main focus is to allow clients to query which metrics are unused, based on their usage in alerts, records, dashboards, and queries. The changes include new data structures, API route, and implementations for both PostgreSQL and SQLite providers.

Key changes include:

**API Enhancements:**

* Added a new endpoint `/api/v1/metrics/unused` that accepts a list of metric names (and optional job) and returns usage summary and unused status for each metric. [[1]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR105) [[2]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR959-R1019)

**Data Model Updates:**

* Introduced `UnusedSummary` and `UnusedMetric` structs in `api/models/unused.go` to represent unused metric data and its summary.

**Database Provider Support:**

* Added `GetSeriesMetadataByNames` method to the `Provider` interface and implemented it for both PostgreSQL (`internal/db/postgresql.go`) and SQLite (`internal/db/sqlite.go`) providers, enabling efficient batch retrieval of metric metadata and usage. [[1]](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4R58) [[2]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dR761-R816) [[3]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caR804-R871)

**Testing Support:**

* Updated the mock database provider in `internal/ingester/queryingester_test.go` to support the new `GetSeriesMetadataByNames` method.

**Miscellaneous:**

* Added a minimal `package-lock.json` for the `examples/promqlsmith` example.