### PR TITLE
feat: add time range column to the executions table

### DIFF
--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -267,6 +267,8 @@ type QueryExecutionRow struct {
 	Type        string            `json:"type"`
 	Steps       float64           `json:"steps"`
 	HTTPHeaders map[string]string `json:"httpHeaders,omitempty"`
+	Start       time.Time         `json:"start"`
+	End         time.Time         `json:"end,omitempty"`
 }
 
 type SeriesMetadataParams struct {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -1620,6 +1620,8 @@ func (p *SQLiteProvider) GetQueryExecutions(ctx context.Context, params QueryExe
             samples,
             type,
 			httpHeaders,
+			start,
+			"end",
             COALESCE(step, 0) AS steps,
             total_count
         FROM filtered, counted
@@ -1669,11 +1671,13 @@ func (p *SQLiteProvider) GetQueryExecutions(ctx context.Context, params QueryExe
 		var samples int
 		var typ string
 		var steps float64
+		var start time.Time
+		var end time.Time
 		var httpHeadersJSON string
-		if err := rows.Scan(&ts, &status, &duration, &samples, &typ, &httpHeadersJSON, &steps, &totalCount); err != nil {
+		if err := rows.Scan(&ts, &status, &duration, &samples, &typ, &httpHeadersJSON, &start, &end, &steps, &totalCount); err != nil {
 			return PagedResult{}, fmt.Errorf("failed to scan row: %w", err)
 		}
-		r := QueryExecutionRow{Timestamp: ts, Status: status, Duration: duration, Samples: samples, Type: typ, Steps: steps}
+		r := QueryExecutionRow{Timestamp: ts, Status: status, Duration: duration, Samples: samples, Type: typ, Steps: steps, Start: start, End: end}
 		if httpHeadersJSON != "" {
 			if err := json.Unmarshal([]byte(httpHeadersJSON), &r.HTTPHeaders); err != nil {
 				return PagedResult{}, fmt.Errorf("failed to unmarshal httpHeaders: %w", err)

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -127,4 +127,6 @@ export interface QueryExecution {
   type: "instant" | "range";
   steps: number;
   httpHeaders: Record<string, string>;
+  start: string;
+  end?: string;
 }


### PR DESCRIPTION
resolves #392

Adds `Time range` column to the executions table

<img width="1177" height="563" alt="image" src="https://github.com/user-attachments/assets/1c502e56-7611-4ca3-88df-522e8763772b" />



Signed-off-by: Martin Chodur <m.chodur@seznam.cz>