### PR TITLE
[CHORE] add pprof endpoints for performance profiling in routes and i…

### DIFF
--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
+	"net/http/pprof"
 	"net/url"
 	"slices"
 	"strconv"
@@ -78,6 +79,17 @@ func WithHandlers(uiFS fs.FS, registry *prometheus.Registry, isTracingEnabled bo
 		mux := http.NewServeMux()
 		mux.Handle("/", r.ui(uiFS))
 		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+		// pprof endpoints
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+		mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+		mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+		mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
 		mux.Handle("/api/", http.HandlerFunc(r.passthrough))
 		mux.Handle("/api/v1/query", i.NewHandler(
 			prometheus.Labels{"handler": "query"},

--- a/cmd/ingester/run.go
+++ b/cmd/ingester/run.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/http/pprof"
 	"strings"
 	"syscall"
 	"time"
@@ -106,6 +107,18 @@ func Run() error {
 	{
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
+
+		// pprof endpoints
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+		mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+		mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+		mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
 
 		// Kubernetes-style liveness probe: returns 200 as long as the process is running.
 		mux.HandleFunc("/livez", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This pull request adds pprof profiling endpoints to both the main API server and the ingester service, making it easier to collect runtime profiling data for debugging and performance analysis. The changes are focused on enhancing observability and diagnostics by exposing standard Go pprof endpoints.

Profiling and observability enhancements:

* Added `net/http/pprof` import to both `api/routes/routes.go` and `cmd/ingester/run.go` to enable pprof handlers. [[1]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR14) [[2]](diffhunk://#diff-65b03d93f8d2142a8a4d7627517fe882ac4a66e4c06f01df4c42fc659c6df17fR10)
* Registered all standard pprof endpoints (e.g., `/debug/pprof/`, `/debug/pprof/profile`, `/debug/pprof/heap`, etc.) on the HTTP mux in both the API server (`WithHandlers`) and ingester (`Run`) functions, allowing profiling access via HTTP. [[1]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR82-R92) [[2]](diffhunk://#diff-65b03d93f8d2142a8a4d7627517fe882ac4a66e4c06f01df4c42fc659c6df17fR111-R122)…ngester

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose standard Go pprof endpoints under /debug/pprof/* on both the API server and ingester HTTP servers.
> 
> - **Observability / Profiling**:
>   - **API server** (`api/routes/routes.go`): Register Go `pprof` handlers under `/debug/pprof/*`.
>   - **Ingester** (`cmd/ingester/run.go`): Register Go `pprof` handlers under `/debug/pprof/*` on the metrics/health HTTP server.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6beec53f1c5ad34c375c7b8301acde431c669ebe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->