### PR TITLE
[CHORE] updating go version

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,2 @@
-golang-version=1.25
+golang-version=1.26
 node-version=23.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ./ui .
 RUN npm install
 RUN NODE_ENV=production npm run build
 
-FROM golang:1.25 AS gobuild
+FROM golang:1.26 AS gobuild
 
 WORKDIR /go/src/github.com/nicolastakashi/prom-analytics-proxy
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,7 +9,7 @@ COPY ./ui .
 RUN npm install
 RUN NODE_ENV=production npm run build
 
-FROM golang:1.25.4 AS gobuild
+FROM golang:1.26.0 AS gobuild
 
 WORKDIR /go/src/github.com/nicolastakashi/prom-analytics-proxy
 

--- a/examples/promqlsmith/go.mod
+++ b/examples/promqlsmith/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicolastakashi/promcon-2025/promqlsmith
 
-go 1.25
+go 1.26
 
 require (
 	github.com/cortexproject/promqlsmith v0.0.0-20250429034839-226ab9cf9540

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicolastakashi/prom-analytics-proxy
 
-go 1.25.4
+go 1.26.0
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicolastakashi/prom-analytics-proxy/tooling
 
-go 1.25.4
+go 1.26.0
 
 require (
 	github.com/bwplotka/mdox v0.9.0


### PR DESCRIPTION
This pull request updates the Go version across the project from 1.25 to 1.26. The changes ensure consistency in the build environment and dependencies for all modules and Docker images.

Go version upgrade:

* Updated the Go version in `.github/env` to `1.26` for CI/CD workflows.
* Changed the base image in `Dockerfile` from `golang:1.25` to `golang:1.26` to use the latest Go version for builds.
* Changed the base image in `Dockerfile.alpine` from `golang:1.25.4` to `golang:1.26.0` to use the latest Go version for Alpine builds.
* Updated the Go version in `go.mod`, `scripts/go.mod`, and `examples/promqlsmith/go.mod` to `1.26.0` for all project modules. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-bb92fe9b06f8ba4d1f89a4c2f60be649df000b97dfad60a474afd9de34e1d7d5L3-R3) [[3]](diffhunk://#diff-189a75fab9bb5426b203875ccae8e2e20c3e50f147394f6bb3d738dd284bf2f5L3-R3)