### PR TITLE
feat(metrics): enable sorting by usage columns and default to Queries

### DIFF
--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -854,8 +854,8 @@ func (r *routes) seriesMetadata(w http.ResponseWriter, req *http.Request) {
 	params := db.SeriesMetadataParams{
 		Page:      1,
 		PageSize:  10,
-		SortBy:    "name",
-		SortOrder: "asc",
+		SortBy:    "queryCount",
+		SortOrder: "desc",
 		Filter:    "",
 		Type:      "",
 		Usage:     db.SeriesMetadataUsageAll,
@@ -879,8 +879,8 @@ func (r *routes) seriesMetadata(w http.ResponseWriter, req *http.Request) {
 			params.SortBy = sortBy
 		} else {
 			// Invalid sortBy provided - log warning and use safe default
-			slog.Warn("invalid sortBy parameter provided", "sortBy", sortBy, "using_default", "name")
-			params.SortBy = "name" // Safe default
+			slog.Warn("invalid sortBy parameter provided", "sortBy", sortBy, "using_default", "queryCount")
+			params.SortBy = "queryCount" // Safe default
 		}
 	}
 
@@ -891,8 +891,8 @@ func (r *routes) seriesMetadata(w http.ResponseWriter, req *http.Request) {
 			params.SortOrder = normalizedOrder
 		} else {
 			// Invalid sortOrder provided - log warning and use safe default
-			slog.Warn("invalid sortOrder parameter provided", "sortOrder", sortOrder, "using_default", "asc")
-			params.SortOrder = "asc" // Safe default
+			slog.Warn("invalid sortOrder parameter provided", "sortOrder", sortOrder, "using_default", "desc")
+			params.SortOrder = "desc" // Safe default
 		}
 	}
 	if filter := req.FormValue("filter"); filter != "" {

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -694,10 +694,10 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 		params.PageSize = 10
 	}
 	if params.SortBy == "" {
-		params.SortBy = "name"
+		params.SortBy = "queryCount"
 	}
 	if params.SortOrder == "" {
-		params.SortOrder = "asc"
+		params.SortOrder = "desc"
 	}
 	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
