### PR TITLE
[UI] making sample format consistent

### DIFF
--- a/ui/src/app/queries/index.tsx
+++ b/ui/src/app/queries/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/sheet";
 import { QueryDetails } from "@/components/query-details";
 import { useSearchNumberState, useSearchState } from "@/hooks/use-search-state";
+import { formatUnit } from "@/lib/utils";
 
 // Extend ColumnDef to support maxWidth so DataTable can apply ellipsis + tooltip
 type ExtendedColumnDef<TData, TValue = unknown> = ColumnDef<TData, TValue> & {
@@ -69,7 +70,7 @@ const columns: ExtendedColumnDef<QueryExpression>[] = [
     ),
     cell: ({ row }) => {
       const value = Number(row.getValue("peakSamples"));
-      return <div className="text-right">{value.toLocaleString()}</div>;
+      return <div className="text-right">{formatUnit(value)}</div>;
     },
   },
 ];

--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -121,6 +121,9 @@ export function DataTable<TData>({
     }
   }, [data, serverSide]);
 
+  // TanStack Table returns non-memoizable helpers; this component is already
+  // opted out of React Compiler memoization with "use no memo".
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data,
     columns,

--- a/ui/src/components/metrics-explorer/metric-usage.tsx
+++ b/ui/src/components/metrics-explorer/metric-usage.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { DataTable, DataTableColumnHeader } from "@/components/data-table";
 import { ColumnDef, SortingState } from "@tanstack/react-table";
 import { DateRange } from "@/lib/types";
+import { formatUnit } from "@/lib/utils";
 
 // Define our extended column type with maxWidth
 type ExtendedColumnDef<TData, TValue = unknown> = ColumnDef<TData, TValue> & {
@@ -127,7 +128,7 @@ const getQueriesColumns = (): ExtendedColumnDef<
     ),
     cell: ({ row }) => {
       const value = row.getValue("maxPeakSamples") as number;
-      return <span>{value?.toLocaleString() ?? "N/A"}</span>;
+      return <span>{value != null ? formatUnit(value) : "N/A"}</span>;
     },
   },
   {
@@ -137,7 +138,7 @@ const getQueriesColumns = (): ExtendedColumnDef<
     ),
     cell: ({ row }) => {
       const value = row.getValue("avgPeakySamples") as number;
-      return <span>{value?.toFixed(2) ?? "N/A"}</span>;
+      return <span>{value != null ? formatUnit(value) : "N/A"}</span>;
     },
   },
 ];

--- a/ui/src/components/query-details/table.tsx
+++ b/ui/src/components/query-details/table.tsx
@@ -7,6 +7,7 @@ import { getQueryExecutions } from "@/api/queries";
 import type { PagedResult, QueryExecution } from "@/lib/types";
 import { formatUTCtoLocal } from "@/lib/utils/date-utils";
 import { Badge } from "@/components/ui/badge";
+import { formatUnit } from "@/lib/utils";
 import {
   Tooltip,
   TooltipContent,
@@ -233,11 +234,7 @@ const columns: ExtendedColumnDef<QueryExecution>[] = [
     ),
     cell: ({ row }) => {
       const v = Number(row.getValue("samples"));
-      return (
-        <div className="text-right">
-          {Number.isFinite(v) ? v.toLocaleString() : "-"}
-        </div>
-      );
+      return <div className="text-right">{Number.isFinite(v) ? formatUnit(v) : "-"}</div>;
     },
   },
   {

--- a/ui/src/components/query-details/table.tsx
+++ b/ui/src/components/query-details/table.tsx
@@ -234,7 +234,11 @@ const columns: ExtendedColumnDef<QueryExecution>[] = [
     ),
     cell: ({ row }) => {
       const v = Number(row.getValue("samples"));
-      return <div className="text-right">{Number.isFinite(v) ? formatUnit(v) : "-"}</div>;
+      return (
+        <div className="text-right">
+          {Number.isFinite(v) ? formatUnit(v) : "-"}
+        </div>
+      );
     },
   },
   {


### PR DESCRIPTION
This pull request updates how numerical values representing sample counts are displayed across several components by introducing the `formatUnit` utility function. Instead of using `toLocaleString()` or `toFixed()`, the new approach standardizes formatting for better readability and consistency in the UI.

**Formatting improvements:**

* Replaced `toLocaleString()` and `toFixed()` with the `formatUnit` utility function for displaying sample counts in the following components:
  - [`ui/src/app/queries/index.tsx`](diffhunk://#diff-af4ca91d2260971b2c438c3293137de803de8ba4b5e81233b46ee440e7d131ddR20): Used `formatUnit` in the `peakSamples` column. [[1]](diffhunk://#diff-af4ca91d2260971b2c438c3293137de803de8ba4b5e81233b46ee440e7d131ddR20) [[2]](diffhunk://#diff-af4ca91d2260971b2c438c3293137de803de8ba4b5e81233b46ee440e7d131ddL72-R73)
  - [`ui/src/components/metrics-explorer/metric-usage.tsx`](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eR12): Applied `formatUnit` in the `maxPeakSamples` and `avgPeakySamples` columns. [[1]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eR12) [[2]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eL130-R131) [[3]](diffhunk://#diff-3151ab394838f893c3760948fc570fbcd036f223dc1b0e1101fff0576162d03eL140-R141)
  - [`ui/src/components/query-details/table.tsx`](diffhunk://#diff-9f3e78e936d9da13c13b3ae1c8279f446ad31186d385916aebfc2d2f5ad5c775R10): Updated the `samples` column to use `formatUnit` for consistent formatting. [[1]](diffhunk://#diff-9f3e78e936d9da13c13b3ae1c8279f446ad31186d385916aebfc2d2f5ad5c775R10) [[2]](diffhunk://#diff-9f3e78e936d9da13c13b3ae1c8279f446ad31186d385916aebfc2d2f5ad5c775L236-R237)