### PR TITLE
fix(ui): rename 'All Jobs' filter to 'All Producers' for consistency …

### DIFF
--- a/ui/src/api/metrics.ts
+++ b/ui/src/api/metrics.ts
@@ -40,7 +40,7 @@ interface ApiConfig {
     metricQueryPerformanceStatistics: string;
     serieExpressions: string;
     metricUsage: string;
-    jobs: string;
+    producers: string;
   };
 }
 
@@ -68,7 +68,7 @@ const API_CONFIG: ApiConfig = {
       "/api/v1/metricQueryPerformanceStatistics",
     serieExpressions: "/api/v1/serieExpressions",
     metricUsage: "/api/v1/serieUsage",
-    jobs: "/api/v1/jobs",
+    producers: "/api/v1/jobs",
   },
 };
 
@@ -266,9 +266,11 @@ export async function getMetricUsage(
   );
 }
 
-export async function getJobs(): Promise<string[]> {
-  const res = await fetch(`${API_CONFIG.baseUrl}${API_CONFIG.endpoints.jobs}`);
-  if (!res.ok) throw new Error(`Failed to fetch jobs: ${res.status}`);
+export async function getProducers(): Promise<string[]> {
+  const res = await fetch(
+    `${API_CONFIG.baseUrl}${API_CONFIG.endpoints.producers}`,
+  );
+  if (!res.ok) throw new Error(`Failed to fetch producers: ${res.status}`);
   const body = (await res.json()) as { data: string[] };
   return body.data || [];
 }

--- a/ui/src/app/metrics/index.tsx
+++ b/ui/src/app/metrics/index.tsx
@@ -12,7 +12,7 @@ export default function MetricsExplorer() {
   const [usageFilter, setUsageFilter] = useState<"all" | "used" | "unused">(
     "all",
   );
-  const [jobFilter, setJobFilter] = useState<string>("");
+  const [producerFilter, setProducerFilter] = useState<string>("");
   const [tableState, setTableState] = useState<TableState>({
     page: 1,
     pageSize: 10,
@@ -29,7 +29,7 @@ export default function MetricsExplorer() {
     tableState,
     debouncedSearchQuery,
     usageFilter,
-    jobFilter,
+    producerFilter,
   );
 
   if (isLoading) {
@@ -58,9 +58,9 @@ export default function MetricsExplorer() {
         onTypeFilterChange={handleTypeFilterChange}
         usageFilter={usageFilter}
         onUsageFilterChange={setUsageFilter}
-        jobs={data.jobs}
-        jobFilter={jobFilter}
-        onJobFilterChange={setJobFilter}
+        producers={data.producers}
+        producerFilter={producerFilter}
+        onProducerFilterChange={setProducerFilter}
       />
       <MetricsTable
         metrics={data.metrics}

--- a/ui/src/app/metrics/use-metrics-data.ts
+++ b/ui/src/app/metrics/use-metrics-data.ts
@@ -5,7 +5,7 @@ import {
   getSeriesMetadata,
   getSerieExpressions,
   getMetricUsage,
-  getJobs,
+  getProducers,
 } from "@/api/metrics";
 import {
   PagedResult,
@@ -20,7 +20,7 @@ import { getQueryLatencyTrends } from "@/api/queries";
 
 interface MetricsData {
   metrics: PagedResult<MetricMetadata> | undefined;
-  jobs: string[] | undefined;
+  producers: string[] | undefined;
 }
 
 interface MetricStatisticsData {
@@ -64,15 +64,15 @@ export function useSeriesMetadataTable(
       ),
   });
 
-  const { data: jobs } = useQuery<string[]>({
-    queryKey: ["jobs"],
-    queryFn: getJobs,
+  const { data: producers } = useQuery<string[]>({
+    queryKey: ["producers"],
+    queryFn: getProducers,
   });
 
   return {
     data: {
       metrics,
-      jobs,
+      producers,
     } as MetricsData,
     isLoading,
     error,

--- a/ui/src/components/metrics-explorer/metrics-explorer-header.tsx
+++ b/ui/src/components/metrics-explorer/metrics-explorer-header.tsx
@@ -15,9 +15,9 @@ interface MetricsExplorerHeaderProps {
   onTypeFilterChange: (value: string) => void;
   usageFilter?: "all" | "used" | "unused";
   onUsageFilterChange?: (value: "all" | "used" | "unused") => void;
-  jobs?: string[];
-  jobFilter?: string;
-  onJobFilterChange?: (value: string) => void;
+  producers?: string[];
+  producerFilter?: string;
+  onProducerFilterChange?: (value: string) => void;
 }
 
 export function MetricsExplorerHeader({
@@ -27,13 +27,13 @@ export function MetricsExplorerHeader({
   onTypeFilterChange,
   usageFilter = "all",
   onUsageFilterChange,
-  jobs = [],
-  jobFilter = "",
-  onJobFilterChange,
+  producers = [],
+  producerFilter = "",
+  onProducerFilterChange,
 }: MetricsExplorerHeaderProps) {
-  const jobOptions = (jobs ?? []).filter((j) => !!j && j.trim().length > 0);
-  const currentJobValue = jobOptions.includes(jobFilter)
-    ? jobFilter
+  const producerOptions = producers.filter((p) => !!p && p.trim().length > 0);
+  const currentProducerValue = producerOptions.includes(producerFilter)
+    ? producerFilter
     : "__all__";
   return (
     <div className="flex flex-col gap-2">
@@ -66,22 +66,27 @@ export function MetricsExplorerHeader({
           </SelectContent>
         </Select>
         <Select
-          value={currentJobValue}
-          onValueChange={(v) => onJobFilterChange?.(v === "__all__" ? "" : v)}
+          value={currentProducerValue}
+          onValueChange={(v) =>
+            onProducerFilterChange?.(v === "__all__" ? "" : v)
+          }
         >
           <SelectTrigger className="w-[220px] sm:w-[240px] md:w-[280px] lg:w-[320px] text-left">
             <div className="flex items-center gap-2 min-w-0">
               <Filter className="h-4 w-4 shrink-0" />
-              <span className="truncate" title={jobFilter || "All Jobs"}>
-                <SelectValue placeholder="All Jobs" />
+              <span
+                className="truncate"
+                title={producerFilter || "All Producers"}
+              >
+                <SelectValue placeholder="All Producers" />
               </span>
             </div>
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="__all__">All Jobs</SelectItem>
-            {jobOptions.map((j) => (
-              <SelectItem key={j} value={j}>
-                {j}
+            <SelectItem value="__all__">All Producers</SelectItem>
+            {producerOptions.map((producer) => (
+              <SelectItem key={producer} value={producer}>
+                {producer}
               </SelectItem>
             ))}
           </SelectContent>


### PR DESCRIPTION
This pull request refactors the metrics explorer feature to rename the "job" filter and related variables to "producer" throughout the codebase. This change improves clarity and consistency in naming. All references to jobs in API calls, state, props, and UI labels are updated to use "producers" instead.

**Renaming "jobs" to "producers" throughout the metrics explorer:**

* API configuration and functions:
  - Renamed the `jobs` endpoint and related API function to `producers` in `ui/src/api/metrics.ts`, updating both the endpoint name and the function `getJobs` to `getProducers`. [[1]](diffhunk://#diff-2e4c5f078fd93181ec542c201add368751f78e5b32fd984cf3971f659345af4dL43-R43) [[2]](diffhunk://#diff-2e4c5f078fd93181ec542c201add368751f78e5b32fd984cf3971f659345af4dL71-R71) [[3]](diffhunk://#diff-2e4c5f078fd93181ec542c201add368751f78e5b32fd984cf3971f659345af4dL269-R271)
* Data fetching and state management:
  - Updated the metrics data hook to fetch and expose `producers` instead of `jobs` in `ui/src/app/metrics/use-metrics-data.ts`. [[1]](diffhunk://#diff-3ae0d1df8df893f2fc644ec03a7e4370672bc9cbf56106ad42a86f8b4cedca87L8-R8) [[2]](diffhunk://#diff-3ae0d1df8df893f2fc644ec03a7e4370672bc9cbf56106ad42a86f8b4cedca87L23-R23) [[3]](diffhunk://#diff-3ae0d1df8df893f2fc644ec03a7e4370672bc9cbf56106ad42a86f8b4cedca87L67-R75)
  - Changed all state and props related to `jobFilter` to `producerFilter` in `ui/src/app/metrics/index.tsx`. [[1]](diffhunk://#diff-f338dac67fc32f15b168d3b98df77692999cf325ce1e2b435759a448acad4716L15-R15) [[2]](diffhunk://#diff-f338dac67fc32f15b168d3b98df77692999cf325ce1e2b435759a448acad4716L32-R32) [[3]](diffhunk://#diff-f338dac67fc32f15b168d3b98df77692999cf325ce1e2b435759a448acad4716L61-R63)
* UI and component props:
  - Updated the `MetricsExplorerHeader` component and its props to use `producers` and `producerFilter`, including UI labels and select options, replacing all references to jobs. [[1]](diffhunk://#diff-124e5e9bbae0c433035804055a382b13ba9661eee5105d7034d0774fe98b5302L18-R20) [[2]](diffhunk://#diff-124e5e9bbae0c433035804055a382b13ba9661eee5105d7034d0774fe98b5302L30-R36) [[3]](diffhunk://#diff-124e5e9bbae0c433035804055a382b13ba9661eee5105d7034d0774fe98b5302L69-R84)…with metrics detail page

Closes: #510