@@ -768,7 +768,7 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
           ))
     `
 	// Build complete query with safe ORDER BY clause to prevent SQL injection
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $5 OFFSET $6", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "name")
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $5 OFFSET $6", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
 
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Usage, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -66,10 +66,27 @@ const MaxPageSize = 100
 // ValidSeriesMetadataSortFields centralizes sortable fields for series metadata
 // Note: These should match the actual column names used in the SQL query
 var ValidSeriesMetadataSortFields = map[string]bool{
-	"name": true,
-	"type": true,
-	"help": true,
-	"unit": true,
+	"name":           true,
+	"type":           true,
+	"help":           true,
+	"unit":           true,
+	"alertCount":     true,
+	"recordCount":    true,
+	"dashboardCount": true,
+	"queryCount":     true,
+}
+
+// SeriesMetadataSortAliases maps sort fields to their SQL expression with the correct table alias.
+// Fields from metrics_catalog use alias "c", fields from metrics_usage_summary use alias "s" with COALESCE.
+var SeriesMetadataSortAliases = map[string]string{
+	"name":           "c.name",
+	"type":           "c.type",
+	"help":           "c.help",
+	"unit":           "c.unit",
+	"alertCount":     "COALESCE(s.alert_count, 0)",
+	"recordCount":    "COALESCE(s.record_count, 0)",
+	"dashboardCount": "COALESCE(s.dashboard_count, 0)",
+	"queryCount":     "COALESCE(s.query_count, 0)",
 }
 
 const (
@@ -185,38 +202,45 @@ func ValidatePagination(page *int, pageSize *int, defaultPageSize int) {
 
 // BuildSafeOrderByClause constructs a safe ORDER BY clause using validated parameters
 // tableAlias should be the table alias (e.g., "c") or empty string if not needed
-func BuildSafeOrderByClause(sortBy, sortOrder, tableAlias string, validSortFields map[string]bool, defaultSort string) string {
-	// Validate parameters using existing validation function
+// sortAliases optionally maps field names to their full SQL expression (e.g., "alertCount" -> "COALESCE(s.alert_count, 0)")
+func BuildSafeOrderByClause(sortBy, sortOrder, tableAlias string, validSortFields map[string]bool, defaultSort string, sortAliases ...map[string]string) string {
 	ValidateSortField(&sortBy, &sortOrder, validSortFields, defaultSort)
 
-	// Build the ORDER BY clause safely
-	var orderByClause string
-	if tableAlias != "" {
-		orderByClause = fmt.Sprintf(" ORDER BY %s.%s %s NULLS LAST", tableAlias, sortBy, strings.ToUpper(sortOrder))
-	} else {
-		orderByClause = fmt.Sprintf(" ORDER BY %s %s NULLS LAST", sortBy, strings.ToUpper(sortOrder))
+	var sortExpr string
+	if len(sortAliases) > 0 && sortAliases[0] != nil {
+		if expr, ok := sortAliases[0][sortBy]; ok {
+			sortExpr = expr
+		}
+	}
+	if sortExpr == "" && tableAlias != "" {
+		sortExpr = fmt.Sprintf("%s.%s", tableAlias, sortBy)
+	} else if sortExpr == "" {
+		sortExpr = sortBy
 	}
 
-	return orderByClause
+	return fmt.Sprintf(" ORDER BY %s %s NULLS LAST", sortExpr, strings.ToUpper(sortOrder))
 }
 
 // BuildSafeQueryWithOrderBy constructs a complete query with validated ORDER BY clause
 // This function minimizes string concatenation for better static analysis compatibility
-func BuildSafeQueryWithOrderBy(baseQuery, tableAlias, limitClause string, sortBy, sortOrder string, validSortFields map[string]bool, defaultSort string) string {
-	// Validate parameters first
+// sortAliases optionally maps field names to their full SQL expression for mixed-table sorting
+func BuildSafeQueryWithOrderBy(baseQuery, tableAlias, limitClause string, sortBy, sortOrder string, validSortFields map[string]bool, defaultSort string, sortAliases ...map[string]string) string {
 	ValidateSortField(&sortBy, &sortOrder, validSortFields, defaultSort)
 
-	// Build complete query with validated components
-	var completeQuery string
-	if tableAlias != "" {
-		completeQuery = fmt.Sprintf("%s ORDER BY %s.%s %s NULLS LAST%s",
-			baseQuery, tableAlias, sortBy, strings.ToUpper(sortOrder), limitClause)
-	} else {
-		completeQuery = fmt.Sprintf("%s ORDER BY %s %s NULLS LAST%s",
-			baseQuery, sortBy, strings.ToUpper(sortOrder), limitClause)
+	var sortExpr string
+	if len(sortAliases) > 0 && sortAliases[0] != nil {
+		if expr, ok := sortAliases[0][sortBy]; ok {
+			sortExpr = expr
+		}
+	}
+	if sortExpr == "" && tableAlias != "" {
+		sortExpr = fmt.Sprintf("%s.%s", tableAlias, sortBy)
+	} else if sortExpr == "" {
+		sortExpr = sortBy
 	}
 
-	return completeQuery
+	return fmt.Sprintf("%s ORDER BY %s %s NULLS LAST%s",
+		baseQuery, sortExpr, strings.ToUpper(sortOrder), limitClause)
 }
 
 func CalculateTotalPages(totalCount, pageSize int) int {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -707,10 +707,10 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 		params.PageSize = 10
 	}
 	if params.SortBy == "" {
-		params.SortBy = "name"
+		params.SortBy = "queryCount"
 	}
 	if params.SortOrder == "" {
-		params.SortOrder = "asc"
+		params.SortOrder = "desc"
 	}
 	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
@@ -783,7 +783,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
           ))
     `
 	// Build complete query with safe ORDER BY clause to prevent SQL injection
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "name")
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
 
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Filter, params.Filter, params.Filter,

