### PR TITLE
refactor(db): normalize PagedResult to value type across Provider

### DIFF
--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -42,8 +42,8 @@ func (p *benchDBProvider) InsertRulesUsage(_ context.Context, _ []db.RulesUsage)
 func (p *benchDBProvider) InsertDashboardUsage(_ context.Context, _ []db.DashboardUsage) error {
 	return nil
 }
-func (p *benchDBProvider) GetSeriesMetadata(_ context.Context, _ db.SeriesMetadataParams) (*db.PagedResult, error) {
-	return nil, nil
+func (p *benchDBProvider) GetSeriesMetadata(_ context.Context, _ db.SeriesMetadataParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
 }
 func (p *benchDBProvider) UpsertMetricsCatalog(_ context.Context, _ []db.MetricCatalogItem) error {
 	return nil
@@ -64,8 +64,8 @@ func (p *benchDBProvider) GetAverageDuration(_ context.Context, _ db.TimeRange, 
 func (p *benchDBProvider) GetQueryRate(_ context.Context, _ db.TimeRange, _ string, _ string) (*db.QueryRateResult, error) {
 	return nil, nil
 }
-func (p *benchDBProvider) GetQueriesBySerieName(_ context.Context, _ db.QueriesBySerieNameParams) (*db.PagedResult, error) {
-	return nil, nil
+func (p *benchDBProvider) GetQueriesBySerieName(_ context.Context, _ db.QueriesBySerieNameParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
 }
 func (p *benchDBProvider) GetQueryStatusDistribution(_ context.Context, _ db.TimeRange, _ string) ([]db.QueryStatusDistributionResult, error) {
 	return nil, nil
@@ -94,11 +94,11 @@ func (p *benchDBProvider) GetMetricStatistics(_ context.Context, _ string, _ db.
 func (p *benchDBProvider) GetMetricQueryPerformanceStatistics(_ context.Context, _ string, _ db.TimeRange) (db.MetricQueryPerformanceStatistics, error) {
 	return db.MetricQueryPerformanceStatistics{}, nil
 }
-func (p *benchDBProvider) GetRulesUsage(_ context.Context, _ db.RulesUsageParams) (*db.PagedResult, error) {
-	return nil, nil
+func (p *benchDBProvider) GetRulesUsage(_ context.Context, _ db.RulesUsageParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
 }
-func (p *benchDBProvider) GetDashboardUsage(_ context.Context, _ db.DashboardUsageParams) (*db.PagedResult, error) {
-	return nil, nil
+func (p *benchDBProvider) GetDashboardUsage(_ context.Context, _ db.DashboardUsageParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
 }
 func (p *benchDBProvider) DeleteQueriesBefore(_ context.Context, _ time.Time) (int64, error) {
 	return 0, nil
@@ -109,21 +109,21 @@ func (p *benchDBProvider) DeleteQueriesBefore(_ context.Context, _ time.Time) (i
 // HTTP and JSON overhead from any database work.
 type seriesMetaBenchProvider struct {
 	benchDBProvider
-	result *db.PagedResult
+	result db.PagedResult
 }
 
-func (p *seriesMetaBenchProvider) GetSeriesMetadata(_ context.Context, _ db.SeriesMetadataParams) (*db.PagedResult, error) {
+func (p *seriesMetaBenchProvider) GetSeriesMetadata(_ context.Context, _ db.SeriesMetadataParams) (db.PagedResult, error) {
 	return p.result, nil
 }
 
 // makePagedResult builds a PagedResult representing one page of n unused metrics
 // out of a total of n*totalPages metrics across all pages.
-func makePagedResult(n, totalPages int) *db.PagedResult {
+func makePagedResult(n, totalPages int) db.PagedResult {
 	data := make([]models.MetricMetadata, n)
 	for i := range n {
 		data[i] = models.MetricMetadata{Name: fmt.Sprintf("metric_%d", i), Type: "gauge"}
 	}
-	return &db.PagedResult{
+	return db.PagedResult{
 		TotalPages: totalPages,
 		Total:      n * totalPages,
 		Data:       data,

--- a/api/routes/routes_test.go
+++ b/api/routes/routes_test.go
@@ -166,9 +166,9 @@ type captureSeriesMetadataProvider struct {
 	captured db.SeriesMetadataParams
 }
 
-func (p *captureSeriesMetadataProvider) GetSeriesMetadata(_ context.Context, params db.SeriesMetadataParams) (*db.PagedResult, error) {
+func (p *captureSeriesMetadataProvider) GetSeriesMetadata(_ context.Context, params db.SeriesMetadataParams) (db.PagedResult, error) {
 	p.captured = params
-	return &db.PagedResult{}, nil
+	return db.PagedResult{}, nil
 }
 
 func TestSeriesMetadataPageSizeClamp(t *testing.T) {

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -337,7 +337,7 @@ func (p *PostGreSQLProvider) Insert(ctx context.Context, queries []Query) error 
 
 func (p *PostGreSQLProvider) GetQueriesBySerieName(
 	ctx context.Context,
-	params QueriesBySerieNameParams) (*PagedResult, error) {
+	params QueriesBySerieNameParams) (PagedResult, error) {
 
 	// Set default values using common helpers
 	ValidatePagination(&params.Page, &params.PageSize, 10)
@@ -398,7 +398,7 @@ func (p *PostGreSQLProvider) GetQueriesBySerieName(
 
 	rows, err := ExecuteQuery(ctx, p.db, query, args...)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	defer CloseResource(rows)
 
@@ -414,18 +414,18 @@ func (p *PostGreSQLProvider) GetQueriesBySerieName(
 			&result.MaxPeakSamples,
 			&totalCount,
 		); err != nil {
-			return nil, ErrorWithOperation(err, "scanning row")
+			return PagedResult{}, ErrorWithOperation(err, "scanning row")
 		}
 		results = append(results, result)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, ErrorWithOperation(err, "row iteration")
+		return PagedResult{}, ErrorWithOperation(err, "row iteration")
 	}
 
 	totalPages := CalculateTotalPages(totalCount, params.PageSize)
 
-	return &PagedResult{
+	return PagedResult{
 		Total:      totalCount,
 		TotalPages: totalPages,
 		Data:       results,
@@ -515,7 +515,7 @@ func (p *PostGreSQLProvider) InsertRulesUsage(ctx context.Context, rulesUsage []
 	return nil
 }
 
-func (p *PostGreSQLProvider) GetRulesUsage(ctx context.Context, params RulesUsageParams) (*PagedResult, error) {
+func (p *PostGreSQLProvider) GetRulesUsage(ctx context.Context, params RulesUsageParams) (PagedResult, error) {
 	if params.Page <= 0 {
 		params.Page = 1
 	}
@@ -563,7 +563,7 @@ func (p *PostGreSQLProvider) GetRulesUsage(ctx context.Context, params RulesUsag
 	err := p.db.QueryRowContext(ctx, countQuery, params.Serie, params.Kind, startTime, endTime,
 		params.Filter).Scan(&totalCount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query total count: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query total count: %w", err)
 	}
 
 	totalPages := (totalCount + params.PageSize - 1) / params.PageSize
@@ -617,7 +617,7 @@ func (p *PostGreSQLProvider) GetRulesUsage(ctx context.Context, params RulesUsag
 
 	rows, err := ExecuteQuery(ctx, p.db, query, args...)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	defer CloseResource(rows)
 
@@ -634,13 +634,13 @@ func (p *PostGreSQLProvider) GetRulesUsage(ctx context.Context, params RulesUsag
 		)
 
 		if err := rows.Scan(&serie, &groupName, &name, &expression, &kind, &labelsJSON, &createdAt); err != nil {
-			return nil, fmt.Errorf("failed to scan row: %w", err)
+			return PagedResult{}, fmt.Errorf("failed to scan row: %w", err)
 		}
 
 		var labels []string
 		if len(labelsJSON) > 0 {
 			if err := json.Unmarshal(labelsJSON, &labels); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal labels: %w", err)
+				return PagedResult{}, fmt.Errorf("failed to unmarshal labels: %w", err)
 			}
 		}
 
@@ -655,10 +655,10 @@ func (p *PostGreSQLProvider) GetRulesUsage(ctx context.Context, params RulesUsag
 		})
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("row iteration error: %w", err)
+		return PagedResult{}, fmt.Errorf("row iteration error: %w", err)
 	}
 
-	return &PagedResult{
+	return PagedResult{
 		Total:      totalCount,
 		TotalPages: totalPages,
 		Data:       results,
@@ -712,7 +712,7 @@ func (p *PostGreSQLProvider) InsertDashboardUsage(ctx context.Context, dashboard
 	return nil
 }
 
-func (p *PostGreSQLProvider) GetDashboardUsage(ctx context.Context, params DashboardUsageParams) (*PagedResult, error) {
+func (p *PostGreSQLProvider) GetDashboardUsage(ctx context.Context, params DashboardUsageParams) (PagedResult, error) {
 	if params.Page <= 0 {
 		params.Page = 1
 	}
@@ -759,7 +759,7 @@ func (p *PostGreSQLProvider) GetDashboardUsage(ctx context.Context, params Dashb
 	err := p.db.QueryRowContext(ctx, countQuery,
 		params.Serie, from, to, params.Filter).Scan(&totalCount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query total count: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query total count: %w", err)
 	}
 
 	totalPages := (totalCount + params.PageSize - 1) / params.PageSize
@@ -804,7 +804,7 @@ func (p *PostGreSQLProvider) GetDashboardUsage(ctx context.Context, params Dashb
 		params.Serie, from, to, params.Filter,
 		params.PageSize, offset)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	defer CloseResource(rows)
 
@@ -819,7 +819,7 @@ func (p *PostGreSQLProvider) GetDashboardUsage(ctx context.Context, params Dashb
 		)
 
 		if err := rows.Scan(&id, &serie, &name, &url, &createdAt); err != nil {
-			return nil, fmt.Errorf("failed to scan row: %w", err)
+			return PagedResult{}, fmt.Errorf("failed to scan row: %w", err)
 		}
 
 		results = append(results, DashboardUsage{
@@ -832,17 +832,17 @@ func (p *PostGreSQLProvider) GetDashboardUsage(ctx context.Context, params Dashb
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("row iteration error: %w", err)
+		return PagedResult{}, fmt.Errorf("row iteration error: %w", err)
 	}
 
-	return &PagedResult{
+	return PagedResult{
 		Total:      totalCount,
 		TotalPages: totalPages,
 		Data:       results,
 	}, nil
 }
 
-func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params SeriesMetadataParams) (PagedResult, error) {
 	if params.Page <= 0 {
 		params.Page = 1
 	}
@@ -870,25 +870,25 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 	// Used / all: catalog-driven LEFT JOIN shape.
 	var total int
 	if err := p.db.QueryRowContext(ctx, pgSeriesMetadataCountSQL, params.Filter, params.Type, params.Usage, params.Job).Scan(&total); err != nil {
-		return nil, fmt.Errorf("count: %w", err)
+		return PagedResult{}, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+		return PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
 	query := BuildSafeQueryWithOrderBy(pgSeriesMetadataBaseSQL, "c", " LIMIT $5 OFFSET $6", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Usage, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
-		return nil, fmt.Errorf("select: %w", err)
+		return PagedResult{}, fmt.Errorf("select: %w", err)
 	}
 	defer CloseResource(rows)
 
 	out, err := scanSeriesMetadataRows(rows, params.PageSize)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	pages := (total + params.PageSize - 1) / params.PageSize
-	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+	return PagedResult{Total: total, TotalPages: pages, Data: out}, nil
 }
 
 // getSeriesMetadataUnused drives the ?usage=unused query from
@@ -904,17 +904,17 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 // catastrophically misses for jobs that match a small slice of unused
 // metrics. The job case is therefore handled by getSeriesMetadataUnusedJobScoped,
 // which drives from metrics_job_index instead.
-func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params SeriesMetadataParams) (PagedResult, error) {
 	if params.Job != "" {
 		return p.getSeriesMetadataUnusedJobScoped(ctx, params)
 	}
 
 	var total int
 	if err := p.db.QueryRowContext(ctx, pgSeriesMetadataUnusedCountSQL, params.Filter, params.Type).Scan(&total); err != nil {
-		return nil, fmt.Errorf("count: %w", err)
+		return PagedResult{}, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+		return PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
 	// Force ORDER BY c.name for the unused branch regardless of the
@@ -930,16 +930,16 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params
 	query := BuildSafeQueryWithOrderBy(pgSeriesMetadataUnusedBaseSQL, "c", " LIMIT $3 OFFSET $4", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
-		return nil, fmt.Errorf("select: %w", err)
+		return PagedResult{}, fmt.Errorf("select: %w", err)
 	}
 	defer CloseResource(rows)
 
 	out, err := scanSeriesMetadataRows(rows, params.PageSize)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	pages := (total + params.PageSize - 1) / params.PageSize
-	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+	return PagedResult{Total: total, TotalPages: pages, Data: out}, nil
 }
 
 // getSeriesMetadataUnusedJobScoped drives ?usage=unused&job=<X> from
@@ -950,13 +950,13 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params
 // unused universe - the latter is what cratered cx10 when the operator's
 // ?usage=unused&job=kube-state-metrics request hit 139k unused metrics
 // looking for a sparse 57-row match.
-func (p *PostGreSQLProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+func (p *PostGreSQLProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, params SeriesMetadataParams) (PagedResult, error) {
 	var total int
 	if err := p.db.QueryRowContext(ctx, pgSeriesMetadataUnusedJobCountSQL, params.Filter, params.Type, params.Job).Scan(&total); err != nil {
-		return nil, fmt.Errorf("count: %w", err)
+		return PagedResult{}, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+		return PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
 	// Force ORDER BY c.name; see getSeriesMetadataUnused for rationale.
@@ -966,16 +966,16 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnusedJobScoped(ctx context.Contex
 	query := BuildSafeQueryWithOrderBy(pgSeriesMetadataUnusedJobBaseSQL, "c", " LIMIT $4 OFFSET $5", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
-		return nil, fmt.Errorf("select: %w", err)
+		return PagedResult{}, fmt.Errorf("select: %w", err)
 	}
 	defer CloseResource(rows)
 
 	out, err := scanSeriesMetadataRows(rows, params.PageSize)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	pages := (total + params.PageSize - 1) / params.PageSize
-	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+	return PagedResult{Total: total, TotalPages: pages, Data: out}, nil
 }
 
 // scanSeriesMetadataRows scans rows returned by either GetSeriesMetadata

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -42,7 +42,7 @@ type Provider interface {
 	Insert(ctx context.Context, queries []Query) error
 	InsertRulesUsage(ctx context.Context, rulesUsage []RulesUsage) error
 	InsertDashboardUsage(ctx context.Context, dashboardUsage []DashboardUsage) error
-	GetSeriesMetadata(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error)
+	GetSeriesMetadata(ctx context.Context, params SeriesMetadataParams) (PagedResult, error)
 	UpsertMetricsCatalog(ctx context.Context, items []MetricCatalogItem) error
 	RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error
 	UpsertMetricsJobIndex(ctx context.Context, items []MetricJobIndexItem) error
@@ -51,7 +51,7 @@ type Provider interface {
 	GetQueryTypes(ctx context.Context, tr TimeRange, fingerprint string) (*QueryTypesResult, error)
 	GetAverageDuration(ctx context.Context, tr TimeRange, fingerprint string) (*AverageDurationResult, error)
 	GetQueryRate(ctx context.Context, tr TimeRange, metricName string, fingerprint string) (*QueryRateResult, error)
-	GetQueriesBySerieName(ctx context.Context, params QueriesBySerieNameParams) (*PagedResult, error)
+	GetQueriesBySerieName(ctx context.Context, params QueriesBySerieNameParams) (PagedResult, error)
 	GetQueryStatusDistribution(ctx context.Context, tr TimeRange, fingerprint string) ([]QueryStatusDistributionResult, error)
 	GetQueryLatencyTrends(ctx context.Context, tr TimeRange, metricName string, fingerprint string) ([]QueryLatencyTrendsResult, error)
 	GetQueryThroughputAnalysis(ctx context.Context, tr TimeRange) ([]QueryThroughputAnalysisResult, error)
@@ -61,8 +61,8 @@ type Provider interface {
 	GetQueryExecutions(ctx context.Context, params QueryExecutionsParams) (PagedResult, error)
 	GetMetricStatistics(ctx context.Context, metricName string, tr TimeRange) (MetricUsageStatics, error)
 	GetMetricQueryPerformanceStatistics(ctx context.Context, metricName string, tr TimeRange) (MetricQueryPerformanceStatistics, error)
-	GetRulesUsage(ctx context.Context, params RulesUsageParams) (*PagedResult, error)
-	GetDashboardUsage(ctx context.Context, params DashboardUsageParams) (*PagedResult, error)
+	GetRulesUsage(ctx context.Context, params RulesUsageParams) (PagedResult, error)
+	GetDashboardUsage(ctx context.Context, params DashboardUsageParams) (PagedResult, error)
 	GetSeriesMetadataByNames(ctx context.Context, names []string, job string) ([]models.MetricMetadata, error)
 	DeleteQueriesBefore(ctx context.Context, cutoff time.Time) (int64, error)
 

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -251,7 +251,7 @@ func (p *SQLiteProvider) Insert(ctx context.Context, queries []Query) error {
 	return nil
 }
 
-func (p *SQLiteProvider) GetQueriesBySerieName(ctx context.Context, params QueriesBySerieNameParams) (*PagedResult, error) {
+func (p *SQLiteProvider) GetQueriesBySerieName(ctx context.Context, params QueriesBySerieNameParams) (PagedResult, error) {
 	ValidatePagination(&params.Page, &params.PageSize, 10)
 
 	validSortFields := map[string]bool{
@@ -327,13 +327,13 @@ func (p *SQLiteProvider) GetQueriesBySerieName(ctx context.Context, params Queri
 
 	stmt, err := p.db.PrepareContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare statement: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer CloseResource(stmt)
 
 	rows, err := ExecuteQuery(ctx, p.db, query, args...)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	defer CloseResource(rows)
 
@@ -349,18 +349,18 @@ func (p *SQLiteProvider) GetQueriesBySerieName(ctx context.Context, params Queri
 			&result.MaxPeakSamples,
 			&totalCount,
 		); err != nil {
-			return nil, ErrorWithOperation(err, "scanning row")
+			return PagedResult{}, ErrorWithOperation(err, "scanning row")
 		}
 		results = append(results, result)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, ErrorWithOperation(err, "row iteration")
+		return PagedResult{}, ErrorWithOperation(err, "row iteration")
 	}
 
 	totalPages := CalculateTotalPages(totalCount, params.PageSize)
 
-	return &PagedResult{
+	return PagedResult{
 		Total:      totalCount,
 		TotalPages: totalPages,
 		Data:       results,
@@ -454,7 +454,7 @@ func (p *SQLiteProvider) InsertRulesUsage(ctx context.Context, rulesUsage []Rule
 	return nil
 }
 
-func (p *SQLiteProvider) GetRulesUsage(ctx context.Context, params RulesUsageParams) (*PagedResult, error) {
+func (p *SQLiteProvider) GetRulesUsage(ctx context.Context, params RulesUsageParams) (PagedResult, error) {
 	if params.Page <= 0 {
 		params.Page = 1
 	}
@@ -505,7 +505,7 @@ func (p *SQLiteProvider) GetRulesUsage(ctx context.Context, params RulesUsagePar
 	err := p.db.QueryRowContext(ctx, countQuery, params.Serie, params.Kind, endTime, startTime,
 		params.Filter, params.Filter, params.Filter).Scan(&totalCount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query total count: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query total count: %w", err)
 	}
 
 	totalPages := (totalCount + params.PageSize - 1) / params.PageSize
@@ -576,7 +576,7 @@ func (p *SQLiteProvider) GetRulesUsage(ctx context.Context, params RulesUsagePar
 
 	rows, err := p.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query rules usage: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query rules usage: %w", err)
 	}
 	defer CloseResource(rows)
 
@@ -593,13 +593,13 @@ func (p *SQLiteProvider) GetRulesUsage(ctx context.Context, params RulesUsagePar
 		)
 
 		if err := rows.Scan(&serie, &groupName, &name, &expression, &kind, &labelsJSON, &createdAt); err != nil {
-			return nil, fmt.Errorf("failed to scan row: %w", err)
+			return PagedResult{}, fmt.Errorf("failed to scan row: %w", err)
 		}
 
 		var labels []string
 		if labelsJSON != "" {
 			if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal labels: %w", err)
+				return PagedResult{}, fmt.Errorf("failed to unmarshal labels: %w", err)
 			}
 		}
 
@@ -616,10 +616,10 @@ func (p *SQLiteProvider) GetRulesUsage(ctx context.Context, params RulesUsagePar
 
 	// Check for errors after iteration
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("row iteration error: %w", err)
+		return PagedResult{}, fmt.Errorf("row iteration error: %w", err)
 	}
 
-	return &PagedResult{
+	return PagedResult{
 		Total:      totalCount,
 		TotalPages: totalPages,
 		Data:       results,
@@ -674,7 +674,7 @@ func (p *SQLiteProvider) InsertDashboardUsage(ctx context.Context, dashboardUsag
 	return nil
 }
 
-func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params DashboardUsageParams) (*PagedResult, error) {
+func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params DashboardUsageParams) (PagedResult, error) {
 	if params.Page <= 0 {
 		params.Page = 1
 	}
@@ -723,7 +723,7 @@ func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params Dashboard
 		params.Serie, endTime, startTime,
 		params.Filter, params.Filter, params.Filter).Scan(&totalCount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query total count: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query total count: %w", err)
 	}
 
 	totalPages := (totalCount + params.PageSize - 1) / params.PageSize
@@ -788,7 +788,7 @@ func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params Dashboard
 
 	rows, err := p.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query dashboard usage: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query dashboard usage: %w", err)
 	}
 	defer CloseResource(rows)
 
@@ -803,7 +803,7 @@ func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params Dashboard
 		)
 
 		if err := rows.Scan(&id, &serie, &name, &url, &createdAt); err != nil {
-			return nil, fmt.Errorf("failed to scan row: %w", err)
+			return PagedResult{}, fmt.Errorf("failed to scan row: %w", err)
 		}
 
 		results = append(results, DashboardUsage{
@@ -816,17 +816,17 @@ func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params Dashboard
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("row iteration error: %w", err)
+		return PagedResult{}, fmt.Errorf("row iteration error: %w", err)
 	}
 
-	return &PagedResult{
+	return PagedResult{
 		Total:      totalCount,
 		TotalPages: totalPages,
 		Data:       results,
 	}, nil
 }
 
-func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMetadataParams) (PagedResult, error) {
 	if params.Page <= 0 {
 		params.Page = 1
 	}
@@ -859,10 +859,10 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 		params.Usage, params.Usage,
 		params.Job, params.Job,
 	).Scan(&total); err != nil {
-		return nil, fmt.Errorf("failed to count catalog: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to count catalog: %w", err)
 	}
 	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+		return PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
 	query := BuildSafeQueryWithOrderBy(sqliteSeriesMetadataBaseSQL, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
@@ -874,16 +874,16 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 		params.PageSize, (params.Page-1)*params.PageSize,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query series metadata: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query series metadata: %w", err)
 	}
 	defer CloseResource(rows)
 
 	out, err := scanSeriesMetadataRows(rows, params.PageSize)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	pages := (total + params.PageSize - 1) / params.PageSize
-	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+	return PagedResult{Total: total, TotalPages: pages, Data: out}, nil
 }
 
 // getSeriesMetadataUnused drives the ?usage=unused query from
@@ -899,7 +899,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 // catastrophically misses for jobs that match a small slice of unused
 // metrics. The job case is therefore handled by getSeriesMetadataUnusedJobScoped,
 // which drives from metrics_job_index instead.
-func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params SeriesMetadataParams) (PagedResult, error) {
 	if params.Job != "" {
 		return p.getSeriesMetadataUnusedJobScoped(ctx, params)
 	}
@@ -909,10 +909,10 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
 	).Scan(&total); err != nil {
-		return nil, fmt.Errorf("failed to count catalog: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to count catalog: %w", err)
 	}
 	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+		return PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
 	// Force ORDER BY c.name for the unused branch regardless of the
@@ -932,16 +932,16 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
 		params.PageSize, (params.Page-1)*params.PageSize,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query series metadata: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query series metadata: %w", err)
 	}
 	defer CloseResource(rows)
 
 	out, err := scanSeriesMetadataRows(rows, params.PageSize)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	pages := (total + params.PageSize - 1) / params.PageSize
-	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+	return PagedResult{Total: total, TotalPages: pages, Data: out}, nil
 }
 
 // getSeriesMetadataUnusedJobScoped drives ?usage=unused&job=<X> from
@@ -952,17 +952,17 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
 // unused universe - the latter is what cratered cx10 when the operator's
 // ?usage=unused&job=kube-state-metrics request hit 139k unused metrics
 // looking for a sparse 57-row match.
-func (p *SQLiteProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+func (p *SQLiteProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, params SeriesMetadataParams) (PagedResult, error) {
 	var total int
 	if err := p.db.QueryRowContext(ctx, sqliteSeriesMetadataUnusedJobCountSQL,
 		params.Job,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
 	).Scan(&total); err != nil {
-		return nil, fmt.Errorf("failed to count catalog: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to count catalog: %w", err)
 	}
 	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+		return PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
 	// Force ORDER BY c.name; see getSeriesMetadataUnused for rationale.
@@ -977,16 +977,16 @@ func (p *SQLiteProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, p
 		params.PageSize, (params.Page-1)*params.PageSize,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query series metadata: %w", err)
+		return PagedResult{}, fmt.Errorf("failed to query series metadata: %w", err)
 	}
 	defer CloseResource(rows)
 
 	out, err := scanSeriesMetadataRows(rows, params.PageSize)
 	if err != nil {
-		return nil, err
+		return PagedResult{}, err
 	}
 	pages := (total + params.PageSize - 1) / params.PageSize
-	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+	return PagedResult{Total: total, TotalPages: pages, Data: out}, nil
 }
 
 // GetSeriesMetadataByNames returns metadata and usage summary for a fixed list of names, optionally filtered by job.

--- a/internal/ingester/queryingester_test.go
+++ b/internal/ingester/queryingester_test.go
@@ -35,12 +35,9 @@ func (m *MockDBProvider) GetQueryExecutions(ctx context.Context, params db.Query
 	return db.PagedResult{}, nil
 }
 
-func (m *MockDBProvider) GetSeriesMetadata(ctx context.Context, params db.SeriesMetadataParams) (*db.PagedResult, error) {
+func (m *MockDBProvider) GetSeriesMetadata(ctx context.Context, params db.SeriesMetadataParams) (db.PagedResult, error) {
 	args := m.Called(ctx, params)
-	if v := args.Get(0); v != nil {
-		return v.(*db.PagedResult), args.Error(1)
-	}
-	return nil, args.Error(1)
+	return args.Get(0).(db.PagedResult), args.Error(1)
 }
 
 func (m *MockDBProvider) UpsertMetricsCatalog(ctx context.Context, items []db.MetricCatalogItem) error {
@@ -74,9 +71,9 @@ func (m *MockDBProvider) WithDB(f func(db *sql.DB)) {
 
 func (m *MockDBProvider) GetQueriesBySerieName(
 	ctx context.Context,
-	params db.QueriesBySerieNameParams) (*db.PagedResult, error) {
+	params db.QueriesBySerieNameParams) (db.PagedResult, error) {
 	args := m.Called(ctx, params)
-	return args.Get(0).(*db.PagedResult), args.Error(1)
+	return args.Get(0).(db.PagedResult), args.Error(1)
 }
 
 func (m *MockDBProvider) InsertRulesUsage(ctx context.Context, rulesUsage []db.RulesUsage) error {
@@ -84,9 +81,9 @@ func (m *MockDBProvider) InsertRulesUsage(ctx context.Context, rulesUsage []db.R
 	return args.Error(0)
 }
 
-func (m *MockDBProvider) GetRulesUsage(ctx context.Context, params db.RulesUsageParams) (*db.PagedResult, error) {
+func (m *MockDBProvider) GetRulesUsage(ctx context.Context, params db.RulesUsageParams) (db.PagedResult, error) {
 	args := m.Called(ctx, params)
-	return args.Get(0).(*db.PagedResult), args.Error(1)
+	return args.Get(0).(db.PagedResult), args.Error(1)
 }
 
 func (m *MockDBProvider) InsertDashboardUsage(ctx context.Context, dashboardUsage []db.DashboardUsage) error {
@@ -94,9 +91,9 @@ func (m *MockDBProvider) InsertDashboardUsage(ctx context.Context, dashboardUsag
 	return args.Error(0)
 }
 
-func (m *MockDBProvider) GetDashboardUsage(ctx context.Context, params db.DashboardUsageParams) (*db.PagedResult, error) {
+func (m *MockDBProvider) GetDashboardUsage(ctx context.Context, params db.DashboardUsageParams) (db.PagedResult, error) {
 	args := m.Called(ctx, params)
-	return args.Get(0).(*db.PagedResult), args.Error(1)
+	return args.Get(0).(db.PagedResult), args.Error(1)
 }
 
 func (m *MockDBProvider) GetQueryTypes(ctx context.Context, tr db.TimeRange, fingerprint string) (*db.QueryTypesResult, error) {

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -44,8 +44,8 @@ func (f *fakeProvider) WithDB(func(*sql.DB))                                    
 func (f *fakeProvider) Insert(context.Context, []db.Query) error                        { return nil }
 func (f *fakeProvider) InsertRulesUsage(context.Context, []db.RulesUsage) error         { return nil }
 func (f *fakeProvider) InsertDashboardUsage(context.Context, []db.DashboardUsage) error { return nil }
-func (f *fakeProvider) GetSeriesMetadata(context.Context, db.SeriesMetadataParams) (*db.PagedResult, error) {
-	return nil, nil
+func (f *fakeProvider) GetSeriesMetadata(context.Context, db.SeriesMetadataParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
 }
 func (f *fakeProvider) UpsertMetricsCatalog(context.Context, []db.MetricCatalogItem) error {
 	return nil
@@ -64,8 +64,8 @@ func (f *fakeProvider) GetAverageDuration(context.Context, db.TimeRange, string)
 func (f *fakeProvider) GetQueryRate(context.Context, db.TimeRange, string, string) (*db.QueryRateResult, error) {
 	return nil, nil
 }
-func (f *fakeProvider) GetQueriesBySerieName(context.Context, db.QueriesBySerieNameParams) (*db.PagedResult, error) {
-	return nil, nil
+func (f *fakeProvider) GetQueriesBySerieName(context.Context, db.QueriesBySerieNameParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
 }
 func (f *fakeProvider) GetQueryStatusDistribution(context.Context, db.TimeRange, string) ([]db.QueryStatusDistributionResult, error) {
 	return nil, nil
@@ -94,11 +94,11 @@ func (f *fakeProvider) GetMetricStatistics(context.Context, string, db.TimeRange
 func (f *fakeProvider) GetMetricQueryPerformanceStatistics(context.Context, string, db.TimeRange) (db.MetricQueryPerformanceStatistics, error) {
 	return db.MetricQueryPerformanceStatistics{}, nil
 }
-func (f *fakeProvider) GetRulesUsage(context.Context, db.RulesUsageParams) (*db.PagedResult, error) {
-	return nil, nil
+func (f *fakeProvider) GetRulesUsage(context.Context, db.RulesUsageParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
 }
-func (f *fakeProvider) GetDashboardUsage(context.Context, db.DashboardUsageParams) (*db.PagedResult, error) {
-	return nil, nil
+func (f *fakeProvider) GetDashboardUsage(context.Context, db.DashboardUsageParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
 }
 func (f *fakeProvider) GetSeriesMetadataByNames(context.Context, []string, string) ([]models.MetricMetadata, error) {
 	return nil, nil


### PR DESCRIPTION
GetSeriesMetadata, GetQueriesBySerieName, GetRulesUsage, and
GetDashboardUsage returned *PagedResult while GetQueryExpressions and
GetQueryExecutions returned PagedResult. PagedResult is a small struct
with no nil semantics — pointer added no benefit and caused
inconsistency.

All six now return (PagedResult, error). No behavior change.

Change-Id: Ia2ea267b958b6ce7d68a6bbb2fe82af5bae09fcb
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>