### PR TITLE
refactor(ui): migrate all paginated surfaces to usePagedQuery + useTableState

### DIFF
--- a/ui/src/api/metrics.ts
+++ b/ui/src/api/metrics.ts
@@ -1,9 +1,10 @@
 import {
   MetricQueryPerformanceStatistics,
+  MetricMetadata,
   MetricStatistics,
+  MetricUsageItem,
   PagedResult,
 } from "@/lib/types";
-import { MetricMetadata } from "@/lib/types";
 import { toUTC } from "@/lib/utils/date-utils";
 
 interface SerieExpression {
@@ -18,18 +19,6 @@ interface SerieExpressionsResponse {
   data: SerieExpression[];
   total: number;
   totalPages: number;
-}
-
-interface MetricUsageResponse {
-  total: number;
-  totalPages: number;
-  data: Array<{
-    id?: string;
-    name: string;
-    url?: string;
-    groupName?: string;
-    expression?: string;
-  }>;
 }
 
 interface ApiConfig {
@@ -249,7 +238,7 @@ export async function getMetricUsage(
   pageSize: number = 10,
   from: string = "",
   to: string = "",
-): Promise<MetricUsageResponse> {
+): Promise<PagedResult<MetricUsageItem>> {
   const url = API_CONFIG.endpoints.metricUsage + `/${metricName}`;
   const params: Record<string, string | number> = { kind, page, pageSize };
 
@@ -261,7 +250,7 @@ export async function getMetricUsage(
   }
 
   return withErrorHandling(
-    () => fetchApiData<MetricUsageResponse>(url, params),
+    () => fetchApiData<PagedResult<MetricUsageItem>>(url, params),
     DEFAULT_ERROR_VALUES.metricUsage,
   );
 }

--- a/ui/src/app/metrics/index.tsx
+++ b/ui/src/app/metrics/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { MetricsExplorerHeader } from "@/components/metrics-explorer/metrics-explorer-header";
 import { MetricsTable } from "@/components/metrics-explorer/metrics-table";
 import { useSeriesMetadataTable } from "./use-metrics-data";
-import { TableState } from "@/lib/types";
+import { useTableState } from "@/hooks/use-table-state";
 import { LoadingState } from "./loading";
 import { useDebounce } from "@/hooks/use-debounce";
 
@@ -13,20 +13,22 @@ export default function MetricsExplorer() {
     "all",
   );
   const [producerFilter, setProducerFilter] = useState<string>("");
-  const [tableState, setTableState] = useState<TableState>({
-    page: 1,
-    pageSize: 10,
-    sortBy: "queryCount",
-    sortOrder: "desc",
-    filter: "",
-    type: "all",
+  const tableState = useTableState({
+    defaultSortBy: "queryCount",
+    defaultSortOrder: "desc",
   });
 
-  // Increase debounce delay to 750ms for better performance
   const debouncedSearchQuery = useDebounce(searchQuery, 750);
 
   const { data, isLoading, error } = useSeriesMetadataTable(
-    tableState,
+    {
+      page: tableState.page,
+      pageSize: tableState.pageSize,
+      sortBy: tableState.sortBy,
+      sortOrder: tableState.sortOrder,
+      filter: tableState.filter,
+      type: typeFilter,
+    },
     debouncedSearchQuery,
     usageFilter,
     producerFilter,
@@ -42,11 +44,7 @@ export default function MetricsExplorer() {
 
   const handleTypeFilterChange = (value: string) => {
     setTypeFilter(value);
-    setTableState((prev) => ({
-      ...prev,
-      page: 1, // Reset to first page when changing type
-      type: value,
-    }));
+    tableState.setPage(1);
   };
 
   return (
@@ -66,7 +64,6 @@ export default function MetricsExplorer() {
         metrics={data.metrics}
         searchQuery={debouncedSearchQuery}
         tableState={tableState}
-        onTableStateChange={setTableState}
       />
     </div>
   );

--- a/ui/src/app/metrics/use-metrics-data.test.ts
+++ b/ui/src/app/metrics/use-metrics-data.test.ts
@@ -1,0 +1,179 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useSeriesMetadataTable, useMetricUsage } from "./use-metrics-data";
+import * as metricsApi from "@/api/metrics";
+
+vi.mock("@/api/metrics");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+}
+
+const pagedMetrics = {
+  total: 2,
+  totalPages: 1,
+  data: [
+    { name: "up", type: "gauge", help: "", unit: "" },
+    { name: "scrape_duration_seconds", type: "gauge", help: "", unit: "" },
+  ],
+};
+
+const pagedUsage = {
+  total: 3,
+  totalPages: 1,
+  data: [
+    { name: "alert-rule-1", expression: "up == 0" },
+    { name: "alert-rule-2", expression: "rate(errors[5m]) > 0" },
+    { name: "alert-rule-3", expression: "up < 1" },
+  ],
+};
+
+describe("useSeriesMetadataTable", () => {
+  beforeEach(() => {
+    vi.mocked(metricsApi.getSeriesMetadata).mockResolvedValue(pagedMetrics);
+    vi.mocked(metricsApi.getProducers).mockResolvedValue([]);
+  });
+
+  it("calls getSeriesMetadata with page and pageSize from tableState", async () => {
+    const tableState = {
+      page: 2,
+      pageSize: 20,
+      sortBy: "queryCount",
+      sortOrder: "desc" as const,
+      filter: "",
+      type: "all",
+    };
+    const { result } = renderHook(
+      () => useSeriesMetadataTable(tableState),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(metricsApi.getSeriesMetadata).toHaveBeenCalledWith(
+      2, 20, "queryCount", "desc", "", "all", "all", undefined,
+    );
+  });
+
+  it("calls getSeriesMetadata with sortBy and sortOrder from tableState", async () => {
+    const tableState = {
+      page: 1,
+      pageSize: 10,
+      sortBy: "alertCount",
+      sortOrder: "asc" as const,
+      filter: "",
+      type: "gauge",
+    };
+    renderHook(() => useSeriesMetadataTable(tableState), { wrapper: makeWrapper() });
+    await waitFor(() =>
+      expect(metricsApi.getSeriesMetadata).toHaveBeenCalledWith(
+        1, 10, "alertCount", "asc", "", "gauge", "all", undefined,
+      ),
+    );
+  });
+
+  it("passes searchQuery as the filter argument", async () => {
+    const tableState = { page: 1, pageSize: 10, sortBy: "name", sortOrder: "asc" as const, filter: "", type: "all" };
+    renderHook(
+      () => useSeriesMetadataTable(tableState, "prom"),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() =>
+      expect(metricsApi.getSeriesMetadata).toHaveBeenCalledWith(
+        1, 10, "name", "asc", "prom", "all", "all", undefined,
+      ),
+    );
+  });
+
+  it("passes usage filter to getSeriesMetadata", async () => {
+    const tableState = { page: 1, pageSize: 10, sortBy: "name", sortOrder: "asc" as const, filter: "", type: "all" };
+    renderHook(
+      () => useSeriesMetadataTable(tableState, "", "unused"),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() =>
+      expect(metricsApi.getSeriesMetadata).toHaveBeenCalledWith(
+        1, 10, "name", "asc", "", "all", "unused", undefined,
+      ),
+    );
+  });
+
+  it("returns PagedResult data", async () => {
+    const tableState = { page: 1, pageSize: 10, sortBy: "name", sortOrder: "asc" as const, filter: "", type: "all" };
+    const { result } = renderHook(
+      () => useSeriesMetadataTable(tableState),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data.metrics?.total).toBe(2);
+    expect(result.current.data.metrics?.data).toHaveLength(2);
+    expect(result.current.data.metrics?.data[0].name).toBe("up");
+  });
+});
+
+describe("useMetricUsage", () => {
+  beforeEach(() => {
+    vi.mocked(metricsApi.getMetricUsage).mockResolvedValue(pagedUsage);
+  });
+
+  it("calls getMetricUsage with the right params", async () => {
+    const { result } = renderHook(
+      () => useMetricUsage("my_metric", "alert", 1, 10),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(metricsApi.getMetricUsage).toHaveBeenCalledWith(
+      "my_metric", "alert", 1, 10, "", "",
+    );
+  });
+
+  it("is disabled when metricName is empty", () => {
+    const { result } = renderHook(
+      () => useMetricUsage("", "alert"),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.isPending).toBe(true);
+    expect(metricsApi.getMetricUsage).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when kind is empty", () => {
+    const { result } = renderHook(
+      () => useMetricUsage("my_metric", ""),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.isPending).toBe(true);
+    expect(metricsApi.getMetricUsage).not.toHaveBeenCalled();
+  });
+
+  it("returns PagedResult data", async () => {
+    const { result } = renderHook(
+      () => useMetricUsage("my_metric", "record"),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.total).toBe(3);
+    expect(result.current.data?.data).toHaveLength(3);
+  });
+
+  it("re-fetches when page changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ page }: { page: number }) => useMetricUsage("my_metric", "alert", page, 10),
+      { wrapper: makeWrapper(), initialProps: { page: 1 } },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(metricsApi.getMetricUsage).toHaveBeenCalledWith("my_metric", "alert", 1, 10, "", "");
+
+    rerender({ page: 2 });
+    await waitFor(() =>
+      expect(metricsApi.getMetricUsage).toHaveBeenCalledWith("my_metric", "alert", 2, 10, "", ""),
+    );
+  });
+});

--- a/ui/src/app/metrics/use-metrics-data.test.ts
+++ b/ui/src/app/metrics/use-metrics-data.test.ts
@@ -53,13 +53,19 @@ describe("useSeriesMetadataTable", () => {
       filter: "",
       type: "all",
     };
-    const { result } = renderHook(
-      () => useSeriesMetadataTable(tableState),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useSeriesMetadataTable(tableState), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(metricsApi.getSeriesMetadata).toHaveBeenCalledWith(
-      2, 20, "queryCount", "desc", "", "all", "all", undefined,
+      2,
+      20,
+      "queryCount",
+      "desc",
+      "",
+      "all",
+      "all",
+      undefined,
     );
   });
 
@@ -72,46 +78,87 @@ describe("useSeriesMetadataTable", () => {
       filter: "",
       type: "gauge",
     };
-    renderHook(() => useSeriesMetadataTable(tableState), { wrapper: makeWrapper() });
+    renderHook(() => useSeriesMetadataTable(tableState), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() =>
       expect(metricsApi.getSeriesMetadata).toHaveBeenCalledWith(
-        1, 10, "alertCount", "asc", "", "gauge", "all", undefined,
+        1,
+        10,
+        "alertCount",
+        "asc",
+        "",
+        "gauge",
+        "all",
+        undefined,
       ),
     );
   });
 
   it("passes searchQuery as the filter argument", async () => {
-    const tableState = { page: 1, pageSize: 10, sortBy: "name", sortOrder: "asc" as const, filter: "", type: "all" };
-    renderHook(
-      () => useSeriesMetadataTable(tableState, "prom"),
-      { wrapper: makeWrapper() },
-    );
+    const tableState = {
+      page: 1,
+      pageSize: 10,
+      sortBy: "name",
+      sortOrder: "asc" as const,
+      filter: "",
+      type: "all",
+    };
+    renderHook(() => useSeriesMetadataTable(tableState, "prom"), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() =>
       expect(metricsApi.getSeriesMetadata).toHaveBeenCalledWith(
-        1, 10, "name", "asc", "prom", "all", "all", undefined,
+        1,
+        10,
+        "name",
+        "asc",
+        "prom",
+        "all",
+        "all",
+        undefined,
       ),
     );
   });
 
   it("passes usage filter to getSeriesMetadata", async () => {
-    const tableState = { page: 1, pageSize: 10, sortBy: "name", sortOrder: "asc" as const, filter: "", type: "all" };
-    renderHook(
-      () => useSeriesMetadataTable(tableState, "", "unused"),
-      { wrapper: makeWrapper() },
-    );
+    const tableState = {
+      page: 1,
+      pageSize: 10,
+      sortBy: "name",
+      sortOrder: "asc" as const,
+      filter: "",
+      type: "all",
+    };
+    renderHook(() => useSeriesMetadataTable(tableState, "", "unused"), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() =>
       expect(metricsApi.getSeriesMetadata).toHaveBeenCalledWith(
-        1, 10, "name", "asc", "", "all", "unused", undefined,
+        1,
+        10,
+        "name",
+        "asc",
+        "",
+        "all",
+        "unused",
+        undefined,
       ),
     );
   });
 
   it("returns PagedResult data", async () => {
-    const tableState = { page: 1, pageSize: 10, sortBy: "name", sortOrder: "asc" as const, filter: "", type: "all" };
-    const { result } = renderHook(
-      () => useSeriesMetadataTable(tableState),
-      { wrapper: makeWrapper() },
-    );
+    const tableState = {
+      page: 1,
+      pageSize: 10,
+      sortBy: "name",
+      sortOrder: "asc" as const,
+      filter: "",
+      type: "all",
+    };
+    const { result } = renderHook(() => useSeriesMetadataTable(tableState), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.data.metrics?.total).toBe(2);
     expect(result.current.data.metrics?.data).toHaveLength(2);
@@ -131,33 +178,35 @@ describe("useMetricUsage", () => {
     );
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(metricsApi.getMetricUsage).toHaveBeenCalledWith(
-      "my_metric", "alert", 1, 10, "", "",
+      "my_metric",
+      "alert",
+      1,
+      10,
+      "",
+      "",
     );
   });
 
   it("is disabled when metricName is empty", () => {
-    const { result } = renderHook(
-      () => useMetricUsage("", "alert"),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useMetricUsage("", "alert"), {
+      wrapper: makeWrapper(),
+    });
     expect(result.current.isPending).toBe(true);
     expect(metricsApi.getMetricUsage).not.toHaveBeenCalled();
   });
 
   it("is disabled when kind is empty", () => {
-    const { result } = renderHook(
-      () => useMetricUsage("my_metric", ""),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useMetricUsage("my_metric", ""), {
+      wrapper: makeWrapper(),
+    });
     expect(result.current.isPending).toBe(true);
     expect(metricsApi.getMetricUsage).not.toHaveBeenCalled();
   });
 
   it("returns PagedResult data", async () => {
-    const { result } = renderHook(
-      () => useMetricUsage("my_metric", "record"),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useMetricUsage("my_metric", "record"), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.total).toBe(3);
     expect(result.current.data?.data).toHaveLength(3);
@@ -165,15 +214,30 @@ describe("useMetricUsage", () => {
 
   it("re-fetches when page changes", async () => {
     const { result, rerender } = renderHook(
-      ({ page }: { page: number }) => useMetricUsage("my_metric", "alert", page, 10),
+      ({ page }: { page: number }) =>
+        useMetricUsage("my_metric", "alert", page, 10),
       { wrapper: makeWrapper(), initialProps: { page: 1 } },
     );
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(metricsApi.getMetricUsage).toHaveBeenCalledWith("my_metric", "alert", 1, 10, "", "");
+    expect(metricsApi.getMetricUsage).toHaveBeenCalledWith(
+      "my_metric",
+      "alert",
+      1,
+      10,
+      "",
+      "",
+    );
 
     rerender({ page: 2 });
     await waitFor(() =>
-      expect(metricsApi.getMetricUsage).toHaveBeenCalledWith("my_metric", "alert", 2, 10, "", ""),
+      expect(metricsApi.getMetricUsage).toHaveBeenCalledWith(
+        "my_metric",
+        "alert",
+        2,
+        10,
+        "",
+        "",
+      ),
     );
   });
 });

--- a/ui/src/app/metrics/use-metrics-data.ts
+++ b/ui/src/app/metrics/use-metrics-data.ts
@@ -13,10 +13,12 @@ import {
   MetricMetadata,
   MetricStatistics,
   MetricQueryPerformanceStatistics,
+  MetricUsageItem,
   QueryLatencyTrendsResult,
   DateRange,
 } from "@/lib/types";
 import { getQueryLatencyTrends } from "@/api/queries";
+import { usePagedQuery } from "@/hooks/use-paged-query";
 
 interface MetricsData {
   metrics: PagedResult<MetricMetadata> | undefined;
@@ -25,18 +27,6 @@ interface MetricsData {
 
 interface MetricStatisticsData {
   statistics: MetricStatistics | undefined;
-}
-
-interface MetricUsageResponse {
-  total: number;
-  totalPages: number;
-  data: Array<{
-    id?: string;
-    name: string;
-    url?: string;
-    groupName?: string;
-    expression?: string;
-  }>;
 }
 
 export function useSeriesMetadataTable(
@@ -49,9 +39,9 @@ export function useSeriesMetadataTable(
     data: metrics,
     isLoading,
     error,
-  } = useQuery<PagedResult<MetricMetadata>>({
-    queryKey: ["metrics", tableState, searchQuery, usage, job],
-    queryFn: () =>
+  } = usePagedQuery<MetricMetadata>(
+    ["metrics", tableState, searchQuery, usage, job],
+    () =>
       getSeriesMetadata(
         tableState?.page || 1,
         tableState?.pageSize || 10,
@@ -62,7 +52,7 @@ export function useSeriesMetadataTable(
         usage || "all",
         job,
       ),
-  });
+  );
 
   const { data: producers } = useQuery<string[]>({
     queryKey: ["producers"],
@@ -155,20 +145,11 @@ export function useMetricUsage(
   const fromParam = from ? from.toISOString() : "";
   const toParam = to ? to.toISOString() : "";
 
-  return useQuery<MetricUsageResponse, Error>({
-    queryKey: [
-      "metric-usage",
-      metricName,
-      kind,
-      page,
-      pageSize,
-      fromParam,
-      toParam,
-    ],
-    queryFn: () =>
-      getMetricUsage(metricName, kind, page, pageSize, fromParam, toParam),
-    enabled: !!metricName && !!kind,
-  });
+  return usePagedQuery<MetricUsageItem>(
+    ["metric-usage", metricName, kind, page, pageSize, fromParam, toParam],
+    () => getMetricUsage(metricName, kind, page, pageSize, fromParam, toParam),
+    { enabled: !!metricName && !!kind },
+  );
 }
 
 export function useSerieExpressions(

--- a/ui/src/app/queries/index.tsx
+++ b/ui/src/app/queries/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { usePagedQuery } from "@/hooks/use-paged-query";
 import { Input } from "@/components/ui/input";
 import { DataTable, DataTableColumnHeader } from "@/components/data-table";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
@@ -7,7 +7,7 @@ import { useDateRange } from "@/contexts/date-range";
 import { useDebounce } from "@/hooks/use-debounce";
 import { getQueryExpressions } from "@/api/queries";
 import { LoadingState } from "./loading";
-import type { PagedResult, QueryExpression } from "@/lib/types";
+import type { QueryExpression } from "@/lib/types";
 import {
   Sheet,
   SheetContent,
@@ -109,8 +109,8 @@ export default function QueriesPage() {
     setPage(page);
   };
 
-  const { data, isLoading } = useQuery<PagedResult<QueryExpression>>({
-    queryKey: [
+  const { data, isLoading } = usePagedQuery<QueryExpression>(
+    [
       "queryExpressions",
       fromISO,
       toISO,
@@ -120,7 +120,7 @@ export default function QueriesPage() {
       sorting[0]?.desc ? "desc" : "asc",
       debouncedSearch,
     ],
-    queryFn: () =>
+    () =>
       getQueryExpressions(
         fromISO,
         toISO,
@@ -130,8 +130,8 @@ export default function QueriesPage() {
         sorting[0]?.desc ? "desc" : "asc",
         debouncedSearch,
       ),
-    enabled: Boolean(fromISO && toISO),
-  });
+    { enabled: Boolean(fromISO && toISO) },
+  );
 
   const parsedSelectedQuery = useMemo(() => {
     if (!selectedQuery) return null;

--- a/ui/src/components/metrics-explorer/metric-usage.test.tsx
+++ b/ui/src/components/metrics-explorer/metric-usage.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { useTableState } from "@/hooks/use-table-state";
+
+describe("tab pagination state (useTableState)", () => {
+  it("resets page to 1 when filter changes", () => {
+    const { result } = renderHook(() => useTableState({ defaultPage: 5 }));
+    act(() => result.current.setFilter("cpu"));
+    expect(result.current.page).toBe(1);
+  });
+
+  it("resets page to 1 when sort column changes via setSorting", () => {
+    const { result } = renderHook(() => useTableState({ defaultPage: 5 }));
+    act(() => result.current.setSorting([{ id: "name", desc: false }]));
+    expect(result.current.page).toBe(1);
+  });
+
+  it("resets page to 1 when sort column changes via setSort", () => {
+    const { result } = renderHook(() => useTableState({ defaultPage: 5 }));
+    act(() => result.current.setSort("name", "asc"));
+    expect(result.current.page).toBe(1);
+  });
+
+  it("preserves page when only the page number changes", () => {
+    const { result } = renderHook(() => useTableState({ defaultPage: 1 }));
+    act(() => result.current.setPage(4));
+    expect(result.current.page).toBe(4);
+  });
+
+  it("initialises sorting state from defaultSortBy and defaultSortOrder", () => {
+    const { result } = renderHook(() =>
+      useTableState({ defaultSortBy: "avgDuration", defaultSortOrder: "desc" }),
+    );
+    expect(result.current.sorting).toEqual([{ id: "avgDuration", desc: true }]);
+    expect(result.current.sortBy).toBe("avgDuration");
+    expect(result.current.sortOrder).toBe("desc");
+  });
+});

--- a/ui/src/components/metrics-explorer/metric-usage.tsx
+++ b/ui/src/components/metrics-explorer/metric-usage.tsx
@@ -10,6 +10,7 @@ import { DataTable, DataTableColumnHeader } from "@/components/data-table";
 import { ColumnDef, SortingState } from "@tanstack/react-table";
 import { DateRange } from "@/lib/types";
 import { formatUnit } from "@/lib/utils";
+import { useTableState } from "@/hooks/use-table-state";
 
 // Define our extended column type with maxWidth
 type ExtendedColumnDef<TData, TValue = unknown> = ColumnDef<TData, TValue> & {
@@ -36,66 +37,6 @@ interface MetricUsageItem {
   url?: string;
   groupName?: string;
   expression?: string;
-}
-
-// Define a generic type for tab state
-interface TabState {
-  page: number;
-  filter: string;
-  sorting: SortingState;
-  sortBy?: string;
-  sortOrder?: "asc" | "desc";
-}
-
-// Custom hook for managing tab state
-function useTabState(
-  initialPage = 1,
-  initialSortBy = "avgDuration",
-  initialSortOrder: "asc" | "desc" = "desc",
-) {
-  const [state, setState] = React.useState<TabState>({
-    page: initialPage,
-    filter: "",
-    sorting: initialSortBy
-      ? [{ id: initialSortBy, desc: initialSortOrder === "desc" }]
-      : [],
-    sortBy: initialSortBy,
-    sortOrder: initialSortOrder,
-  });
-
-  const setPage = (page: number) => {
-    setState((prev) => ({ ...prev, page }));
-  };
-
-  const setFilter = (filter: string) => {
-    setState((prev) => ({ ...prev, filter, page: 1 })); // Reset to first page on filter change
-  };
-
-  const setSorting = (newSorting: SortingState) => {
-    if (newSorting.length > 0) {
-      const column = newSorting[0].id;
-      const direction = newSorting[0].desc ? "desc" : "asc";
-
-      setState((prev) => ({
-        ...prev,
-        sorting: newSorting,
-        sortBy: column,
-        sortOrder: direction,
-      }));
-    } else {
-      setState((prev) => ({
-        ...prev,
-        sorting: newSorting,
-      }));
-    }
-  };
-
-  return {
-    ...state,
-    setPage,
-    setFilter,
-    setSorting,
-  };
 }
 
 // Define column configurations
@@ -219,7 +160,7 @@ interface TabContentProps<T> {
   error: unknown;
   data: { data: T[]; totalPages: number } | undefined;
   columns: ColumnDef<T, unknown>[];
-  state: TabState;
+  state: { page: number; filter: string; sorting: SortingState };
   searchColumn: string;
   pageSize: number;
   onSortingChange: (sorting: SortingState) => void;
@@ -289,11 +230,10 @@ export default function MetricUsage({
 }: MetricUsageProps) {
   const pageSize = 10;
 
-  // Initialize tab states using the custom hook
-  const queriesState = useTabState(1, "avgDuration", "desc");
-  const alertsState = useTabState(1);
-  const recordingsState = useTabState(1);
-  const dashboardsState = useTabState(1);
+  const queriesState = useTableState({ defaultSortBy: "avgDuration", defaultSortOrder: "desc" });
+  const alertsState = useTableState();
+  const recordingsState = useTableState();
+  const dashboardsState = useTableState();
 
   // Fetch data for queries tab
   const {

--- a/ui/src/components/metrics-explorer/metric-usage.tsx
+++ b/ui/src/components/metrics-explorer/metric-usage.tsx
@@ -230,7 +230,10 @@ export default function MetricUsage({
 }: MetricUsageProps) {
   const pageSize = 10;
 
-  const queriesState = useTableState({ defaultSortBy: "avgDuration", defaultSortOrder: "desc" });
+  const queriesState = useTableState({
+    defaultSortBy: "avgDuration",
+    defaultSortOrder: "desc",
+  });
   const alertsState = useTableState();
   const recordingsState = useTableState();
   const dashboardsState = useTableState();

--- a/ui/src/components/metrics-explorer/metrics-table.tsx
+++ b/ui/src/components/metrics-explorer/metrics-table.tsx
@@ -4,7 +4,8 @@ import * as React from "react";
 import { type ColumnDef, SortingState } from "@tanstack/react-table";
 import { MetricTypeTag } from "@/components/metrics-explorer/metric-type-tag";
 import { useLocation } from "wouter";
-import { MetricMetadata, PagedResult, TableState } from "@/lib/types";
+import { MetricMetadata, PagedResult } from "@/lib/types";
+import { UseTableStateResult } from "@/hooks/use-table-state";
 import { fromUTC } from "@/lib/utils/date-utils";
 import { DataTable, DataTableColumnHeader } from "@/components/data-table";
 import { ROUTES } from "@/lib/routes";
@@ -12,30 +13,24 @@ import { ROUTES } from "@/lib/routes";
 interface MetricsTableProps {
   metrics?: PagedResult<MetricMetadata>;
   searchQuery: string;
-  tableState: TableState;
-  onTableStateChange: (state: TableState) => void;
+  tableState: UseTableStateResult;
 }
 
 export function MetricsTable({
   metrics,
   searchQuery,
   tableState,
-  onTableStateChange,
 }: MetricsTableProps) {
   const [, setLocation] = useLocation();
   const prevSearchRef = React.useRef(searchQuery);
 
-  // Update filter when search query changes
+  // Sync external search query into table state (resets page via setFilter)
   React.useEffect(() => {
     if (prevSearchRef.current !== searchQuery) {
       prevSearchRef.current = searchQuery;
-      onTableStateChange({
-        ...tableState,
-        filter: searchQuery,
-        page: 1, // Reset to first page only when search changes
-      });
+      tableState.setFilter(searchQuery);
     }
-  }, [searchQuery, tableState, onTableStateChange]);
+  }, [searchQuery, tableState]);
 
   const handleMetricClick = (metricName: string) => {
     // Use the route path from ROUTES constant, replacing the parameter with the actual value
@@ -46,42 +41,18 @@ export function MetricsTable({
     setLocation(detailsPath);
   };
 
-  // Initialize sorting state from tableState
-  const sortingState: SortingState = React.useMemo(() => {
-    return tableState.sortBy
-      ? [
-          {
-            id: tableState.sortBy,
-            desc: tableState.sortOrder === "desc",
-          },
-        ]
-      : [];
-  }, [tableState.sortBy, tableState.sortOrder]);
+  const sortingState = tableState.sorting;
 
-  // Handler functions for DataTable callbacks
   const handleSortingChange = (newSorting: SortingState) => {
-    if (newSorting.length > 0) {
-      onTableStateChange({
-        ...tableState,
-        sortBy: newSorting[0].id,
-        sortOrder: newSorting[0].desc ? "desc" : "asc",
-      });
-    }
+    tableState.setSorting(newSorting);
   };
 
   const handleFilterChange = (value: string) => {
-    onTableStateChange({
-      ...tableState,
-      filter: value,
-      page: 1, // Reset to first page on filter change
-    });
+    tableState.setFilter(value);
   };
 
   const handlePaginationChange = (page: number) => {
-    onTableStateChange({
-      ...tableState,
-      page,
-    });
+    tableState.setPage(page);
   };
 
   const columns: ColumnDef<MetricMetadata>[] = [

--- a/ui/src/components/query-details/table.tsx
+++ b/ui/src/components/query-details/table.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { usePagedQuery } from "@/hooks/use-paged-query";
 import { DataTable, DataTableColumnHeader } from "@/components/data-table";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { useDateRange } from "@/contexts/date-range";
 import { getQueryExecutions } from "@/api/queries";
-import type { PagedResult, QueryExecution } from "@/lib/types";
+import type { QueryExecution } from "@/lib/types";
 import { formatUTCtoLocal } from "@/lib/utils/date-utils";
 import { Badge } from "@/components/ui/badge";
 import { formatUnit } from "@/lib/utils";
@@ -395,8 +395,8 @@ export const QueryExecutions: React.FC<Props> = ({ fingerprint }) => {
     [sorting],
   );
 
-  const { data, isLoading } = useQuery<PagedResult<QueryExecution>>({
-    queryKey: [
+  const { data, isLoading } = usePagedQuery<QueryExecution>(
+    [
       "queryExecutions",
       fingerprint,
       fromISO,
@@ -406,7 +406,7 @@ export const QueryExecutions: React.FC<Props> = ({ fingerprint }) => {
       serverSortBy,
       sortOrder,
     ],
-    queryFn: () =>
+    () =>
       getQueryExecutions(
         fingerprint || "",
         fromISO,
@@ -417,8 +417,8 @@ export const QueryExecutions: React.FC<Props> = ({ fingerprint }) => {
         sortOrder,
         "all",
       ),
-    enabled: Boolean(fingerprint),
-  });
+    { enabled: Boolean(fingerprint) },
+  );
 
   if (isLoading) {
     return <div className="p-2 text-sm text-muted-foreground">Loading...</div>;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -56,6 +56,14 @@ export interface PagedResult<T> {
   data: T[];
 }
 
+export interface MetricUsageItem {
+  id?: string;
+  name: string;
+  url?: string;
+  groupName?: string;
+  expression?: string;
+}
+
 export type TimeGranularity = "15m" | "30m" | "1h" | "1d";
 
 export interface TimeRange {


### PR DESCRIPTION
Every surface that fetched a PagedResult now goes through usePagedQuery,
giving a single seam to wire the count/data split in a later commit.
State management is aligned to useTableState across the board.

Changes:
- types.ts: add MetricUsageItem (was duplicated in 3 files)
- api/metrics.ts: consolidate MetricUsageResponse → PagedResult<MetricUsageItem>
- use-metrics-data.ts: useSeriesMetadataTable + useMetricUsage use usePagedQuery
- queries/index.tsx, query-details/table.tsx: useQuery → usePagedQuery
- metrics/index.tsx: useState<TableState> → useTableState; type filter kept
  as separate useState since it is not a pagination concern
- metrics-table.tsx: accepts UseTableStateResult directly, removes
  onTableStateChange callback; handlers delegate to tableState setters
- metric-usage.tsx: removes local useTabState (which did not reset page on
  sort change); replaced by useTableState which enforces the invariant

Tests added before implementation (TDD):
- use-metrics-data.test.ts: params contract for useSeriesMetadataTable and
  useMetricUsage; enabled guard for empty metricName/kind
- metric-usage.test.tsx: tab state invariants — filter/sort changes reset
  page to 1; page-only changes are preserved

Change-Id: I6d5fef664ae50f06f551fc437dfc4ee840d02460
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>