--- a/ui/src/api/metrics.ts
+++ b/ui/src/api/metrics.ts
@@ -171,8 +171,8 @@ function withErrorHandling<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
 export async function getSeriesMetadata(
   page: number = 1,
   pageSize: number = 10,
-  sortBy: string = "name",
-  sortOrder: string = "asc",
+  sortBy: string = "queryCount",
+  sortOrder: string = "desc",
   filter: string = "",
   type: string = "",
   usage: "all" | "used" | "unused" = "all",

--- a/ui/src/app/metrics/index.tsx
+++ b/ui/src/app/metrics/index.tsx
@@ -16,8 +16,8 @@ export default function MetricsExplorer() {
   const [tableState, setTableState] = useState<TableState>({
     page: 1,
     pageSize: 10,
-    sortBy: "name",
-    sortOrder: "asc",
+    sortBy: "queryCount",
+    sortOrder: "desc",
     filter: "",
     type: "all",
   });

--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -168,16 +168,22 @@ export function DataTable<TData>({
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                ))}
+                {headerGroup.headers.map((header) => {
+                  const colSize = header.column.columnDef.size;
+                  return (
+                    <TableHead
+                      key={header.id}
+                      style={colSize ? { width: colSize } : undefined}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  );
+                })}
               </TableRow>
             ))}
           </TableHeader>
