### PR TITLE
refactor(db): centralize pagination validation via ValidatePagination 

### DIFF
--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -516,14 +516,7 @@ func (p *PostGreSQLProvider) InsertRulesUsage(ctx context.Context, rulesUsage []
 }
 
 func (p *PostGreSQLProvider) GetRulesUsage(ctx context.Context, params RulesUsageParams) (PagedResult, error) {
-	if params.Page <= 0 {
-		params.Page = 1
-	}
-	if params.PageSize <= 0 {
-		params.PageSize = 10
-	} else if params.PageSize > MaxPageSize {
-		params.PageSize = MaxPageSize
-	}
+	ValidatePagination(&params.Page, &params.PageSize, 10)
 	if params.SortOrder == "" {
 		params.SortOrder = "desc"
 	}
@@ -1655,12 +1648,7 @@ func (p *PostGreSQLProvider) GetQueryTimeRangeDistribution(ctx context.Context, 
 
 // GetQueryExpressions aggregates queries by fingerprint returning executions, avgDuration, errorRatePercent, peakSamples and latest query text
 func (p *PostGreSQLProvider) GetQueryExpressions(ctx context.Context, params QueryExpressionsParams) (PagedResult, error) {
-	if params.Page <= 0 {
-		params.Page = 1
-	}
-	if params.PageSize <= 0 {
-		params.PageSize = 10
-	}
+	ValidatePagination(&params.Page, &params.PageSize, 10)
 
 	validSortFields := map[string]bool{
 		"query":            true,

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -455,14 +455,7 @@ func (p *SQLiteProvider) InsertRulesUsage(ctx context.Context, rulesUsage []Rule
 }
 
 func (p *SQLiteProvider) GetRulesUsage(ctx context.Context, params RulesUsageParams) (PagedResult, error) {
-	if params.Page <= 0 {
-		params.Page = 1
-	}
-	if params.PageSize <= 0 {
-		params.PageSize = 10
-	} else if params.PageSize > MaxPageSize {
-		params.PageSize = MaxPageSize
-	}
+	ValidatePagination(&params.Page, &params.PageSize, 10)
 	if params.SortBy == "" {
 		params.SortBy = "created_at"
 	}
@@ -1693,12 +1686,7 @@ func (p *SQLiteProvider) GetQueryTimeRangeDistribution(ctx context.Context, tr T
 
 // GetQueryExpressions aggregates queries by fingerprint for SQLite
 func (p *SQLiteProvider) GetQueryExpressions(ctx context.Context, params QueryExpressionsParams) (PagedResult, error) {
-	if params.Page <= 0 {
-		params.Page = 1
-	}
-	if params.PageSize <= 0 {
-		params.PageSize = 10
-	}
+	ValidatePagination(&params.Page, &params.PageSize, 10)
 	if params.SortOrder == "" {
 		params.SortOrder = "desc"
 	}


### PR DESCRIPTION
GetRulesUsage and GetQueryExpressions duplicated the page >= 1 /
default pageSize / cap-at-MaxPageSize logic that ValidatePagination()
already provides. Replace both inline blocks with a single call in
postgresql.go and sqlite.go. No behavior change for GetRulesUsage;
GetQueryExpressions now also caps at MaxPageSize (was missing the cap).

Change-Id: Ie8b6e3dee0b30d101c3790215ae67dcca239612c
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>