### PR TITLE
[CHORE] Add used-only filter to metrics catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ The proxy provides several API endpoints for accessing query analytics and metri
 - `sortOrder` (string): Sort direction - `asc` or `desc` (default: `asc`)
 - `filter` (string): Filter metrics by name or help text
 - `type` (string): Filter by metric type - `counter`, `gauge`, `histogram`, `summary`, etc.
-- `unused` (boolean): Filter to show only unused metrics (no alerts, recording rules, dashboards, or queries)
+- `usage` (string): Filter metrics by usage state - `all`, `used`, or `unused`
 - `job` (string): Filter to show metrics produced by a specific job
 
 #### Examples
@@ -563,11 +563,11 @@ The proxy provides several API endpoints for accessing query analytics and metri
 # Get all metrics with pagination
 curl "http://localhost:9091/api/v1/seriesMetadata?page=1&pageSize=20"
 
-# Find unused metrics
-curl "http://localhost:9091/api/v1/seriesMetadata?unused=true"
+# Find used metrics
+curl "http://localhost:9091/api/v1/seriesMetadata?usage=used"
 
 # Find unused metrics for a specific job
-curl "http://localhost:9091/api/v1/seriesMetadata?unused=true&job=myapp"
+curl "http://localhost:9091/api/v1/seriesMetadata?usage=unused&job=myapp"
 
 # Search for HTTP-related metrics
 curl "http://localhost:9091/api/v1/seriesMetadata?filter=http&type=counter"

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -671,6 +671,7 @@ func (r *routes) seriesMetadata(w http.ResponseWriter, req *http.Request) {
 		SortOrder: "asc",
 		Filter:    "",
 		Type:      "",
+		Usage:     db.SeriesMetadataUsageAll,
 	}
 
 	if page, err := getQueryParamAsInt(req, "page", 1); err == nil {
@@ -714,8 +715,15 @@ func (r *routes) seriesMetadata(w http.ResponseWriter, req *http.Request) {
 		params.Type = metricType
 	}
 
-	if unused := req.FormValue("unused"); unused == "true" {
-		params.Unused = true
+	if usage := req.FormValue("usage"); usage != "" {
+		normalizedUsage := strings.ToLower(strings.TrimSpace(usage))
+		if db.ValidSeriesMetadataUsageFilters[normalizedUsage] {
+			params.Usage = normalizedUsage
+		} else {
+			slog.Warn("invalid usage parameter provided", "usage", usage, "using_default", db.SeriesMetadataUsageAll)
+		}
+	} else if unused := req.FormValue("unused"); unused == "true" {
+		params.Usage = db.SeriesMetadataUsageUnused
 	}
 
 	if job := req.FormValue("job"); job != "" {

--- a/api/routes/routes_test.go
+++ b/api/routes/routes_test.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"context"
+	"encoding/json"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +43,82 @@ func TestSeriesMetadata_DBBacked(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != 200 {
 		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSeriesMetadata_UsageFilter_Route(t *testing.T) {
+	provider, err := db.GetDbProvider(context.Background(), db.SQLite)
+	if err != nil {
+		t.Skipf("sqlite provider unavailable: %v", err)
+	}
+	defer func() { _ = provider.Close() }()
+
+	now := time.Now().UTC()
+	_ = provider.UpsertMetricsCatalog(context.Background(), []db.MetricCatalogItem{
+		{Name: "used_metric", Type: "gauge"},
+		{Name: "unused_metric", Type: "gauge"},
+	})
+	_ = provider.Insert(context.Background(), []db.Query{{
+		TS:            now.Add(-5 * time.Minute),
+		QueryParam:    "used_metric",
+		TimeParam:     now,
+		Duration:      10 * time.Millisecond,
+		StatusCode:    200,
+		LabelMatchers: db.LabelMatchers{{"__name__": "used_metric"}},
+		Type:          db.QueryTypeInstant,
+	}})
+	_ = provider.RefreshMetricsUsageSummary(context.Background(), db.TimeRange{From: now.Add(-1 * time.Hour), To: now})
+	_ = provider.UpsertMetricsCatalog(context.Background(), []db.MetricCatalogItem{{Name: "no_summary_metric", Type: "gauge"}})
+
+	upstream, _ := url.Parse("http://127.0.0.1")
+	reg := prometheus.NewRegistry()
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+	r, _ := NewRoutes(
+		WithDBProvider(provider),
+		WithProxy(upstream),
+		WithPromAPI(upstream),
+		WithHandlers(uiFS, reg, false),
+	)
+
+	tests := []struct {
+		name      string
+		query     string
+		wantNames []string
+	}{
+		{
+			name:      "used usage filter",
+			query:     "/api/v1/seriesMetadata?page=1&pageSize=10&type=all&usage=used",
+			wantNames: []string{"used_metric"},
+		},
+		{
+			name:      "unused usage filter",
+			query:     "/api/v1/seriesMetadata?page=1&pageSize=10&type=all&usage=unused",
+			wantNames: []string{"no_summary_metric", "unused_metric"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.query, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != 200 {
+				t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+			}
+
+			var response struct {
+				Data []models.MetricMetadata `json:"data"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+
+			names := make([]string, 0, len(response.Data))
+			for _, metric := range response.Data {
+				names = append(names, metric.Name)
+			}
+			assert.ElementsMatch(t, tt.wantNames, names)
+		})
 	}
 }
 

--- a/docs/plans/issue-427-used-metrics-filter.md
+++ b/docs/plans/issue-427-used-metrics-filter.md
@@ -1,0 +1,45 @@
+# Issue 427: Used Metrics Filter
+
+## Goal
+
+Add a `Used Only` filter to the Metrics Catalog so users can switch between:
+
+- `All Metrics`
+- `Used Only`
+- `Unused Only`
+
+A metric counts as used when any of these summary fields is greater than zero:
+
+- `queryCount`
+- `alertCount`
+- `recordCount`
+- `dashboardCount`
+
+The usage view should continue to reflect the inventory summary window, which defaults to 30 days.
+
+## Implementation Checklist
+
+- [x] Replace the current boolean unused filter flow with a three-state usage filter in the UI.
+- [x] Update the Metrics Catalog header to expose `All Metrics`, `Used Only`, and `Unused Only`.
+- [x] Extend the API client to send a usage filter parameter for series metadata.
+- [x] Update the `/api/v1/seriesMetadata` route to parse the usage filter.
+- [x] Extend the shared DB params model to carry the usage filter.
+- [x] Add `used` and `unused` filtering logic to the SQLite series metadata query.
+- [x] Add `used` and `unused` filtering logic to the PostgreSQL series metadata query.
+- [x] Add route coverage for the new filter.
+- [x] Add SQLite coverage for `all`, `used`, and `unused` behavior.
+- [x] Add PostgreSQL coverage for `all`, `used`, and `unused` behavior.
+- [x] Run targeted UI and Go tests.
+
+## Verification
+
+- `go test ./api/routes ./internal/db` reaches existing PostgreSQL tests that require Docker and fails in this environment because rootless Docker is unavailable.
+- `go test ./internal/db -run 'TestSeriesMetadataParams_Struct|TestSQLite_GetSeriesMetadata_UsageFilters'` passed.
+- `npm run lint` passed with pre-existing warnings only.
+- `npm ci --legacy-peer-deps && npm run build` passed.
+
+## Notes
+
+- Keep `All Metrics` as the default selection.
+- Metrics with no summary row should still behave as unused.
+- Prefer a single usage parameter such as `usage=all|used|unused` over adding more booleans.

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -390,6 +390,7 @@ func TestSeriesMetadataParams_Struct(t *testing.T) {
 		SortOrder: "asc",
 		Filter:    "type=counter",
 		Type:      "counter",
+		Usage:     SeriesMetadataUsageUsed,
 	}
 
 	assert.Equal(t, 1, params.Page)
@@ -398,4 +399,5 @@ func TestSeriesMetadataParams_Struct(t *testing.T) {
 	assert.Equal(t, "asc", params.SortOrder)
 	assert.Equal(t, "type=counter", params.Filter)
 	assert.Equal(t, "counter", params.Type)
+	assert.Equal(t, SeriesMetadataUsageUsed, params.Usage)
 }

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -706,6 +706,7 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 	if params.SortOrder == "" {
 		params.SortOrder = "asc"
 	}
+	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
 	// Count
 	countSQL := `
@@ -715,18 +716,29 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
         WHERE ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
           AND ($2 = 'all' OR
                CASE
-                 WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = $2
-               END)
-          AND (CASE WHEN $3 THEN COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0 ELSE TRUE END)
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+          AND (
+                $3 = 'all'
+                OR ($3 = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+                OR ($3 = 'unused' AND
+                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
+                )
+          )
           AND ($4 = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
                 WHERE j.name = c.name AND j.job = $4
           ))
     `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Unused, params.Job).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Usage, params.Job).Scan(&total); err != nil {
 		return nil, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
@@ -741,11 +753,22 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
         WHERE ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
           AND ($2 = 'all' OR
                CASE
-                 WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = $2
-               END)
-          AND (CASE WHEN $3 THEN COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0 ELSE TRUE END)
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+          AND (
+                $3 = 'all'
+                OR ($3 = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+                OR ($3 = 'unused' AND
+                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
+                )
+          )
           AND ($4 = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
                 WHERE j.name = c.name AND j.job = $4
@@ -754,7 +777,7 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 	// Build complete query with safe ORDER BY clause to prevent SQL injection
 	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $5 OFFSET $6", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "name")
 
-	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Unused, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
+	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Usage, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("select: %w", err)
 	}

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -597,6 +597,59 @@ func TestPostgreSQL_MetricsInventoryAndList(t *testing.T) {
 	assert.Greater(t, res.Total, 0, "expected at least one metric in catalog")
 }
 
+func TestPostgreSQL_GetSeriesMetadata_UsageFilters(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "used_metric", Type: "gauge", Help: "used metric"},
+		{Name: "unused_metric", Type: "gauge", Help: "unused metric"},
+	})
+	mustInsertQueries(t, p, []Query{{
+		TS:            now.Add(-5 * time.Minute),
+		QueryParam:    "used_metric",
+		TimeParam:     now,
+		Duration:      10 * time.Millisecond,
+		StatusCode:    200,
+		LabelMatchers: LabelMatchers{{"__name__": "used_metric"}},
+		Type:          QueryTypeInstant,
+	}})
+
+	assert.NoError(t, p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-1 * time.Hour), To: now}))
+	mustUpsertCatalog(t, p, []MetricCatalogItem{{Name: "no_summary_metric", Type: "gauge", Help: "no summary metric"}})
+
+	tests := []struct {
+		name      string
+		usage     string
+		wantNames []string
+	}{
+		{name: "all metrics", usage: SeriesMetadataUsageAll, wantNames: []string{"no_summary_metric", "unused_metric", "used_metric"}},
+		{name: "used metrics", usage: SeriesMetadataUsageUsed, wantNames: []string{"used_metric"}},
+		{name: "unused metrics", usage: SeriesMetadataUsageUnused, wantNames: []string{"no_summary_metric", "unused_metric"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := p.GetSeriesMetadata(context.Background(), SeriesMetadataParams{
+				Page: 1, PageSize: 10, SortBy: "name", SortOrder: "asc", Type: "all", Usage: tt.usage,
+			})
+			assert.NoError(t, err, "GetSeriesMetadata")
+
+			data, ok := res.Data.([]models.MetricMetadata)
+			if !assert.True(t, ok, "Expected Data to be []models.MetricMetadata") {
+				return
+			}
+
+			names := make([]string, 0, len(data))
+			for _, metric := range data {
+				names = append(names, metric.Name)
+			}
+			assert.ElementsMatch(t, tt.wantNames, names)
+		})
+	}
+}
+
 func TestPostgreSQL_DashboardUsage(t *testing.T) {
 	p, cleanup := newTestPostgreSQLProvider(t)
 	defer cleanup()

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -72,6 +72,18 @@ var ValidSeriesMetadataSortFields = map[string]bool{
 	"unit": true,
 }
 
+const (
+	SeriesMetadataUsageAll    = "all"
+	SeriesMetadataUsageUsed   = "used"
+	SeriesMetadataUsageUnused = "unused"
+)
+
+var ValidSeriesMetadataUsageFilters = map[string]bool{
+	SeriesMetadataUsageAll:    true,
+	SeriesMetadataUsageUsed:   true,
+	SeriesMetadataUsageUnused: true,
+}
+
 // ValidSortDirections centralizes valid sort directions
 var ValidSortDirections = map[string]bool{
 	"asc":  true,
@@ -278,8 +290,16 @@ type SeriesMetadataParams struct {
 	SortOrder string
 	Filter    string
 	Type      string
-	Unused    bool
+	Usage     string
 	Job       string
+}
+
+func NormalizeSeriesMetadataUsage(usage string) string {
+	normalized := strings.ToLower(strings.TrimSpace(usage))
+	if ValidSeriesMetadataUsageFilters[normalized] {
+		return normalized
+	}
+	return SeriesMetadataUsageAll
 }
 
 type MetricCatalogItem struct {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -18,13 +18,6 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-func boolToInt(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
-}
-
 type SQLiteProvider struct {
 	mu sync.RWMutex
 	db *sql.DB
@@ -719,6 +712,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 	if params.SortOrder == "" {
 		params.SortOrder = "asc"
 	}
+	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
 	// Count
 	countQuery := `
@@ -731,15 +725,26 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                  WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
                  WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
                  ELSE c.type = ?
-               END)
-          AND (CASE WHEN ? = 1 THEN COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0 ELSE 1 END)
+                END)
+          AND (
+                ? = 'all'
+                OR (? = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+                OR (? = 'unused' AND
+                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
+                )
+          )
           AND (? = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
                 WHERE j.name = c.name AND j.job = ?
           ))
     `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter, params.Filter, params.Filter, params.Type, params.Type, params.Type, params.Type, boolToInt(params.Unused), params.Job, params.Job).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter, params.Filter, params.Filter, params.Type, params.Type, params.Type, params.Type, params.Usage, params.Usage, params.Usage, params.Job, params.Job).Scan(&total); err != nil {
 		return nil, fmt.Errorf("failed to count catalog: %w", err)
 	}
 
@@ -759,8 +764,19 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                  WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
                  WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
                  ELSE c.type = ?
-               END)
-          AND (CASE WHEN ? = 1 THEN COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0 ELSE 1 END)
+                END)
+          AND (
+                ? = 'all'
+                OR (? = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+                OR (? = 'unused' AND
+                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
+                )
+          )
           AND (? = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
                 WHERE j.name = c.name AND j.job = ?
@@ -772,7 +788,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
-		boolToInt(params.Unused),
+		params.Usage, params.Usage, params.Usage,
 		params.Job, params.Job,
 		params.PageSize, (params.Page-1)*params.PageSize,
 	)

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -692,6 +692,59 @@ func TestSQLite_MetricsInventoryAndList(t *testing.T) {
 	assert.Greater(t, res.Total, 0, "expected at least one metric in catalog")
 }
 
+func TestSQLite_GetSeriesMetadata_UsageFilters(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "used_metric", Type: "gauge", Help: "used metric"},
+		{Name: "unused_metric", Type: "gauge", Help: "unused metric"},
+	})
+	mustInsertQueries(t, p, []Query{{
+		TS:            now.Add(-5 * time.Minute),
+		QueryParam:    "used_metric",
+		TimeParam:     now,
+		Duration:      10 * time.Millisecond,
+		StatusCode:    200,
+		LabelMatchers: LabelMatchers{{"__name__": "used_metric"}},
+		Type:          QueryTypeInstant,
+	}})
+
+	assert.NoError(t, p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-1 * time.Hour), To: now}))
+	mustUpsertCatalog(t, p, []MetricCatalogItem{{Name: "no_summary_metric", Type: "gauge", Help: "no summary metric"}})
+
+	tests := []struct {
+		name      string
+		usage     string
+		wantNames []string
+	}{
+		{name: "all metrics", usage: SeriesMetadataUsageAll, wantNames: []string{"no_summary_metric", "unused_metric", "used_metric"}},
+		{name: "used metrics", usage: SeriesMetadataUsageUsed, wantNames: []string{"used_metric"}},
+		{name: "unused metrics", usage: SeriesMetadataUsageUnused, wantNames: []string{"no_summary_metric", "unused_metric"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := p.GetSeriesMetadata(context.Background(), SeriesMetadataParams{
+				Page: 1, PageSize: 10, SortBy: "name", SortOrder: "asc", Type: "all", Usage: tt.usage,
+			})
+			assert.NoError(t, err, "GetSeriesMetadata")
+
+			data, ok := res.Data.([]models.MetricMetadata)
+			if !assert.True(t, ok, "Expected Data to be []models.MetricMetadata") {
+				return
+			}
+
+			names := make([]string, 0, len(data))
+			for _, metric := range data {
+				names = append(names, metric.Name)
+			}
+			assert.ElementsMatch(t, tt.wantNames, names)
+		})
+	}
+}
+
 // TestSQLite_DashboardUsage verifies dashboard usage time range filtering
 func TestSQLite_DashboardUsage(t *testing.T) {
 	p, cleanup := newTestSQLiteProvider(t)

--- a/ui/src/api/metrics.ts
+++ b/ui/src/api/metrics.ts
@@ -54,7 +54,7 @@ interface FetchOptions {
   from?: string;
   to?: string;
   kind?: string;
-  unused?: boolean;
+  usage?: "all" | "used" | "unused";
   job?: string;
 }
 
@@ -140,7 +140,9 @@ async function fetchApiData<T>(
     ...(from && { from: toUTC(from) }),
     ...(to && { to: toUTC(to) }),
     ...(kind && { kind }),
-    ...(options.unused ? { unused: "true" } : {}),
+    ...(options.usage && options.usage !== "all"
+      ? { usage: options.usage }
+      : {}),
     ...(job ? { job } : {}),
   });
 
@@ -173,14 +175,14 @@ export async function getSeriesMetadata(
   sortOrder: string = "asc",
   filter: string = "",
   type: string = "",
-  unused: boolean = false,
+  usage: "all" | "used" | "unused" = "all",
   job?: string,
 ): Promise<PagedResult<MetricMetadata>> {
   return withErrorHandling(
     () =>
       fetchApiData<PagedResult<MetricMetadata>>(
         API_CONFIG.endpoints.seriesMetadata,
-        { page, pageSize, sortBy, sortOrder, filter, type, unused, job },
+        { page, pageSize, sortBy, sortOrder, filter, type, usage, job },
       ),
     DEFAULT_ERROR_VALUES.seriesMetadata,
   );

--- a/ui/src/app/metrics/index.tsx
+++ b/ui/src/app/metrics/index.tsx
@@ -9,7 +9,9 @@ import { useDebounce } from "@/hooks/use-debounce";
 export default function MetricsExplorer() {
   const [searchQuery, setSearchQuery] = useState("");
   const [typeFilter, setTypeFilter] = useState("all");
-  const [usageFilter, setUsageFilter] = useState<"all" | "unused">("all");
+  const [usageFilter, setUsageFilter] = useState<"all" | "used" | "unused">(
+    "all",
+  );
   const [jobFilter, setJobFilter] = useState<string>("");
   const [tableState, setTableState] = useState<TableState>({
     page: 1,
@@ -26,7 +28,7 @@ export default function MetricsExplorer() {
   const { data, isLoading, error } = useSeriesMetadataTable(
     tableState,
     debouncedSearchQuery,
-    usageFilter === "unused",
+    usageFilter,
     jobFilter,
   );
 

--- a/ui/src/app/metrics/use-metrics-data.ts
+++ b/ui/src/app/metrics/use-metrics-data.ts
@@ -42,7 +42,7 @@ interface MetricUsageResponse {
 export function useSeriesMetadataTable(
   tableState?: TableState,
   searchQuery?: string,
-  unused?: boolean,
+  usage?: "all" | "used" | "unused",
   job?: string,
 ) {
   const {
@@ -50,7 +50,7 @@ export function useSeriesMetadataTable(
     isLoading,
     error,
   } = useQuery<PagedResult<MetricMetadata>>({
-    queryKey: ["metrics", tableState, searchQuery, unused, job],
+    queryKey: ["metrics", tableState, searchQuery, usage, job],
     queryFn: () =>
       getSeriesMetadata(
         tableState?.page || 1,
@@ -59,7 +59,7 @@ export function useSeriesMetadataTable(
         tableState?.sortOrder || "asc",
         searchQuery || "",
         tableState?.type || "all",
-        unused || false,
+        usage || "all",
         job,
       ),
   });

--- a/ui/src/components/metrics-explorer/metrics-explorer-header.tsx
+++ b/ui/src/components/metrics-explorer/metrics-explorer-header.tsx
@@ -13,8 +13,8 @@ interface MetricsExplorerHeaderProps {
   onSearchChange: (value: string) => void;
   typeFilter: string;
   onTypeFilterChange: (value: string) => void;
-  usageFilter?: "all" | "unused";
-  onUsageFilterChange?: (value: "all" | "unused") => void;
+  usageFilter?: "all" | "used" | "unused";
+  onUsageFilterChange?: (value: "all" | "used" | "unused") => void;
   jobs?: string[];
   jobFilter?: string;
   onJobFilterChange?: (value: string) => void;
@@ -88,9 +88,11 @@ export function MetricsExplorerHeader({
         </Select>
         <Select
           value={usageFilter}
-          onValueChange={(v) => onUsageFilterChange?.(v as "all" | "unused")}
+          onValueChange={(v) =>
+            onUsageFilterChange?.(v as "all" | "used" | "unused")
+          }
         >
-          <SelectTrigger className="sm:max-w-[160px]">
+          <SelectTrigger className="sm:max-w-[170px]">
             <div className="flex items-center gap-2">
               <Filter className="h-4 w-4" />
               <SelectValue placeholder="All Metrics" />
@@ -98,6 +100,7 @@ export function MetricsExplorerHeader({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">All Metrics</SelectItem>
+            <SelectItem value="used">Used Only</SelectItem>
             <SelectItem value="unused">Unused Only</SelectItem>
           </SelectContent>
         </Select>


### PR DESCRIPTION
This pull request introduces a new three-state usage filter (`all`, `used`, `unused`) for metrics in the catalog, replacing the previous boolean unused filter. This allows users and API clients to easily switch between viewing all metrics, only those that are used, or only those that are unused. The filter is consistently applied across the API, database layer (both SQLite and PostgreSQL), and is thoroughly tested. Documentation and planning files have also been updated to reflect this enhancement.

**API and UI improvements:**

* Replaced the boolean `unused` filter with a string `usage` filter in the API (`README.md`) and updated example queries to use `usage=used` or `usage=unused`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L557-R557) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L566-R570)
* Added a detailed implementation plan and checklist for the new filter in `docs/plans/issue-427-used-metrics-filter.md`.

**Backend changes (Routes & DB):**

* Updated the `/api/v1/seriesMetadata` route to parse and validate the new `usage` parameter, defaulting to `all` if not provided or invalid. [[1]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR674) [[2]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL717-R726)
* Extended the `SeriesMetadataParams` struct to use a `Usage` string instead of an `Unused` boolean, and added normalization and validation helpers for usage values.
* Updated both SQLite and PostgreSQL providers to apply the new usage filter logic in their SQL queries, ensuring consistent filtering of used/unused metrics. [[1]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dR709) [[2]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL722-R741) [[3]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL748-R771) [[4]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL757-R780) [[5]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caR722) [[6]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL735-R754) [[7]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL763-R786) [[8]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL775-R798)

**Testing and verification:**

* Added new route and database tests to verify correct behavior for all three usage states (`all`, `used`, `unused`) in both SQLite and PostgreSQL backends. [[1]](diffhunk://#diff-6c5e270953c61ceed22901222d56cea721d9c3ee2b517d515737e3586882dcafR49-R124) [[2]](diffhunk://#diff-aa505ee5ecf26172ca4b4a7a705fa2de7b27a9ff5a5b712f02180a06445664daR600-R652) [[3]](diffhunk://#diff-0c539bed9321b4fa5a1f9b10bf40b7c3ecffc57b225d08551691344ea515281bR393) [[4]](diffhunk://#diff-0c539bed9321b4fa5a1f9b10bf40b7c3ecffc57b225d08551691344ea515281bR402)

**Constants and validation:**

* Introduced constants and validation maps for usage filter values to ensure only valid states are accepted throughout the codebase.

These changes make the metrics catalog more flexible and user-friendly, allowing for more granular filtering and analysis of metric usage.

Resolved #427 