### PR TITLE
[CHORE] update Makefile to support conditional debug info stripping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,12 @@ GOBUILD=$(GOCMD) build
 GOOS?=$(shell go env GOOS)
 ENVVARS=GOOS=$(GOOS) CGO_ENABLED=0
 
-LDFLAGS=-w -extldflags "-static" \
+# STRIP_DEBUG: Set to 'true' to strip DWARF debug info (-w flag)
+# Disable for eBPF CPU profilers which need debug symbols
+STRIP_DEBUG ?= false
+STRIP_FLAG = $(if $(filter true,$(STRIP_DEBUG)),-w,)
+
+LDFLAGS=$(STRIP_FLAG) -extldflags "-static" \
 		-X github.com/prometheus/common/version.Version=$(RELEASE_VERSION) \
 		-X github.com/prometheus/common/version.Revision=$(REVISION) \
 		-X github.com/prometheus/common/version.Branch=$(BRANCH) \


### PR DESCRIPTION
This pull request introduces a configurable option to control whether DWARF debug information is stripped from binaries during the build process. This is particularly useful for scenarios like eBPF CPU profiling, where debug symbols are required.

Build configuration improvements:

* Added a new `STRIP_DEBUG` variable to the `Makefile` to control the inclusion of the `-w` flag, allowing users to easily enable or disable stripping of DWARF debug info during builds. This supports use cases (such as eBPF CPU profilers) that require debug symbols.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `STRIP_DEBUG` option to conditionally include the `-w` flag in `LDFLAGS`, enabling or disabling DWARF debug-info stripping.
> 
> - **Build/Makefile**:
>   - Introduces `STRIP_DEBUG` (default `false`) and derives `STRIP_FLAG` to control inclusion of `-w`.
>   - Updates `LDFLAGS` to prepend `$(STRIP_FLAG)` before `-extldflags "-static"`, preserving existing version metadata injections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 232620a10223e3db4d0e8bfa39025de50ef2a5ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->