@@ -207,7 +213,15 @@ export function DataTable<TData>({
                     );
 
                     return (
-                      <TableCell key={cell.id}>
+                      <TableCell
+                        key={cell.id}
+                        className="overflow-hidden"
+                        style={
+                          cell.column.columnDef.size
+                            ? { width: cell.column.columnDef.size }
+                            : undefined
+                        }
+                      >
                         {maxWidth ? (
                           <TooltipProvider>
                             <Tooltip>

--- a/ui/src/components/metrics-explorer/metrics-table.tsx
+++ b/ui/src/components/metrics-explorer/metrics-table.tsx
@@ -87,16 +87,17 @@ export function MetricsTable({
   const columns: ColumnDef<MetricMetadata>[] = [
     {
       accessorKey: "name",
+      size: 200,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Metric Name" />
       ),
       cell: ({ row }) => {
         return (
           <div
-            className="font-medium max-w-[300px] truncate cursor-pointer hover:text-blue-500"
+            className="font-medium max-w-[200px] truncate cursor-pointer hover:text-blue-500"
             title={row.getValue("name")}
             onClick={(e) => {
-              e.stopPropagation(); // Prevent row click from triggering twice
+              e.stopPropagation();
               handleMetricClick(row.getValue("name"));
             }}
           >
@@ -107,6 +108,7 @@ export function MetricsTable({
     },
     {
       accessorKey: "type",
+      size: 100,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Type" />
       ),
@@ -114,10 +116,11 @@ export function MetricsTable({
     },
     {
       accessorKey: "help",
+      size: 250,
       header: "Description",
       cell: ({ row }) => (
         <div
-          className="text-sm text-muted-foreground max-w-[500px] truncate"
+          className="text-sm text-muted-foreground truncate"
           title={row.getValue("help")}
         >
           {row.getValue("help")}
@@ -126,26 +129,27 @@ export function MetricsTable({
     },
     {
       accessorKey: "alertCount",
+      size: 80,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Alerts" />
       ),
       cell: ({ row }) => (
         <span className="tabular-nums">{row.getValue("alertCount") ?? 0}</span>
       ),
-      enableSorting: false,
     },
     {
       accessorKey: "recordCount",
+      size: 90,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Records" />
       ),
       cell: ({ row }) => (
         <span className="tabular-nums">{row.getValue("recordCount") ?? 0}</span>
       ),
-      enableSorting: false,
     },
     {
       accessorKey: "dashboardCount",
+      size: 110,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Dashboards" />
       ),
@@ -154,10 +158,10 @@ export function MetricsTable({
           {row.getValue("dashboardCount") ?? 0}
         </span>
       ),
-      enableSorting: false,
     },
     {
       accessorKey: "queryCount",
+      size: 120,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Queries (30d)" />
       ),
@@ -178,7 +182,6 @@ export function MetricsTable({
           </div>
         );
       },
-      enableSorting: false,
     },
   ];
 

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -4,15 +4,15 @@ import { cn } from "@/lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
-      <table
-        data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
-        {...props}
-      />
+      <div
+        data-slot="table-container"
+        className="relative w-full"
+      >
+        <table
+          data-slot="table"
+          className={cn("w-full table-fixed caption-bottom text-sm", className)}
+          {...props}
+        />
     </div>
   );
 }

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -4,15 +4,12 @@ import { cn } from "@/lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
-      <div
-        data-slot="table-container"
-        className="relative w-full"
-      >
-        <table
-          data-slot="table"
-          className={cn("w-full table-fixed caption-bottom text-sm", className)}
-          {...props}
-        />
+    <div data-slot="table-container" className="relative w-full">
+      <table
+        data-slot="table"
+        className={cn("w-full table-fixed caption-bottom text-sm", className)}
+        {...props}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This pull request updates the default metric sorting in the Metrics Explorer to prioritize metrics by recent query activity and improves the metrics table layout and sorting capabilities. It also introduces more robust and flexible SQL query generation for sorting, and enhances the UI to better handle column widths and overflow.

**Backend: Default sorting and robust query generation**

* Changed the default sorting for series metadata from `name` (ascending) to `queryCount` (descending), so the most-used metrics appear first by default. This applies to API routes, database providers, and the frontend API. (`api/routes/routes.go`, `internal/db/postgresql.go`, `internal/db/sqlite.go`, `ui/src/api/metrics.ts`, `ui/src/app/metrics/index.tsx`) [[1]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL857-R858) [[2]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL882-R883) [[3]](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eL894-R895) [[4]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL697-R700) [[5]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL710-R713) [[6]](diffhunk://#diff-2e4c5f078fd93181ec542c201add368751f78e5b32fd984cf3971f659345af4dL174-R175) [[7]](diffhunk://#diff-f338dac67fc32f15b168d3b98df77692999cf325ce1e2b435759a448acad4716L19-R20)
* Added new sortable fields (`alertCount`, `recordCount`, `dashboardCount`, `queryCount`) and introduced `SeriesMetadataSortAliases` to map logical field names to SQL expressions, ensuring safe and correct ordering across joined tables. (`internal/db/provider.go`)
* Refactored query generation functions (`BuildSafeOrderByClause`, `BuildSafeQueryWithOrderBy`) to support these aliases and prevent SQL injection. (`internal/db/provider.go`, `internal/db/postgresql.go`, `internal/db/sqlite.go`) [[1]](diffhunk://#diff-33b9300def2946270535b4c3883579884f69baa34df235daa51d7442fce596f4L188-R243) [[2]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL771-R771) [[3]](diffhunk://#diff-d527f9837484d14c4c773f49d5bc029328c6d3fea052fb62748acfe676f4d4caL786-R786)

**Frontend: Table layout and sorting improvements**

* Updated the metrics table columns to specify explicit widths (`size` property) and enabled sorting on usage-related columns (`alertCount`, `recordCount`, `dashboardCount`, `queryCount`) by removing `enableSorting: false`. (`ui/src/components/metrics-explorer/metrics-table.tsx`) [[1]](diffhunk://#diff-a35afb444c03a72c23e9b82d5eff92b7533646aebebdf64d2f7e73c890766bb8R90-R100) [[2]](diffhunk://#diff-a35afb444c03a72c23e9b82d5eff92b7533646aebebdf64d2f7e73c890766bb8R111-R123) [[3]](diffhunk://#diff-a35afb444c03a72c23e9b82d5eff92b7533646aebebdf64d2f7e73c890766bb8R132-R152) [[4]](diffhunk://#diff-a35afb444c03a72c23e9b82d5eff92b7533646aebebdf64d2f7e73c890766bb8L157-R164) [[5]](diffhunk://#diff-a35afb444c03a72c23e9b82d5eff92b7533646aebebdf64d2f7e73c890766bb8L181)
* Enhanced the data table component to apply column widths and overflow handling at both header and cell levels, improving readability and layout consistency. (`ui/src/components/data-table/data-table.tsx`, `ui/src/components/ui/table.tsx`) [[1]](diffhunk://#diff-4e2191035c34a5e0e0c71ac431f98a15c30278b90835c612446fd9a729b418e9L171-R186) [[2]](diffhunk://#diff-4e2191035c34a5e0e0c71ac431f98a15c30278b90835c612446fd9a729b418e9L210-R224) [[3]](diffhunk://#diff-7f482eca5946a209ccd977bb4d1843aaf9d79d24b537345de2ba7c7db62fceb2L7-R10)

These changes together make the Metrics Explorer more user-friendly by surfacing the most relevant metrics and providing a more robust and visually consistent table.

Fixes #372