### PR TITLE
fix(config): accept sqlite database_path in YAML

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,26 @@ type SQLiteConfig struct {
 	DatabasePath string `yaml:"database_paths,omitempty"`
 }
 
+func (c *SQLiteConfig) UnmarshalYAML(value *yaml.Node) error {
+	type sqliteConfig struct {
+		DatabasePath       string `yaml:"database_path,omitempty"`
+		LegacyDatabasePath string `yaml:"database_paths,omitempty"`
+	}
+
+	var raw sqliteConfig
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+
+	if raw.DatabasePath != "" {
+		c.DatabasePath = raw.DatabasePath
+		return nil
+	}
+
+	c.DatabasePath = raw.LegacyDatabasePath
+	return nil
+}
+
 type InsertConfig struct {
 	BatchSize     int           `yaml:"batch_size,omitempty"`
 	BufferSize    int           `yaml:"buffer_size,omitempty"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,7 +24,7 @@ server:
 database:
   provider: "sqlite"
   sqlite:
-    database_paths: "test.db"
+    database_path: "test.db"
 insert:
   batch_size: 20
   buffer_size: 100
@@ -95,6 +95,40 @@ cors:
 	assert.Equal(t, []string{"Content-Type"}, DefaultConfig.CORS.AllowedHeaders)
 	assert.True(t, DefaultConfig.CORS.AllowCredentials)
 	assert.Equal(t, 300, DefaultConfig.CORS.MaxAge)
+}
+
+func TestLoadConfig_SQLiteLegacyDatabasePathKey(t *testing.T) {
+	originalConfig := DefaultConfig
+
+	configContent := `
+database:
+  provider: "sqlite"
+  sqlite:
+    database_paths: "legacy.db"
+`
+
+	tmpfile, err := os.CreateTemp("", "config-*.yaml")
+	require.NoError(t, err)
+	defer func() {
+		if err := os.Remove(tmpfile.Name()); err != nil {
+			t.Logf("failed to remove temp file: %v", err)
+		}
+	}()
+
+	_, err = tmpfile.Write([]byte(configContent))
+	require.NoError(t, err)
+	if err := tmpfile.Close(); err != nil {
+		t.Logf("failed to close temp file: %v", err)
+	}
+
+	DefaultConfig = &Config{}
+	defer func() {
+		DefaultConfig = originalConfig
+	}()
+
+	err = LoadConfig(tmpfile.Name())
+	require.NoError(t, err)
+	assert.Equal(t, "legacy.db", DefaultConfig.Database.SQLite.DatabasePath)
 }
 
 func TestLoadConfig_InvalidYAML(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix SQLite YAML parsing to accept the documented `database.sqlite.database_path` key
- preserve compatibility with the legacy `database_paths` key so existing configs keep working
- add config tests covering both the documented and legacy SQLite path fields

## Intention
This change fixes a real configuration mismatch affecting SQLite deployments, especially in Kubernetes and other containerized setups where the database file is expected to live on a mounted volume.

The project documentation and examples already instruct users to configure SQLite with `database_path`, but the code only accepted `database_paths`. Because unknown YAML fields were ignored, the configured path was silently dropped and the application fell back to the default relative database location. That made mounted persistent volumes appear not to work even when the configuration looked correct.

The goal of this PR is to make the documented configuration actually work, without breaking anyone who may already be using the legacy key.

## Validation
- added tests for `database_path`
- added tests for legacy `database_paths`
- ran `go test ./internal/config`