### PR TITLE
[FIX] fix metrics catalog type filters for histogram and summary aliases

### DIFF
--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -713,7 +713,12 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
         FROM metrics_catalog c
         LEFT JOIN metrics_usage_summary s ON s.name = c.name
         WHERE ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
-          AND ($2 = 'all' OR c.type = $2)
+          AND ($2 = 'all' OR
+               CASE
+                 WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = $2
+               END)
           AND (CASE WHEN $3 THEN COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0 ELSE TRUE END)
           AND ($4 = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
@@ -734,7 +739,12 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
         FROM metrics_catalog c
         LEFT JOIN metrics_usage_summary s ON s.name = c.name
         WHERE ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
-          AND ($2 = 'all' OR c.type = $2)
+          AND ($2 = 'all' OR
+               CASE
+                 WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = $2
+               END)
           AND (CASE WHEN $3 THEN COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0 ELSE TRUE END)
           AND ($4 = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
@@ -537,6 +538,34 @@ func TestPostgreSQL_HistogramSummaryMetricsCatalog(t *testing.T) {
 	res, err := p.GetSeriesMetadata(context.Background(), SeriesMetadataParams{Page: 1, PageSize: 10, SortBy: "name", SortOrder: "asc", Type: "all"})
 	assert.NoError(t, err, "GetSeriesMetadata")
 	assert.Equal(t, 6, res.Total, "Expected 6 metrics")
+
+	histogramRes, err := p.GetSeriesMetadata(context.Background(), SeriesMetadataParams{Page: 1, PageSize: 10, SortBy: "name", SortOrder: "asc", Type: "histogram"})
+	assert.NoError(t, err, "GetSeriesMetadata histogram filter")
+	assert.Equal(t, 3, histogramRes.Total, "Expected 3 histogram metrics")
+	if data, ok := histogramRes.Data.([]models.MetricMetadata); ok {
+		if assert.Len(t, data, 3) {
+			assert.ElementsMatch(t,
+				[]string{"histogram_bucket", "histogram_count", "histogram_sum"},
+				[]string{data[0].Type, data[1].Type, data[2].Type},
+			)
+		}
+	} else {
+		assert.Fail(t, "Expected histogram Data to be []models.MetricMetadata", "got %T", histogramRes.Data)
+	}
+
+	summaryRes, err := p.GetSeriesMetadata(context.Background(), SeriesMetadataParams{Page: 1, PageSize: 10, SortBy: "name", SortOrder: "asc", Type: "summary"})
+	assert.NoError(t, err, "GetSeriesMetadata summary filter")
+	assert.Equal(t, 3, summaryRes.Total, "Expected 3 summary metrics")
+	if data, ok := summaryRes.Data.([]models.MetricMetadata); ok {
+		if assert.Len(t, data, 3) {
+			assert.ElementsMatch(t,
+				[]string{"summary", "summary_count", "summary_sum"},
+				[]string{data[0].Type, data[1].Type, data[2].Type},
+			)
+		}
+	} else {
+		assert.Fail(t, "Expected summary Data to be []models.MetricMetadata", "got %T", summaryRes.Data)
+	}
 }
 
 func TestPostgreSQL_MetricsInventoryAndList(t *testing.T) {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -726,7 +726,12 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
         FROM metrics_catalog c
         LEFT JOIN metrics_usage_summary s ON s.name = c.name
         WHERE (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
-          AND (? = 'all' OR c.type = ?)
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+               END)
           AND (CASE WHEN ? = 1 THEN COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0 ELSE 1 END)
           AND (? = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
@@ -734,7 +739,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
           ))
     `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter, params.Filter, params.Filter, params.Type, params.Type, boolToInt(params.Unused), params.Job, params.Job).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter, params.Filter, params.Filter, params.Type, params.Type, params.Type, params.Type, boolToInt(params.Unused), params.Job, params.Job).Scan(&total); err != nil {
 		return nil, fmt.Errorf("failed to count catalog: %w", err)
 	}
 
@@ -749,7 +754,12 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
         FROM metrics_catalog AS c
         LEFT JOIN metrics_usage_summary AS s ON s.name = c.name
         WHERE (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
-          AND (? = 'all' OR c.type = ?)
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+               END)
           AND (CASE WHEN ? = 1 THEN COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0 ELSE 1 END)
           AND (? = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
@@ -761,7 +771,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Filter, params.Filter, params.Filter,
-		params.Type, params.Type,
+		params.Type, params.Type, params.Type, params.Type,
 		boolToInt(params.Unused),
 		params.Job, params.Job,
 		params.PageSize, (params.Page-1)*params.PageSize,

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -624,6 +624,38 @@ func TestSQLite_HistogramSummaryMetricsCatalog(t *testing.T) {
 			assert.Equal(t, expectedType, actualType, "Summary metric %s type", name)
 		}
 	}
+
+	histogramRes, err := p.GetSeriesMetadata(context.Background(), SeriesMetadataParams{
+		Page: 1, PageSize: 10, SortBy: "name", SortOrder: "asc", Type: "histogram",
+	})
+	assert.NoError(t, err, "GetSeriesMetadata histogram filter")
+	assert.Equal(t, 3, histogramRes.Total, "Expected 3 histogram metrics")
+	if data, ok := histogramRes.Data.([]models.MetricMetadata); ok {
+		if assert.Len(t, data, 3) {
+			assert.ElementsMatch(t,
+				[]string{"histogram_bucket", "histogram_count", "histogram_sum"},
+				[]string{data[0].Type, data[1].Type, data[2].Type},
+			)
+		}
+	} else {
+		assert.Fail(t, "Expected histogram Data to be []models.MetricMetadata", "got %T", histogramRes.Data)
+	}
+
+	summaryRes, err := p.GetSeriesMetadata(context.Background(), SeriesMetadataParams{
+		Page: 1, PageSize: 10, SortBy: "name", SortOrder: "asc", Type: "summary",
+	})
+	assert.NoError(t, err, "GetSeriesMetadata summary filter")
+	assert.Equal(t, 3, summaryRes.Total, "Expected 3 summary metrics")
+	if data, ok := summaryRes.Data.([]models.MetricMetadata); ok {
+		if assert.Len(t, data, 3) {
+			assert.ElementsMatch(t,
+				[]string{"summary", "summary_count", "summary_sum"},
+				[]string{data[0].Type, data[1].Type, data[2].Type},
+			)
+		}
+	} else {
+		assert.Fail(t, "Expected summary Data to be []models.MetricMetadata", "got %T", summaryRes.Data)
+	}
 }
 
 // Basic integration test exercising catalog upsert, summary refresh and list.


### PR DESCRIPTION
This pull request updates the filtering logic for metric types in both the PostgreSQL and SQLite database providers, allowing for more accurate retrieval of histogram and summary metrics. It also adds comprehensive tests to verify the new behavior for both providers.

### Enhanced metric type filtering

* Updated the SQL filtering logic in `GetSeriesMetadata` for both `PostGreSQLProvider` and `SQLiteProvider` to support grouping histogram and summary metric types. When filtering by `histogram`, it now returns all metrics with types `histogram_bucket`, `histogram_count`, and `histogram_sum`; when filtering by `summary`, it returns `summary`, `summary_count`, and `summary_sum`. [[1]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL716-R721) [[2]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL737-R747) [[3]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL729-R742) [[4]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL752-R762)
* Adjusted query parameter handling in SQLite provider to accommodate the expanded filtering logic.

### Testing improvements

* Added tests in `internal/db/postgresql_test.go` and `internal/db/sqlite_test.go` to verify that filtering by `histogram` and `summary` returns the correct metric types and counts. These tests ensure the new logic works as intended for both database backends. [[1]](diffhunk://#diff-aa505ee5ecf26172ca4b4a7a705fa2de7b27a9ff5a5b712f02180a06445664daR541-R568) [[2]](diffhunk://#diff-e7fcd2c8f2ec52fc7c807a504d8445d376604402e750012e476cb4897621d23fR627-R658)
* Imported `models` package in `internal/db/postgresql_test.go` to support the new test assertions.

Resolves #428 