### PR TITLE
chore(examples): Watch also queries in the Prometheus frontend

### DIFF
--- a/examples/config/nginx/nginx.conf
+++ b/examples/config/nginx/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    server {
+        listen 9090;
+
+        location /api/ {
+            proxy_pass http://prom-analytics-proxy:9091;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            proxy_pass http://prometheus-backend:9092;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/examples/config/prometheus/prometheus.yml
+++ b/examples/config/prometheus/prometheus.yml
@@ -7,4 +7,4 @@ scrape_configs:
   - job_name: prometheus
     static_configs:
       - targets:
-          - localhost:9090
+          - localhost:9092

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,12 +1,15 @@
 services:
-  prometheus:
+  prometheus-backend:
     image: prom/prometheus
-    container_name: prometheus
+    container_name: prometheus-backend
+    command:
+      - --web.listen-address=:9092
+      - --config.file=/etc/prometheus/prometheus.yml
     volumes:
       - ./config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./config/prometheus/rules.yml:/etc/prometheus/rules.yml
     ports:
-      - 9090:9090
+      - 9092:9092
     restart: unless-stopped
     networks:
       - promcon-network
@@ -14,7 +17,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://localhost:9090/health",
+          "wget --no-verbose --tries=1 --spider http://localhost:9092/health",
         ]
       interval: 10s
       timeout: 5s
@@ -45,12 +48,39 @@ services:
       retries: 5
     restart: unless-stopped
 
+  prometheus:
+    image: nginx:latest
+    container_name: prometheus
+    ports:
+      - 9090:9090
+    volumes:
+      - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - prometheus-backend
+    networks:
+      - promcon-network
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:9090/",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
   prom-analytics-proxy:
     image: ghcr.io/nicolastakashi/prom-analytics-proxy:main
     container_name: prom-analytics-proxy
     command:
       - --insecure-listen-address=0.0.0.0:9091
-      - --upstream=http://prometheus:9090
+      - --upstream=http://prometheus-backend:9092
       - --database-provider=postgresql
       - --postgresql-addr=postgres
       - --postgresql-port=5432
@@ -66,7 +96,7 @@ services:
       - promcon-network
     depends_on:
       - postgres
-      - prometheus
+      - prometheus-backend
     healthcheck:
       test:
         [
@@ -122,8 +152,6 @@ services:
       - "8081:8080"
     restart: unless-stopped
     depends_on:
-      - prom-analytics-proxy
-      - prometheus
       - perses
     volumes:
       - ./config/metrics-usage/config.yaml:/app/config.yaml


### PR DESCRIPTION
Something we discussed already in private, this is to show in example how to watch also the queries done by the frontend. 

<img width="631" height="332" alt="image" src="https://github.com/user-attachments/assets/86dfd9d1-23a1-45d9-90bf-fa5105b3567a" />

So this PR implement the green part (without the /analysis part actually) and it's working well 🙂 

---

The only drawback I find is that I discovered the frontend is actually make an additional time() query 

<img width="1641" height="649" alt="image" src="https://github.com/user-attachments/assets/7c54455a-08ba-435f-83da-7a697acc8fa5" />

