### PR TITLE
[CI] improving docker build and ci time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.vscode
+.cursor
+tmp
+bin
+scripts
+docs
+examples
+**/node_modules
+ui/dist
+ui/build
+.DS_Store
+npm-debug.log
+yarn-error.log

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -6,7 +6,6 @@ on:
     tags: ["v*.*.*"]
     paths:
       - "Dockerfile"
-      - "Dockerfile.alpine"
       - "**/*.go"
       - "ui/**"
       - ".github/workflows/container-image.yaml"
@@ -15,7 +14,6 @@ on:
   pull_request:
     paths:
       - "Dockerfile"
-      - "Dockerfile.alpine"
       - "**/*.go"
       - "ui/**"
       - ".github/workflows/container-image.yaml"
@@ -89,11 +87,16 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          target: final-distroless
           platforms: linux/amd64,linux/arm64
           # Push for: push events, or PRs from same repo (not forks)
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            REVISION=${{ github.sha }}
+            BRANCH=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            RELEASE_VERSION=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+          cache-from: type=gha,scope=container-image
+          cache-to: type=gha,mode=max,scope=container-image
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -101,11 +104,16 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile.alpine
+          file: ./Dockerfile
+          target: final-alpine
           platforms: linux/amd64,linux/arm64
           # Push for: push events, or PRs from same repo (not forks)
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            REVISION=${{ github.sha }}
+            BRANCH=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            RELEASE_VERSION=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+          cache-from: type=gha,scope=container-image
+          cache-to: type=gha,mode=max,scope=container-image
           tags: ${{ steps.meta-alpine.outputs.tags }}
           labels: ${{ steps.meta-alpine.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,31 +2,48 @@
 
 FROM node:23.6.0-alpine AS uibuild
 
-WORKDIR /go/src/github.com/nicolastakashi/prom-analytics-proxy
+WORKDIR /app/ui
 
-COPY ./ui .
+COPY ui/package.json ui/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci --legacy-peer-deps
 
-RUN npm install
+COPY ui/ ./
 RUN NODE_ENV=production npm run build
 
 FROM golang:1.25 AS gobuild
 
-WORKDIR /go/src/github.com/nicolastakashi/prom-analytics-proxy
+WORKDIR /app
 
-RUN apt-get update
 RUN useradd -ms /bin/bash prom-analytics-proxy
 
-COPY --from=uibuild /go/src/github.com/nicolastakashi/prom-analytics-proxy/dist ./ui/dist
+ARG REVISION=unknown
+ARG BRANCH=unknown
+ARG RELEASE_VERSION=unknown
 
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY --from=uibuild /app/ui/dist ./ui/dist
 COPY --chown=prom-analytics-proxy:prom-analytics-proxy . .
 
-RUN make all
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    make build REVISION=$REVISION BRANCH=$BRANCH RELEASE_VERSION=$RELEASE_VERSION
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest AS final-distroless
 
 WORKDIR /prom-analytics-proxy
 
-COPY --from=gobuild /go/src/github.com/nicolastakashi/prom-analytics-proxy/bin/* /bin/
+COPY --from=gobuild /app/bin/* /bin/
+
+USER nobody
+
+ENTRYPOINT [ "/bin/prom-analytics-proxy" ]
+
+FROM alpine:3.19 AS final-alpine
+
+WORKDIR /prom-analytics-proxy
+
+COPY --from=gobuild /app/bin/* /bin/
 
 USER nobody
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ RELEASE_VERSION ?=$(shell git describe --tags --abbrev=0 2>/dev/null || echo $(R
 BINARY_FOLDER=bin
 BINARY_NAME=prom-analytics-proxy
 ARTIFACT_NAME=coralogix/$(BINARY_NAME)
+DOCKER_TARGET ?= final-alpine
 GOCMD=go
 GOMAIN=main.go
 GOBUILD=$(GOCMD) build
@@ -37,7 +38,11 @@ LDFLAGS=$(STRIP_FLAG) -extldflags "-static" \
 
 .PHONY: docker-build
 docker-build:
-	@DOCKER_BUILDKIT=1 docker build -t ${ARTIFACT_NAME}:${RELEASE_VERSION} -f Dockerfile --progress=plain .
+	@DOCKER_BUILDKIT=1 docker build -t ${ARTIFACT_NAME}:${RELEASE_VERSION} -f Dockerfile --target $(DOCKER_TARGET) --progress=plain \
+		--build-arg REVISION=$(REVISION) \
+		--build-arg BRANCH=$(BRANCH) \
+		--build-arg RELEASE_VERSION=$(RELEASE_VERSION) \
+		.
 
 .PHONY: build
 build:


### PR DESCRIPTION
This pull request updates the container build and release process to improve Docker image builds, optimize caching, and add support for multi-stage and multi-target Docker builds. The changes streamline how the UI and Go binaries are built and packaged, introduce build-time metadata, and enhance the `.dockerignore` for cleaner builds. The GitHub Actions workflow is also updated to match the new Dockerfile structure and caching strategy.

**Container build improvements:**

* Refactored the `Dockerfile` to use multi-stage builds for UI and Go binaries, introduced build arguments (`REVISION`, `BRANCH`, `RELEASE_VERSION`), and added separate targets for `final-distroless` and `final-alpine` images. The build now uses cached dependencies for both Node and Go, and metadata is passed into the binary at build time.
* Updated the `Makefile` to support selecting the Docker build target via the `DOCKER_TARGET` variable and to pass build arguments for revision, branch, and release version into the Docker build. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R20) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L40-R45)

**CI/CD workflow enhancements:**

* Modified the GitHub Actions workflow (`container-image.yaml`) to use the new Dockerfile targets (`final-distroless` and `final-alpine`), improved build caching with scoped keys, and added build arguments for revision, branch, and release version. Also, removed references to the old `Dockerfile.alpine` and updated build triggers accordingly. [[1]](diffhunk://#diff-a8e5d9cb2f89e3a62365c06b091cf9cb29a6a7db10fa9832707ce2a66580a641L9) [[2]](diffhunk://#diff-a8e5d9cb2f89e3a62365c06b091cf9cb29a6a7db10fa9832707ce2a66580a641L18) [[3]](diffhunk://#diff-a8e5d9cb2f89e3a62365c06b091cf9cb29a6a7db10fa9832707ce2a66580a641R90-R117)

**Build context and cleanliness:**

* Added a comprehensive `.dockerignore` file to exclude unnecessary files and directories (such as `.git`, `node_modules`, build artifacts, and logs) from the Docker build context, resulting in smaller and cleaner images.