### PR TITLE
[CHORE] removing minor go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ./ui .
 RUN npm install
 RUN NODE_ENV=production npm run build
 
-FROM golang:1.25.3 AS gobuild
+FROM golang:1.25 AS gobuild
 
 WORKDIR /go/src/github.com/nicolastakashi/prom-analytics-proxy
 

--- a/examples/promqlsmith/go.mod
+++ b/examples/promqlsmith/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicolastakashi/promcon-2025/promqlsmith
 
-go 1.25.1
+go 1.25
 
 require (
 	github.com/cortexproject/promqlsmith v0.0.0-20250429034839-226ab9cf9540

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicolastakashi/prom-analytics-proxy
 
-go 1.25.3
+go 1.25
 
 require (
 	github.com/lib/pq v1.10.9

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicolastakashi/prom-analytics-proxy/tooling
 
-go 1.25.3
+go 1.25
 
 require (
 	github.com/bwplotka/mdox v0.9.0


### PR DESCRIPTION
This pull request updates the Go version specification across multiple files in the repository. The main change is standardizing the Go version from various patch releases to `1.25`, which improves consistency and simplifies maintenance.

Go version standardization:

* Updated the Go version in the main project `go.mod` from `1.25.3` to `1.25` for consistency.
* Changed the Go version in `scripts/go.mod` from `1.25.3` to `1.25` to match the main project.
* Updated the Go version in `examples/promqlsmith/go.mod` from `1.25.1` to `1.25` for consistency across examples.
* Modified the base image version in the `Dockerfile` from `golang:1.25.3` to `golang:1.25` to ensure the Docker build uses the standardized Go version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes Go version to 1.25 in all go.mod files and the Dockerfile build stage.
> 
> - **Build/Go version**:
>   - Set `go 1.25` in `go.mod`, `scripts/go.mod`, and `examples/promqlsmith/go.mod`.
>   - Use `golang:1.25` as the base image in `Dockerfile` for the `gobuild` stage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 622c8566f5173381fc5b42a315d7e999a2bbd4d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->