### PR TITLE
[REFACTORY] split UI helper exports from component modules

### DIFF
--- a/ui/src/app/metrics/details/index.tsx
+++ b/ui/src/app/metrics/details/index.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from "wouter";
 import { MetricDetailHeader } from "@/components/metrics-explorer/metric-detail-header";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { MetricStats } from "@/components/metrics-explorer/metric-stats";
 import { MetricPerformance } from "@/components/metrics-explorer/metric-performance";

--- a/ui/src/app/queries/index.tsx
+++ b/ui/src/app/queries/index.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Input } from "@/components/ui/input";
 import { DataTable, DataTableColumnHeader } from "@/components/data-table";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { useDebounce } from "@/hooks/use-debounce";
 import { getQueryExpressions } from "@/api/queries";
 import { LoadingState } from "./loading";

--- a/ui/src/components/app-sidebar.tsx
+++ b/ui/src/components/app-sidebar.tsx
@@ -13,8 +13,8 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
-  useSidebar,
 } from "@/components/ui/sidebar";
+import { useSidebar } from "@/components/ui/sidebar-context";
 import { routeConfigs } from "@/lib/routes";
 import { PreservedLink } from "@/components/preserved-link.tsx";
 

--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -1,5 +1,3 @@
-"use no memo";
-
 import { useState, useEffect } from "react";
 import {
   flexRender,
@@ -48,6 +46,8 @@ export function DataTable<TData>({
   onFilterChange,
   onPaginationChange,
 }: DataTableProps<TData>) {
+  "use no memo";
+
   // Local state for client-side operations
   const [sorting, setSorting] = useState<SortingState>(
     externalSortingState || [],

--- a/ui/src/components/filter-panel.tsx
+++ b/ui/src/components/filter-panel.tsx
@@ -16,7 +16,7 @@ import {
   startOfDay,
   differenceInMilliseconds,
 } from "date-fns";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 
 // Types
 interface TimeRange {

--- a/ui/src/components/key-metrics.tsx
+++ b/ui/src/components/key-metrics.tsx
@@ -13,7 +13,7 @@ import { PieChart, Pie, ResponsiveContainer, Cell, Tooltip } from "recharts";
 const COLORS = ["hsl(var(--primary))", "hsl(var(--primary) / 0.3)"];
 
 import { useQuery } from "@tanstack/react-query";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { getQueryTypes, getAverageDuration, getQueryRate } from "@/api/queries";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/ui/src/components/metrics-explorer/metric-performance.tsx
+++ b/ui/src/components/metrics-explorer/metric-performance.tsx
@@ -17,7 +17,7 @@ import {
   useMetricQueryPerformanceStatistics,
   useQueryLatencyTrends,
 } from "@/app/metrics/use-metrics-data";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface MetricPerformanceProps {

--- a/ui/src/components/metrics-explorer/metric-producer.tsx
+++ b/ui/src/components/metrics-explorer/metric-producer.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/card";
 
 import { useMetricStatistics } from "@/app/metrics/use-metrics-data";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface MetricProducersProps {

--- a/ui/src/components/metrics-explorer/metric-stats.tsx
+++ b/ui/src/components/metrics-explorer/metric-stats.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Bell, BarChart3, Database, GitMerge } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useMetricStatistics } from "@/app/metrics/use-metrics-data";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { formatUnit } from "@/lib/utils";
 
 interface MetricStatsProps {

--- a/ui/src/components/nav-user.tsx
+++ b/ui/src/components/nav-user.tsx
@@ -23,8 +23,8 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  useSidebar,
 } from "@/components/ui/sidebar";
+import { useSidebar } from "@/components/ui/sidebar-context";
 
 export function NavUser({
   user,

--- a/ui/src/components/query-details/table.tsx
+++ b/ui/src/components/query-details/table.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { DataTable, DataTableColumnHeader } from "@/components/data-table";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { getQueryExecutions } from "@/api/queries";
 import type { PagedResult, QueryExecution } from "@/lib/types";
 import { formatUTCtoLocal } from "@/lib/utils/date-utils";

--- a/ui/src/components/query-error-analysis.tsx
+++ b/ui/src/components/query-error-analysis.tsx
@@ -13,7 +13,7 @@ import {
 } from "recharts";
 
 import { useQuery } from "@tanstack/react-query";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { getQueryErrorAnalysis } from "@/api/queries";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/ui/src/components/query-latency-trends.tsx
+++ b/ui/src/components/query-latency-trends.tsx
@@ -13,7 +13,7 @@ import {
 } from "recharts";
 
 import { useQuery } from "@tanstack/react-query";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { getQueryLatencyTrends } from "@/api/queries";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/ui/src/components/query-performance-analysis.tsx
+++ b/ui/src/components/query-performance-analysis.tsx
@@ -13,7 +13,7 @@ import { QueryThroughputAnalysisResult } from "@/lib/types";
 import { formatTimestampByGranularity } from "@/lib/utils/date-formatting";
 
 import { useQuery } from "@tanstack/react-query";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { getQueryThroughputAnalysis } from "@/api/queries";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/ui/src/components/query-time-range-distribution.tsx
+++ b/ui/src/components/query-time-range-distribution.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Clock } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { getQueryTimeRangeDistribution } from "@/api/queries";
 import { QueryTimeRangeDistributionResult } from "@/lib/types";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/ui/src/components/status-breakdown.tsx
+++ b/ui/src/components/status-breakdown.tsx
@@ -14,7 +14,7 @@ import { QueryStatusDistributionResult } from "@/lib/types";
 import { formatTimestampByGranularity } from "@/lib/utils/date-formatting";
 
 import { useQuery } from "@tanstack/react-query";
-import { useDateRange } from "@/contexts/date-range-context";
+import { useDateRange } from "@/contexts/date-range";
 import { getQueryStatusDistribution } from "@/api/queries";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/ui/src/components/team-switcher.tsx
+++ b/ui/src/components/team-switcher.tsx
@@ -14,8 +14,8 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  useSidebar,
 } from "@/components/ui/sidebar";
+import { useSidebar } from "@/components/ui/sidebar-context";
 
 export function TeamSwitcher({
   teams,

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -43,4 +43,4 @@ function Badge({
   );
 }
 
-export { Badge, badgeVariants };
+export { Badge };

--- a/ui/src/components/ui/button-variants.ts
+++ b/ui/src/components/ui/button-variants.ts
@@ -1,0 +1,32 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -1,39 +1,9 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import { type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  },
-);
+import { buttonVariants } from "@/components/ui/button-variants";
 
 function Button({
   className,
@@ -56,4 +26,4 @@ function Button({
   );
 }
 
-export { Button, buttonVariants };
+export { Button };

--- a/ui/src/components/ui/calendar.tsx
+++ b/ui/src/components/ui/calendar.tsx
@@ -7,7 +7,8 @@ import {
 import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker";
 
 import { cn } from "@/lib/utils";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button-variants";
 
 function Calendar({
   className,

--- a/ui/src/components/ui/sidebar-context.ts
+++ b/ui/src/components/ui/sidebar-context.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+
+export type SidebarContextProps = {
+  state: "expanded" | "collapsed";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+export const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+export function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+
+  return context;
+}

--- a/ui/src/components/ui/sidebar-context.ts
+++ b/ui/src/components/ui/sidebar-context.ts
@@ -12,7 +12,9 @@ export type SidebarContextProps = {
   toggleSidebar: () => void;
 };
 
-export const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+export const SidebarContext = React.createContext<SidebarContextProps | null>(
+  null,
+);
 
 export function useSidebar() {
   const context = React.useContext(SidebarContext);

--- a/ui/src/components/ui/sidebar.tsx
+++ b/ui/src/components/ui/sidebar.tsx
@@ -24,6 +24,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  SidebarContext,
+  type SidebarContextProps,
+  useSidebar,
+} from "@/components/ui/sidebar-context";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -31,27 +36,6 @@ const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
-
-type SidebarContextProps = {
-  state: "expanded" | "collapsed";
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
-  isMobile: boolean;
-  toggleSidebar: () => void;
-};
-
-const SidebarContext = React.createContext<SidebarContextProps | null>(null);
-
-function useSidebar() {
-  const context = React.useContext(SidebarContext);
-  if (!context) {
-    throw new Error("useSidebar must be used within a SidebarProvider.");
-  }
-
-  return context;
-}
 
 function SidebarProvider({
   defaultOpen = true,
@@ -728,5 +712,4 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 };

--- a/ui/src/contexts/date-range-context.tsx
+++ b/ui/src/contexts/date-range-context.tsx
@@ -1,8 +1,4 @@
-import {
-  ReactNode,
-  useMemo,
-  useCallback,
-} from "react";
+import { ReactNode, useMemo, useCallback } from "react";
 import { useSearchParams } from "wouter";
 import type { DateRange } from "react-day-picker";
 import { DateRangeContext } from "@/contexts/date-range";

--- a/ui/src/contexts/date-range-context.tsx
+++ b/ui/src/contexts/date-range-context.tsx
@@ -1,22 +1,12 @@
 import {
-  createContext,
-  useContext,
   ReactNode,
   useMemo,
   useCallback,
 } from "react";
 import { useSearchParams } from "wouter";
 import type { DateRange } from "react-day-picker";
+import { DateRangeContext } from "@/contexts/date-range";
 import { fromUTC, formatLocalToUTC } from "@/lib/utils/date-utils";
-
-interface DateRangeContextType {
-  dateRange: DateRange;
-  setDateRange: (range: DateRange) => void;
-}
-
-const DateRangeContext = createContext<DateRangeContextType | undefined>(
-  undefined,
-);
 
 export function DateRangeProvider({ children }: { children: ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -68,12 +58,4 @@ export function DateRangeProvider({ children }: { children: ReactNode }) {
       {children}
     </DateRangeContext.Provider>
   );
-}
-
-export function useDateRange() {
-  const context = useContext(DateRangeContext);
-  if (context === undefined) {
-    throw new Error("useDateRange must be used within a DateRangeProvider");
-  }
-  return context;
 }

--- a/ui/src/contexts/date-range.ts
+++ b/ui/src/contexts/date-range.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+import type { DateRange } from "react-day-picker";
+
+export interface DateRangeContextType {
+  dateRange: DateRange;
+  setDateRange: (range: DateRange) => void;
+}
+
+export const DateRangeContext = createContext<DateRangeContextType | undefined>(
+  undefined,
+);
+
+export function useDateRange() {
+  const context = useContext(DateRangeContext);
+  if (context === undefined) {
+    throw new Error("useDateRange must be used within a DateRangeProvider");
+  }
+  return context;
+}

--- a/ui/src/contexts/table-context.tsx
+++ b/ui/src/contexts/table-context.tsx
@@ -1,12 +1,6 @@
-import { createContext, useContext, useState, ReactNode } from "react";
-import { TableState } from "@/lib/types";
-
-interface TableContextType {
-  tableState: TableState;
-  setTableState: (state: TableState) => void;
-}
-
-const TableContext = createContext<TableContextType | undefined>(undefined);
+import { useState, ReactNode } from "react";
+import type { TableState } from "@/lib/types";
+import { TableContext } from "@/contexts/table";
 
 export function TableProvider({ children }: { children: ReactNode }) {
   const [tableState, setTableState] = useState<TableState>({
@@ -23,12 +17,4 @@ export function TableProvider({ children }: { children: ReactNode }) {
       {children}
     </TableContext.Provider>
   );
-}
-
-export function useTable() {
-  const context = useContext(TableContext);
-  if (context === undefined) {
-    throw new Error("useTable must be used within a TableProvider");
-  }
-  return context;
 }

--- a/ui/src/contexts/table.ts
+++ b/ui/src/contexts/table.ts
@@ -6,7 +6,9 @@ interface TableContextType {
   setTableState: (state: TableState) => void;
 }
 
-export const TableContext = createContext<TableContextType | undefined>(undefined);
+export const TableContext = createContext<TableContextType | undefined>(
+  undefined,
+);
 
 export function useTable() {
   const context = useContext(TableContext);

--- a/ui/src/contexts/table.ts
+++ b/ui/src/contexts/table.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+import type { TableState } from "@/lib/types";
+
+interface TableContextType {
+  tableState: TableState;
+  setTableState: (state: TableState) => void;
+}
+
+export const TableContext = createContext<TableContextType | undefined>(undefined);
+
+export function useTable() {
+  const context = useContext(TableContext);
+  if (context === undefined) {
+    throw new Error("useTable must be used within a TableProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
This pull request primarily focuses on cleaning up and refactoring UI component imports and exports, with a particular emphasis on improving code organization and consistency. The most significant changes include standardizing the import path for the `useDateRange` hook, refactoring sidebar-related imports, and separating button variant logic into its own file for better maintainability.

**Refactoring and import path updates:**

* Standardized the import path for the `useDateRange` hook across the codebase by replacing imports from `@/contexts/date-range-context` to `@/contexts/date-range` in multiple files, ensuring consistency and preventing potential import errors. [[1]](diffhunk://#diff-d6883040c3d923010f838cb30c03b0dc4cad7db76857f0c7565256937205917fL5-R5) [[2]](diffhunk://#diff-af4ca91d2260971b2c438c3293137de803de8ba4b5e81233b46ee440e7d131ddL6-R6) [[3]](diffhunk://#diff-88842d764b0879e4895672f505e33732a872da12f06d7a27be6f7a4ac5732f97L19-R19) [[4]](diffhunk://#diff-6e283c27a076a1b90efb618830e5fa0737faede1c7fa157e1aa299343e21c0c7L16-R16) [[5]](diffhunk://#diff-77bdb1c77f6961c1bbfdea0b8d7a0c65b1740b1c9b3ed614922bf5ef58b455feL20-R20) [[6]](diffhunk://#diff-fccbf9e62c62b3438229fc3f557a289ecded2f2111402e8c0be5495e864a1ca7L18-R18) [[7]](diffhunk://#diff-325bd7b7e40cfca190818ff7355422090348cee00c7cbf824e163bf0494c291cL7-R7) [[8]](diffhunk://#diff-9f3e78e936d9da13c13b3ae1c8279f446ad31186d385916aebfc2d2f5ad5c775L5-R5) [[9]](diffhunk://#diff-11e780c64e8c991f934d6912bd14025873e709fbca4b85baa7bc73cab483e877L16-R16) [[10]](diffhunk://#diff-f1da0e6931f959746615f1675e936010e5bafb70b0d5ae72a63b84101476d0aaL16-R16) [[11]](diffhunk://#diff-7acc01f50175c68e7d778220d4da3666ef9849ca2a34ce6d7561e4d7fc4841d4L16-R16) [[12]](diffhunk://#diff-0dc8b54ce7e9f7c73f159a7705251b4949cccc92f28bbe3da920114d8d32eaa6L6-R6) [[13]](diffhunk://#diff-0ce5fcb5a6de89627710db3080d567bf437c91c9dbf7b39b8ad4a943a3c4ca33L17-R17)

* Refactored sidebar-related imports by moving `useSidebar` imports from `@/components/ui/sidebar` to `@/components/ui/sidebar-context` in several components, improving separation of concerns and code clarity. [[1]](diffhunk://#diff-e0634193d0ba9120dd418c52953cb10ea359c1ad7583bf0887fa06529233238dL16-R17) [[2]](diffhunk://#diff-43e2eb5f2e475d03035ce2b45645e75a84ba04567333acdd153d0381a3163d73L26-R27) [[3]](diffhunk://#diff-6fe64220c27a542b32e2cf0d69533b04568e4184b8baae31a239d72c3f3ca514L17-R18)

**Button component improvements:**

* Extracted the `buttonVariants` logic from `button.tsx` into a new file `button-variants.ts` to enhance modularity and maintainability. The `Button` component now imports `buttonVariants` from this new file. [[1]](diffhunk://#diff-856d279c4ea91b0d562c7ba9a7492f848edfd71ba0f112afb80cf76d9bee8211R1-R32) [[2]](diffhunk://#diff-697f8cdb6a1a26d9ec3cc1a1d11d70406251e7543c3d018203e226199593db58L3-R6)
* Updated the exports in `button.tsx` and `badge.tsx` to only export the main component (`Button` and `Badge` respectively), removing the export of their variants for a cleaner public API. [[1]](diffhunk://#diff-697f8cdb6a1a26d9ec3cc1a1d11d70406251e7543c3d018203e226199593db58L59-R29) [[2]](diffhunk://#diff-13f152138d3e07afab69db55b86d701c19eb2e93fac5bf42b9916e4779013616L46-R46)

**Minor adjustments:**

* Moved the `"use no memo";` directive inside the `DataTable` component and removed it from the top of the file, likely as a code hygiene improvement. [[1]](diffhunk://#diff-4e2191035c34a5e0e0c71ac431f98a15c30278b90835c612446fd9a729b418e9L1-L2) [[2]](diffhunk://#diff-4e2191035c34a5e0e0c71ac431f98a15c30278b90835c612446fd9a729b418e9R49-R50)