### PR TITLE
test(ui): TDD tests for useTableState and usePagedQuery

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -45,6 +45,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tanstack/react-query-devtools": "^5.101.0",
+        "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
@@ -3248,6 +3249,43 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3309,6 +3347,13 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3980,6 +4025,29 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -4472,6 +4540,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -5713,6 +5791,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6068,6 +6156,28 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tanstack/react-query-devtools": "^5.101.0",
+    "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",

--- a/ui/src/hooks/use-paged-query.test.ts
+++ b/ui/src/hooks/use-paged-query.test.ts
@@ -22,10 +22,9 @@ const sampleResult: PagedResult<{ id: number }> = {
 describe("usePagedQuery", () => {
   it("returns data from queryFn", async () => {
     const queryFn = vi.fn().mockResolvedValue(sampleResult);
-    const { result } = renderHook(
-      () => usePagedQuery(["test-key"], queryFn),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => usePagedQuery(["test-key"], queryFn), {
+      wrapper: makeWrapper(),
+    });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(sampleResult);
@@ -35,10 +34,9 @@ describe("usePagedQuery", () => {
   it("passes queryKey through to TanStack Query", async () => {
     const queryFn = vi.fn().mockResolvedValue(sampleResult);
     const key = ["series-metadata", { page: 1, filter: "cpu" }];
-    const { result } = renderHook(
-      () => usePagedQuery(key, queryFn),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => usePagedQuery(key, queryFn), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(queryFn).toHaveBeenCalledTimes(1);
   });
@@ -55,10 +53,9 @@ describe("usePagedQuery", () => {
 
   it("reflects isError when queryFn rejects", async () => {
     const queryFn = vi.fn().mockRejectedValue(new Error("network error"));
-    const { result } = renderHook(
-      () => usePagedQuery(["error-key"], queryFn),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => usePagedQuery(["error-key"], queryFn), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
 

--- a/ui/src/hooks/use-paged-query.test.ts
+++ b/ui/src/hooks/use-paged-query.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { usePagedQuery } from "./use-paged-query";
+import type { PagedResult } from "@/lib/types";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+}
+
+const sampleResult: PagedResult<{ id: number }> = {
+  total: 42,
+  totalPages: 5,
+  data: [{ id: 1 }, { id: 2 }],
+};
+
+describe("usePagedQuery", () => {
+  it("returns data from queryFn", async () => {
+    const queryFn = vi.fn().mockResolvedValue(sampleResult);
+    const { result } = renderHook(
+      () => usePagedQuery(["test-key"], queryFn),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(sampleResult);
+    expect(queryFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes queryKey through to TanStack Query", async () => {
+    const queryFn = vi.fn().mockResolvedValue(sampleResult);
+    const key = ["series-metadata", { page: 1, filter: "cpu" }];
+    const { result } = renderHook(
+      () => usePagedQuery(key, queryFn),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflects isPending while the query is in-flight", () => {
+    const queryFn = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(
+      () => usePagedQuery(["pending-key"], queryFn),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("reflects isError when queryFn rejects", async () => {
+    const queryFn = vi.fn().mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(
+      () => usePagedQuery(["error-key"], queryFn),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("passes extra options (enabled) through to useQuery", async () => {
+    const queryFn = vi.fn().mockResolvedValue(sampleResult);
+    const { result } = renderHook(
+      () => usePagedQuery(["disabled-key"], queryFn, { enabled: false }),
+      { wrapper: makeWrapper() },
+    );
+    // enabled:false means the query stays idle — queryFn never called
+    expect(result.current.isPending).toBe(true);
+    expect(queryFn).not.toHaveBeenCalled();
+  });
+
+  it("passes staleTime option through to useQuery", async () => {
+    const queryFn = vi.fn().mockResolvedValue(sampleResult);
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client }, children);
+
+    const { result } = renderHook(
+      () => usePagedQuery(["stale-key"], queryFn, { staleTime: 60_000 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // staleTime: data should not be considered stale immediately
+    const query = client.getQueryCache().find({ queryKey: ["stale-key"] });
+    expect(query?.options.staleTime).toBe(60_000);
+  });
+});

--- a/ui/src/hooks/use-paged-query.ts
+++ b/ui/src/hooks/use-paged-query.ts
@@ -1,0 +1,17 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { PagedResult } from "@/lib/types";
+
+// usePagedQuery is the single fetch seam for all paginated endpoints.
+// When the count/data split lands (separate /count endpoint + data-only fetch),
+// change this hook once and every consumer inherits it automatically.
+export function usePagedQuery<T>(
+  queryKey: unknown[],
+  queryFn: () => Promise<PagedResult<T>>,
+  options?: Omit<UseQueryOptions<PagedResult<T>>, "queryKey" | "queryFn">,
+) {
+  return useQuery<PagedResult<T>>({
+    queryKey,
+    queryFn,
+    ...options,
+  });
+}

--- a/ui/src/hooks/use-table-state.test.ts
+++ b/ui/src/hooks/use-table-state.test.ts
@@ -1,0 +1,119 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { useTableState } from "./use-table-state";
+
+describe("useTableState", () => {
+  describe("initial state", () => {
+    it("uses library defaults when no options given", () => {
+      const { result } = renderHook(() => useTableState());
+      expect(result.current.page).toBe(1);
+      expect(result.current.pageSize).toBe(10);
+      expect(result.current.sortBy).toBe("");
+      expect(result.current.sortOrder).toBe("desc");
+      expect(result.current.filter).toBe("");
+      expect(result.current.sorting).toEqual([]);
+    });
+
+    it("uses provided options", () => {
+      const { result } = renderHook(() =>
+        useTableState({
+          defaultPage: 3,
+          defaultPageSize: 25,
+          defaultSortBy: "name",
+          defaultSortOrder: "asc",
+          defaultFilter: "prometheus",
+        }),
+      );
+      expect(result.current.page).toBe(3);
+      expect(result.current.pageSize).toBe(25);
+      expect(result.current.sortBy).toBe("name");
+      expect(result.current.sortOrder).toBe("asc");
+      expect(result.current.filter).toBe("prometheus");
+    });
+
+    it("derives initial SortingState from defaultSortBy + defaultSortOrder", () => {
+      const { result } = renderHook(() =>
+        useTableState({ defaultSortBy: "executions", defaultSortOrder: "desc" }),
+      );
+      expect(result.current.sorting).toEqual([{ id: "executions", desc: true }]);
+    });
+
+    it("produces empty SortingState when no defaultSortBy", () => {
+      const { result } = renderHook(() => useTableState({ defaultSortOrder: "asc" }));
+      expect(result.current.sorting).toEqual([]);
+    });
+  });
+
+  describe("setPage", () => {
+    it("updates page without touching other state", () => {
+      const { result } = renderHook(() =>
+        useTableState({ defaultPage: 1, defaultFilter: "foo", defaultSortBy: "name" }),
+      );
+      act(() => result.current.setPage(4));
+      expect(result.current.page).toBe(4);
+      expect(result.current.filter).toBe("foo");
+      expect(result.current.sortBy).toBe("name");
+    });
+  });
+
+  describe("setFilter", () => {
+    it("updates filter and resets page to 1", () => {
+      const { result } = renderHook(() => useTableState({ defaultPage: 5 }));
+      act(() => result.current.setFilter("my-metric"));
+      expect(result.current.filter).toBe("my-metric");
+      expect(result.current.page).toBe(1);
+    });
+
+    it("resets page to 1 even when filter is cleared", () => {
+      const { result } = renderHook(() =>
+        useTableState({ defaultPage: 3, defaultFilter: "something" }),
+      );
+      act(() => result.current.setFilter(""));
+      expect(result.current.filter).toBe("");
+      expect(result.current.page).toBe(1);
+    });
+  });
+
+  describe("setSort", () => {
+    it("updates sortBy, sortOrder, and SortingState together", () => {
+      const { result } = renderHook(() => useTableState());
+      act(() => result.current.setSort("avgDuration", "asc"));
+      expect(result.current.sortBy).toBe("avgDuration");
+      expect(result.current.sortOrder).toBe("asc");
+      expect(result.current.sorting).toEqual([{ id: "avgDuration", desc: false }]);
+    });
+
+    it("resets page to 1", () => {
+      const { result } = renderHook(() => useTableState({ defaultPage: 7 }));
+      act(() => result.current.setSort("name", "desc"));
+      expect(result.current.page).toBe(1);
+    });
+  });
+
+  describe("setSorting", () => {
+    it("syncs sortBy and sortOrder from SortingState array", () => {
+      const { result } = renderHook(() => useTableState());
+      act(() => result.current.setSorting([{ id: "peakSamples", desc: false }]));
+      expect(result.current.sortBy).toBe("peakSamples");
+      expect(result.current.sortOrder).toBe("asc");
+      expect(result.current.sorting).toEqual([{ id: "peakSamples", desc: false }]);
+    });
+
+    it("resets page to 1", () => {
+      const { result } = renderHook(() => useTableState({ defaultPage: 3 }));
+      act(() => result.current.setSorting([{ id: "name", desc: true }]));
+      expect(result.current.page).toBe(1);
+    });
+
+    it("keeps sortBy/sortOrder unchanged when given empty array, but still resets page", () => {
+      const { result } = renderHook(() =>
+        useTableState({ defaultPage: 2, defaultSortBy: "name", defaultSortOrder: "asc" }),
+      );
+      act(() => result.current.setSorting([]));
+      expect(result.current.sortBy).toBe("name");
+      expect(result.current.sortOrder).toBe("asc");
+      expect(result.current.sorting).toEqual([]);
+      expect(result.current.page).toBe(1);
+    });
+  });
+});

--- a/ui/src/hooks/use-table-state.test.ts
+++ b/ui/src/hooks/use-table-state.test.ts
@@ -33,13 +33,20 @@ describe("useTableState", () => {
 
     it("derives initial SortingState from defaultSortBy + defaultSortOrder", () => {
       const { result } = renderHook(() =>
-        useTableState({ defaultSortBy: "executions", defaultSortOrder: "desc" }),
+        useTableState({
+          defaultSortBy: "executions",
+          defaultSortOrder: "desc",
+        }),
       );
-      expect(result.current.sorting).toEqual([{ id: "executions", desc: true }]);
+      expect(result.current.sorting).toEqual([
+        { id: "executions", desc: true },
+      ]);
     });
 
     it("produces empty SortingState when no defaultSortBy", () => {
-      const { result } = renderHook(() => useTableState({ defaultSortOrder: "asc" }));
+      const { result } = renderHook(() =>
+        useTableState({ defaultSortOrder: "asc" }),
+      );
       expect(result.current.sorting).toEqual([]);
     });
   });
@@ -47,7 +54,11 @@ describe("useTableState", () => {
   describe("setPage", () => {
     it("updates page without touching other state", () => {
       const { result } = renderHook(() =>
-        useTableState({ defaultPage: 1, defaultFilter: "foo", defaultSortBy: "name" }),
+        useTableState({
+          defaultPage: 1,
+          defaultFilter: "foo",
+          defaultSortBy: "name",
+        }),
       );
       act(() => result.current.setPage(4));
       expect(result.current.page).toBe(4);
@@ -80,7 +91,9 @@ describe("useTableState", () => {
       act(() => result.current.setSort("avgDuration", "asc"));
       expect(result.current.sortBy).toBe("avgDuration");
       expect(result.current.sortOrder).toBe("asc");
-      expect(result.current.sorting).toEqual([{ id: "avgDuration", desc: false }]);
+      expect(result.current.sorting).toEqual([
+        { id: "avgDuration", desc: false },
+      ]);
     });
 
     it("resets page to 1", () => {
@@ -93,10 +106,14 @@ describe("useTableState", () => {
   describe("setSorting", () => {
     it("syncs sortBy and sortOrder from SortingState array", () => {
       const { result } = renderHook(() => useTableState());
-      act(() => result.current.setSorting([{ id: "peakSamples", desc: false }]));
+      act(() =>
+        result.current.setSorting([{ id: "peakSamples", desc: false }]),
+      );
       expect(result.current.sortBy).toBe("peakSamples");
       expect(result.current.sortOrder).toBe("asc");
-      expect(result.current.sorting).toEqual([{ id: "peakSamples", desc: false }]);
+      expect(result.current.sorting).toEqual([
+        { id: "peakSamples", desc: false },
+      ]);
     });
 
     it("resets page to 1", () => {
@@ -107,7 +124,11 @@ describe("useTableState", () => {
 
     it("keeps sortBy/sortOrder unchanged when given empty array, but still resets page", () => {
       const { result } = renderHook(() =>
-        useTableState({ defaultPage: 2, defaultSortBy: "name", defaultSortOrder: "asc" }),
+        useTableState({
+          defaultPage: 2,
+          defaultSortBy: "name",
+          defaultSortOrder: "asc",
+        }),
       );
       act(() => result.current.setSorting([]));
       expect(result.current.sortBy).toBe("name");

--- a/ui/src/hooks/use-table-state.ts
+++ b/ui/src/hooks/use-table-state.ts
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { SortingState } from "@tanstack/react-table";
+
+export interface UseTableStateOptions {
+  defaultPage?: number;
+  defaultPageSize?: number;
+  defaultSortBy?: string;
+  defaultSortOrder?: "asc" | "desc";
+  defaultFilter?: string;
+}
+
+export interface UseTableStateResult {
+  page: number;
+  pageSize: number;
+  sortBy: string;
+  sortOrder: "asc" | "desc";
+  filter: string;
+  sorting: SortingState;
+  setPage: (page: number) => void;
+  setFilter: (filter: string) => void;
+  setSort: (sortBy: string, sortOrder: "asc" | "desc") => void;
+  setSorting: (sorting: SortingState) => void;
+}
+
+// useTableState manages page/sort/filter state for a server-side paginated table.
+// Filter and sort changes automatically reset to page 1.
+// For URL-persisted pagination (QueriesPage, QueryExecutions) compose with
+// useSearchNumberState / useSearchState from hooks/use-search-state.ts instead.
+export function useTableState(
+  options: UseTableStateOptions = {},
+): UseTableStateResult {
+  const {
+    defaultPage = 1,
+    defaultPageSize = 10,
+    defaultSortBy = "",
+    defaultSortOrder = "desc",
+    defaultFilter = "",
+  } = options;
+
+  const [page, setPageRaw] = useState(defaultPage);
+  const [pageSize] = useState(defaultPageSize);
+  const [sortBy, setSortByRaw] = useState(defaultSortBy);
+  const [sortOrder, setSortOrderRaw] =
+    useState<"asc" | "desc">(defaultSortOrder);
+  const [filter, setFilterRaw] = useState(defaultFilter);
+  const [sorting, setSortingRaw] = useState<SortingState>(
+    defaultSortBy
+      ? [{ id: defaultSortBy, desc: defaultSortOrder === "desc" }]
+      : [],
+  );
+
+  const setPage = (p: number) => setPageRaw(p);
+
+  const setFilter = (f: string) => {
+    setFilterRaw(f);
+    setPageRaw(1);
+  };
+
+  const setSort = (by: string, order: "asc" | "desc") => {
+    setSortByRaw(by);
+    setSortOrderRaw(order);
+    setSortingRaw([{ id: by, desc: order === "desc" }]);
+    setPageRaw(1);
+  };
+
+  const setSorting = (newSorting: SortingState) => {
+    setSortingRaw(newSorting);
+    if (newSorting.length > 0) {
+      setSortByRaw(newSorting[0].id);
+      setSortOrderRaw(newSorting[0].desc ? "desc" : "asc");
+    }
+    setPageRaw(1);
+  };
+
+  return {
+    page,
+    pageSize,
+    sortBy,
+    sortOrder,
+    filter,
+    sorting,
+    setPage,
+    setFilter,
+    setSort,
+    setSorting,
+  };
+}

--- a/ui/src/hooks/use-table-state.ts
+++ b/ui/src/hooks/use-table-state.ts
@@ -40,8 +40,9 @@ export function useTableState(
   const [page, setPageRaw] = useState(defaultPage);
   const [pageSize] = useState(defaultPageSize);
   const [sortBy, setSortByRaw] = useState(defaultSortBy);
-  const [sortOrder, setSortOrderRaw] =
-    useState<"asc" | "desc">(defaultSortOrder);
+  const [sortOrder, setSortOrderRaw] = useState<"asc" | "desc">(
+    defaultSortOrder,
+  );
   const [filter, setFilterRaw] = useState(defaultFilter);
   const [sorting, setSortingRaw] = useState<SortingState>(
     defaultSortBy


### PR DESCRIPTION
First tests in the codebase. Locks the contracts of both pagination
seam hooks so regressions are caught during the refactor.

- useTableState: 12 cases covering initial state, page/filter/sort
  handlers, and the page-reset invariant on filter and sort changes
- usePagedQuery: 6 cases covering delegation to TanStack Query,
  isPending/isError states, and options passthrough (enabled, staleTime)

Also adds @testing-library/dom missing peer dep and both untracked
hook implementations.

Change-Id: I39484441f3aa2dc68a8546c3c65325e76fd8f8e5
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>