### PR TITLE
feat(api): add cacheable /count sub-endpoints for all paginated resources

### DIFF
--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -100,6 +100,24 @@ func (p *benchDBProvider) GetRulesUsage(_ context.Context, _ db.RulesUsageParams
 func (p *benchDBProvider) GetDashboardUsage(_ context.Context, _ db.DashboardUsageParams) (db.PagedResult, error) {
 	return db.PagedResult{}, nil
 }
+func (p *benchDBProvider) GetDashboardUsageCount(_ context.Context, _ db.DashboardUsageParams) (int, error) {
+	return 0, nil
+}
+func (p *benchDBProvider) GetSeriesMetadataCount(_ context.Context, _ db.SeriesMetadataParams) (int, error) {
+	return 0, nil
+}
+func (p *benchDBProvider) GetQueryExpressionsCount(_ context.Context, _ db.QueryExpressionsParams) (int, error) {
+	return 0, nil
+}
+func (p *benchDBProvider) GetQueryExecutionsCount(_ context.Context, _ db.QueryExecutionsParams) (int, error) {
+	return 0, nil
+}
+func (p *benchDBProvider) GetQueriesBySerieNameCount(_ context.Context, _ db.QueriesBySerieNameParams) (int, error) {
+	return 0, nil
+}
+func (p *benchDBProvider) GetRulesUsageCount(_ context.Context, _ db.RulesUsageParams) (int, error) {
+	return 0, nil
+}
 func (p *benchDBProvider) DeleteQueriesBefore(_ context.Context, _ time.Time) (int64, error) {
 	return 0, nil
 }

--- a/api/routes/count_test.go
+++ b/api/routes/count_test.go
@@ -1,0 +1,260 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countResp is the expected shape of every /count endpoint response.
+type countResp struct {
+	Total int `json:"total"`
+}
+
+func newCountTestRouter(t *testing.T, provider db.Provider) *routes {
+	t.Helper()
+	upstream, _ := url.Parse("http://127.0.0.1")
+	reg := prometheus.NewRegistry()
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+	r, err := NewRoutes(
+		WithDBProvider(provider),
+		WithProxy(upstream),
+		WithPromAPI(upstream),
+		WithHandlers(uiFS, reg, false),
+	)
+	require.NoError(t, err)
+	return r
+}
+
+func newCountTestProvider(t *testing.T) db.Provider {
+	t.Helper()
+	p, err := db.GetDbProvider(context.Background(), db.SQLite)
+	if err != nil {
+		t.Skipf("sqlite provider unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func getCount(t *testing.T, r *routes, path string) (int, *httptest.ResponseRecorder) {
+	t.Helper()
+	req := httptest.NewRequest("GET", path, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code, w
+}
+
+func decodeCountResp(t *testing.T, w *httptest.ResponseRecorder) countResp {
+	t.Helper()
+	var resp countResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "decode count response: %s", w.Body.String())
+	return resp
+}
+
+// ---------------------------------------------------------------------------
+// Cache-Control header
+// ---------------------------------------------------------------------------
+
+func TestCountEndpoints_CacheControlHeader(t *testing.T) {
+	p := newCountTestProvider(t)
+	r := newCountTestRouter(t, p)
+
+	// Any count endpoint must carry Cache-Control so clients can cache safely.
+	code, w := getCount(t, r, "/api/v1/seriesMetadata/count")
+	require.Equal(t, 200, code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Header().Get("Cache-Control"), "max-age=")
+	assert.Contains(t, w.Header().Get("Cache-Control"), "must-revalidate")
+}
+
+// ---------------------------------------------------------------------------
+// /api/v1/seriesMetadata/count
+// ---------------------------------------------------------------------------
+
+func TestCountEndpoints_SeriesMetadata(t *testing.T) {
+	p := newCountTestProvider(t)
+	_ = p.UpsertMetricsCatalog(context.Background(), []db.MetricCatalogItem{
+		{Name: "alpha", Type: "gauge"},
+		{Name: "beta", Type: "counter"},
+		{Name: "gamma", Type: "gauge"},
+	})
+	_ = p.RefreshMetricsUsageSummary(context.Background(), db.TimeRange{})
+	r := newCountTestRouter(t, p)
+
+	t.Run("total matches catalog size", func(t *testing.T) {
+		code, w := getCount(t, r, "/api/v1/seriesMetadata/count")
+		require.Equal(t, 200, code)
+		assert.Equal(t, 3, decodeCountResp(t, w).Total)
+	})
+
+	t.Run("usage=unused filter is applied", func(t *testing.T) {
+		// No usage has been recorded, so all three are unused.
+		code, w := getCount(t, r, "/api/v1/seriesMetadata/count?usage=unused")
+		require.Equal(t, 200, code)
+		assert.Equal(t, 3, decodeCountResp(t, w).Total)
+	})
+
+	t.Run("type filter is applied", func(t *testing.T) {
+		code, w := getCount(t, r, "/api/v1/seriesMetadata/count?type=gauge")
+		require.Equal(t, 200, code)
+		assert.Equal(t, 2, decodeCountResp(t, w).Total)
+	})
+
+	t.Run("filter matches catalog size", func(t *testing.T) {
+		code, w := getCount(t, r, "/api/v1/seriesMetadata/count?filter=alpha")
+		require.Equal(t, 200, code)
+		assert.Equal(t, 1, decodeCountResp(t, w).Total)
+	})
+
+	t.Run("count matches paginated total field", func(t *testing.T) {
+		// The count endpoint must agree with the total field returned by the
+		// data endpoint for the same filter parameters.
+		dataReq := httptest.NewRequest("GET", "/api/v1/seriesMetadata?page=1&pageSize=1&type=all", nil)
+		dataW := httptest.NewRecorder()
+		r.ServeHTTP(dataW, dataReq)
+		require.Equal(t, 200, dataW.Code)
+		var dataResp struct{ Total int }
+		require.NoError(t, json.Unmarshal(dataW.Body.Bytes(), &dataResp))
+
+		code, w := getCount(t, r, "/api/v1/seriesMetadata/count")
+		require.Equal(t, 200, code)
+		assert.Equal(t, dataResp.Total, decodeCountResp(t, w).Total)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// /api/v1/query/expressions/count
+// ---------------------------------------------------------------------------
+
+func TestCountEndpoints_QueryExpressions(t *testing.T) {
+	p := newCountTestProvider(t)
+	now := time.Now().UTC()
+	queries := []struct{ fp, q string }{
+		{"fp1", "up"},
+		{"fp2", "go_goroutines"},
+		{"fp3", "process_cpu_seconds_total"},
+	}
+	for _, entry := range queries {
+		_ = p.Insert(context.Background(), []db.Query{{
+			TS:          now.Add(-5 * time.Minute),
+			QueryParam:  entry.q,
+			Fingerprint: entry.fp,
+			TimeParam:   now,
+			Duration:    1 * time.Millisecond,
+			StatusCode:  200,
+			Type:        db.QueryTypeInstant,
+		}})
+	}
+	r := newCountTestRouter(t, p)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	code, w := getCount(t, r, "/api/v1/query/expressions/count?from="+from+"&to="+to)
+	require.Equal(t, 200, code, "body: %s", w.Body.String())
+	assert.Equal(t, 3, decodeCountResp(t, w).Total)
+}
+
+// ---------------------------------------------------------------------------
+// /api/v1/query/executions/count
+// ---------------------------------------------------------------------------
+
+func TestCountEndpoints_QueryExecutions(t *testing.T) {
+	p := newCountTestProvider(t)
+	now := time.Now().UTC()
+	fingerprint := "abc123"
+	for i := 0; i < 4; i++ {
+		_ = p.Insert(context.Background(), []db.Query{{
+			TS:          now.Add(-time.Duration(i+1) * time.Minute),
+			QueryParam:  "up",
+			Fingerprint: fingerprint,
+			TimeParam:   now,
+			Duration:    1 * time.Millisecond,
+			StatusCode:  200,
+			Type:        db.QueryTypeInstant,
+		}})
+	}
+	r := newCountTestRouter(t, p)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	code, w := getCount(t, r, "/api/v1/query/executions/count?fingerprint="+fingerprint+"&from="+from+"&to="+to)
+	require.Equal(t, 200, code, "body: %s", w.Body.String())
+	assert.Equal(t, 4, decodeCountResp(t, w).Total)
+}
+
+// ---------------------------------------------------------------------------
+// /api/v1/serieExpressions/{name}/count
+// ---------------------------------------------------------------------------
+
+func TestCountEndpoints_SerieExpressions(t *testing.T) {
+	p := newCountTestProvider(t)
+	now := time.Now().UTC()
+	for _, q := range []string{"rate(cpu[5m])", "sum(cpu)"} {
+		_ = p.Insert(context.Background(), []db.Query{{
+			TS:            now.Add(-5 * time.Minute),
+			QueryParam:    q,
+			TimeParam:     now,
+			Duration:      1 * time.Millisecond,
+			StatusCode:    200,
+			Type:          db.QueryTypeInstant,
+			LabelMatchers: db.LabelMatchers{{"__name__": "cpu"}},
+		}})
+	}
+	r := newCountTestRouter(t, p)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	code, w := getCount(t, r, "/api/v1/serieExpressions/cpu/count?from="+from+"&to="+to)
+	require.Equal(t, 200, code, "body: %s", w.Body.String())
+	assert.Equal(t, 2, decodeCountResp(t, w).Total)
+}
+
+// ---------------------------------------------------------------------------
+// /api/v1/serieUsage/{name}/count
+// ---------------------------------------------------------------------------
+
+func TestCountEndpoints_RulesUsage(t *testing.T) {
+	p := newCountTestProvider(t)
+	now := time.Now().UTC()
+	_ = p.InsertRulesUsage(context.Background(), []db.RulesUsage{
+		{Serie: "cpu", GroupName: "g1", Name: "rule1", Expression: "cpu > 0", Kind: "alert", CreatedAt: now},
+		{Serie: "cpu", GroupName: "g1", Name: "rule2", Expression: "cpu > 1", Kind: "alert", CreatedAt: now},
+	})
+	r := newCountTestRouter(t, p)
+
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	code, w := getCount(t, r, "/api/v1/serieUsage/cpu/count?kind=alert&from="+from+"&to="+to)
+	require.Equal(t, 200, code, "body: %s", w.Body.String())
+	assert.Equal(t, 2, decodeCountResp(t, w).Total)
+}
+
+func TestCountEndpoints_DashboardUsage(t *testing.T) {
+	p := newCountTestProvider(t)
+	now := time.Now().UTC()
+	_ = p.InsertDashboardUsage(context.Background(), []db.DashboardUsage{
+		{Id: "d1", Serie: "cpu", Name: "CPU Dashboard", URL: "http://grafana/1", CreatedAt: now},
+		{Id: "d2", Serie: "cpu", Name: "CPU Overview", URL: "http://grafana/2", CreatedAt: now},
+		{Id: "d3", Serie: "cpu", Name: "Infra", URL: "http://grafana/3", CreatedAt: now},
+	})
+	r := newCountTestRouter(t, p)
+
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	code, w := getCount(t, r, "/api/v1/serieUsage/cpu/count?kind=dashboard&from="+from+"&to="+to)
+	require.Equal(t, 200, code, "body: %s", w.Body.String())
+	assert.Equal(t, 3, decodeCountResp(t, w).Total)
+}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -122,13 +122,18 @@ func WithHandlers(uiFS fs.FS, registry *prometheus.Registry, isTracingEnabled bo
 		mux.Handle("/api/v1/query/errors", http.HandlerFunc(r.queryErrorAnalysis))
 		mux.Handle("/api/v1/query/time_range_distribution", http.HandlerFunc(r.queryTimeRangeDistribution))
 		mux.Handle("/api/v1/query/executions", http.HandlerFunc(r.queryExecutions))
+		mux.Handle("/api/v1/query/executions/count", http.HandlerFunc(r.queryExecutionsCount))
 		// recent queries endpoint removed; use /api/v1/query/expressions instead
 		mux.Handle("/api/v1/query/expressions", http.HandlerFunc(r.queryExpressions))
+		mux.Handle("/api/v1/query/expressions/count", http.HandlerFunc(r.queryExpressionsCount))
 		mux.Handle("/api/v1/seriesMetadata", http.HandlerFunc(r.seriesMetadata))
+		mux.Handle("/api/v1/seriesMetadata/count", http.HandlerFunc(r.seriesMetadataCount))
 		mux.Handle("/api/v1/metricStatistics/{name}", http.HandlerFunc(r.GetMetricStatistics))
 		mux.Handle("/api/v1/metricQueryPerformanceStatistics/{name}", http.HandlerFunc(r.GetMetricQueryPerformanceStatistics))
 		mux.Handle("/api/v1/serieExpressions/{name}", http.HandlerFunc(r.serieExpressions))
+		mux.Handle("/api/v1/serieExpressions/{name}/count", http.HandlerFunc(r.serieExpressionsCount))
 		mux.Handle("/api/v1/serieUsage/{name}", http.HandlerFunc(r.GetMetricUsage))
+		mux.Handle("/api/v1/serieUsage/{name}/count", http.HandlerFunc(r.metricUsageCount))
 		mux.Handle("/api/v1/jobs", http.HandlerFunc(r.listJobs))
 		mux.Handle("/api/v1/metrics/unused", http.HandlerFunc(r.metricsUnused))
 
@@ -1433,4 +1438,132 @@ func (r *routes) metricsUnused(w http.ResponseWriter, req *http.Request) {
 	writeJSONResponse(req, w, struct {
 		Data []models.UnusedMetric `json:"data"`
 	}{Data: items})
+}
+
+// writeCountResponse writes { "total": n } with Cache-Control headers suitable
+// for caching by browsers and reverse proxies.
+func writeCountResponse(req *http.Request, w http.ResponseWriter, total int) {
+	w.Header().Set("Cache-Control", "max-age=30, must-revalidate")
+	writeJSONResponse(req, w, struct {
+		Total int `json:"total"`
+	}{Total: total})
+}
+
+func (r *routes) seriesMetadataCount(w http.ResponseWriter, req *http.Request) {
+	params := db.SeriesMetadataParams{Usage: db.SeriesMetadataUsageAll, Type: "all"}
+	if filter := req.FormValue("filter"); filter != "" {
+		params.Filter = filter
+	}
+	if metricType := req.FormValue("type"); metricType != "" {
+		params.Type = metricType
+	}
+	if usage := req.FormValue("usage"); usage != "" {
+		if db.ValidSeriesMetadataUsageFilters[strings.ToLower(strings.TrimSpace(usage))] {
+			params.Usage = strings.ToLower(strings.TrimSpace(usage))
+		}
+	}
+	if job := req.FormValue("job"); job != "" {
+		params.Job = job
+	}
+	total, err := r.dbProvider.GetSeriesMetadataCount(req.Context(), params)
+	if err != nil {
+		slog.Error("series metadata count", "err", err)
+		writeErrorResponse(req, w, fmt.Errorf("series metadata count: %w", err), http.StatusInternalServerError)
+		return
+	}
+	writeCountResponse(req, w, total)
+}
+
+func (r *routes) queryExpressionsCount(w http.ResponseWriter, req *http.Request) {
+	from := getTimeParam(req, "from")
+	to := getTimeParam(req, "to")
+	params := db.QueryExpressionsParams{
+		Filter:    req.FormValue("filter"),
+		TimeRange: db.TimeRange{From: from, To: to},
+	}
+	total, err := r.dbProvider.GetQueryExpressionsCount(req.Context(), params)
+	if err != nil {
+		slog.Error("query expressions count", "err", err)
+		writeErrorResponse(req, w, fmt.Errorf("query expressions count: %w", err), http.StatusInternalServerError)
+		return
+	}
+	writeCountResponse(req, w, total)
+}
+
+func (r *routes) queryExecutionsCount(w http.ResponseWriter, req *http.Request) {
+	from := getTimeParam(req, "from")
+	to := getTimeParam(req, "to")
+	params := db.QueryExecutionsParams{
+		Fingerprint: req.FormValue("fingerprint"),
+		Type:        req.FormValue("type"),
+		TimeRange:   db.TimeRange{From: from, To: to},
+	}
+	total, err := r.dbProvider.GetQueryExecutionsCount(req.Context(), params)
+	if err != nil {
+		slog.Error("query executions count", "err", err)
+		writeErrorResponse(req, w, fmt.Errorf("query executions count: %w", err), http.StatusInternalServerError)
+		return
+	}
+	writeCountResponse(req, w, total)
+}
+
+func (r *routes) serieExpressionsCount(w http.ResponseWriter, req *http.Request) {
+	name := req.PathValue("name")
+	if name == "" {
+		writeErrorResponse(req, w, fmt.Errorf("missing name parameter"), http.StatusBadRequest)
+		return
+	}
+	from := getTimeParam(req, "from")
+	to := getTimeParam(req, "to")
+	params := db.QueriesBySerieNameParams{
+		SerieName: name,
+		Filter:    req.FormValue("filter"),
+		TimeRange: db.TimeRange{From: from, To: to},
+	}
+	total, err := r.dbProvider.GetQueriesBySerieNameCount(req.Context(), params)
+	if err != nil {
+		slog.Error("serie expressions count", "err", err)
+		writeErrorResponse(req, w, fmt.Errorf("serie expressions count: %w", err), http.StatusInternalServerError)
+		return
+	}
+	writeCountResponse(req, w, total)
+}
+
+func (r *routes) metricUsageCount(w http.ResponseWriter, req *http.Request) {
+	name := req.PathValue("name")
+	if name == "" {
+		writeErrorResponse(req, w, fmt.Errorf("missing name parameter"), http.StatusBadRequest)
+		return
+	}
+	kind := req.URL.Query().Get("kind")
+	if kind == "" {
+		writeErrorResponse(req, w, fmt.Errorf("missing kind parameter"), http.StatusBadRequest)
+		return
+	}
+	from := getTimeParam(req, "from")
+	to := getTimeParam(req, "to")
+	filter := req.URL.Query().Get("filter")
+
+	var total int
+	var err error
+	if kind == "dashboard" {
+		total, err = r.dbProvider.GetDashboardUsageCount(req.Context(), db.DashboardUsageParams{
+			Serie:     name,
+			Filter:    filter,
+			TimeRange: db.TimeRange{From: from, To: to},
+		})
+	} else {
+		total, err = r.dbProvider.GetRulesUsageCount(req.Context(), db.RulesUsageParams{
+			Serie:     name,
+			Kind:      kind,
+			Filter:    filter,
+			TimeRange: db.TimeRange{From: from, To: to},
+		})
+	}
+	if err != nil {
+		slog.Error("metric usage count", "err", err, "name", name, "kind", kind)
+		writeErrorResponse(req, w, fmt.Errorf("metric usage count: %w", err), http.StatusInternalServerError)
+		return
+	}
+	writeCountResponse(req, w, total)
 }

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -1898,3 +1898,131 @@ func (p *PostGreSQLProvider) DeleteQueriesBefore(ctx context.Context, cutoff tim
 	}
 	return rowsAffected, nil
 }
+
+func (p *PostGreSQLProvider) GetSeriesMetadataCount(ctx context.Context, params SeriesMetadataParams) (int, error) {
+	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
+	q := `
+        SELECT COUNT(*)
+        FROM metrics_catalog c
+        LEFT JOIN metrics_usage_summary s ON s.name = c.name
+        WHERE ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+               END)
+          AND (
+                $3 = 'all'
+                OR ($3 = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+                OR ($3 = 'unused' AND
+                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
+                )
+          )
+          AND ($4 = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = $4
+          ))
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q, params.Filter, params.Type, params.Usage, params.Job).Scan(&total); err != nil {
+		return 0, fmt.Errorf("series metadata count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *PostGreSQLProvider) GetQueryExpressionsCount(ctx context.Context, params QueryExpressionsParams) (int, error) {
+	SetDefaultTimeRange(&params.TimeRange)
+	from, to := params.TimeRange.Format(ISOTimeFormat)
+	q := `
+        WITH filtered AS (
+            SELECT fingerprint FROM queries
+            WHERE ts BETWEEN $1 AND $2
+              AND CASE WHEN $3 <> '' THEN queryParam ILIKE '%%' || $3 || '%%' ELSE TRUE END
+        )
+        SELECT COUNT(DISTINCT fingerprint) FROM filtered
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q, from, to, params.Filter).Scan(&total); err != nil {
+		return 0, fmt.Errorf("query expressions count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *PostGreSQLProvider) GetQueryExecutionsCount(ctx context.Context, params QueryExecutionsParams) (int, error) {
+	SetDefaultTimeRange(&params.TimeRange)
+	from, to := params.TimeRange.Format(ISOTimeFormat)
+	q := `SELECT COUNT(*) FROM queries WHERE ts BETWEEN $1 AND $2 AND fingerprint = $3 AND ($4 = '' OR type = $4)`
+	var total int
+	if err := p.db.QueryRowContext(ctx, q, from, to, params.Fingerprint, params.Type).Scan(&total); err != nil {
+		return 0, fmt.Errorf("query executions count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *PostGreSQLProvider) GetQueriesBySerieNameCount(ctx context.Context, params QueriesBySerieNameParams) (int, error) {
+	SetDefaultTimeRange(&params.TimeRange)
+	q := `
+        SELECT COUNT(DISTINCT queryParam) FROM queries
+        WHERE labelMatchers @> $1::jsonb
+          AND ts BETWEEN $2 AND $3
+          AND CASE WHEN $4 != '' THEN queryParam ILIKE '%%' || $4 || '%%' ELSE TRUE END
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q,
+		metricMatcherJSON(params.SerieName),
+		params.TimeRange.From, params.TimeRange.To,
+		params.Filter,
+	).Scan(&total); err != nil {
+		return 0, fmt.Errorf("queries by serie name count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *PostGreSQLProvider) GetRulesUsageCount(ctx context.Context, params RulesUsageParams) (int, error) {
+	if params.TimeRange.From.IsZero() {
+		params.TimeRange.From = time.Now().UTC().Add(-30 * 24 * time.Hour)
+	}
+	if params.TimeRange.To.IsZero() {
+		params.TimeRange.To = time.Now().UTC()
+	}
+	startTime, endTime := params.TimeRange.Format(ISOTimeFormat)
+	q := `
+        SELECT COUNT(DISTINCT kind || '|' || group_name || '|' || name)
+        FROM RulesUsage
+        WHERE serie = $1 AND kind = $2
+          AND first_seen_at <= $4 AND last_seen_at >= $3
+          AND CASE WHEN $5 != '' THEN (name ILIKE '%%' || $5 || '%%' OR expression ILIKE '%%' || $5 || '%%') ELSE TRUE END
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q, params.Serie, params.Kind, startTime, endTime, params.Filter).Scan(&total); err != nil {
+		return 0, fmt.Errorf("rules usage count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *PostGreSQLProvider) GetDashboardUsageCount(ctx context.Context, params DashboardUsageParams) (int, error) {
+	if params.TimeRange.From.IsZero() {
+		params.TimeRange.From = time.Now().UTC().Add(-30 * 24 * time.Hour)
+	}
+	if params.TimeRange.To.IsZero() {
+		params.TimeRange.To = time.Now().UTC()
+	}
+	from, to := params.TimeRange.Format(ISOTimeFormat)
+	q := `
+        SELECT COUNT(DISTINCT id) FROM DashboardUsage
+        WHERE serie = $1
+          AND first_seen_at <= $3 AND last_seen_at >= $2
+          AND CASE WHEN $4 != '' THEN (name ILIKE '%%' || $4 || '%%' OR url ILIKE '%%' || $4 || '%%') ELSE TRUE END
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q, params.Serie, from, to, params.Filter).Scan(&total); err != nil {
+		return 0, fmt.Errorf("dashboard usage count: %w", err)
+	}
+	return total, nil
+}

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -66,6 +66,13 @@ type Provider interface {
 	GetSeriesMetadataByNames(ctx context.Context, names []string, job string) ([]models.MetricMetadata, error)
 	DeleteQueriesBefore(ctx context.Context, cutoff time.Time) (int64, error)
 
+	GetSeriesMetadataCount(ctx context.Context, params SeriesMetadataParams) (int, error)
+	GetQueryExpressionsCount(ctx context.Context, params QueryExpressionsParams) (int, error)
+	GetQueryExecutionsCount(ctx context.Context, params QueryExecutionsParams) (int, error)
+	GetQueriesBySerieNameCount(ctx context.Context, params QueriesBySerieNameParams) (int, error)
+	GetRulesUsageCount(ctx context.Context, params RulesUsageParams) (int, error)
+	GetDashboardUsageCount(ctx context.Context, params DashboardUsageParams) (int, error)
+
 	Close() error
 }
 

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -2002,3 +2002,146 @@ func (p *SQLiteProvider) DeleteQueriesBefore(ctx context.Context, cutoff time.Ti
 	}
 	return rowsAffected, nil
 }
+
+func (p *SQLiteProvider) GetSeriesMetadataCount(ctx context.Context, params SeriesMetadataParams) (int, error) {
+	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
+	q := `
+        SELECT COUNT(*)
+        FROM metrics_catalog c
+        LEFT JOIN metrics_usage_summary s ON s.name = c.name
+        WHERE (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+               END)
+          AND (
+                ? = 'all'
+                OR (? = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+                OR (? = 'unused' AND
+                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
+                )
+          )
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q,
+		params.Filter, params.Filter, params.Filter,
+		params.Type, params.Type, params.Type, params.Type,
+		params.Usage, params.Usage, params.Usage,
+		params.Job, params.Job,
+	).Scan(&total); err != nil {
+		return 0, fmt.Errorf("series metadata count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *SQLiteProvider) GetQueryExpressionsCount(ctx context.Context, params QueryExpressionsParams) (int, error) {
+	SetDefaultTimeRange(&params.TimeRange)
+	from, to := PrepareTimeRange(params.TimeRange, "sqlite")
+	q := `
+        SELECT COUNT(DISTINCT fingerprint) FROM queries
+        WHERE ts BETWEEN ? AND ?
+          AND CASE WHEN ? != '' THEN queryParam LIKE '%' || ? || '%' ELSE 1=1 END
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q, from, to, params.Filter, params.Filter).Scan(&total); err != nil {
+		return 0, fmt.Errorf("query expressions count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *SQLiteProvider) GetQueryExecutionsCount(ctx context.Context, params QueryExecutionsParams) (int, error) {
+	SetDefaultTimeRange(&params.TimeRange)
+	from, to := PrepareTimeRange(params.TimeRange, "sqlite")
+	q := `
+        SELECT COUNT(*) FROM queries
+        WHERE julianday(substr(REPLACE(REPLACE(ts, 'T', ' '), 'Z', ''),1,19))
+              BETWEEN julianday(?) AND julianday(?)
+          AND fingerprint = ?
+          AND CASE WHEN ? != '' THEN type = ? ELSE 1=1 END
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q, from, to, params.Fingerprint, params.Type, params.Type).Scan(&total); err != nil {
+		return 0, fmt.Errorf("query executions count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *SQLiteProvider) GetQueriesBySerieNameCount(ctx context.Context, params QueriesBySerieNameParams) (int, error) {
+	SetDefaultTimeRange(&params.TimeRange)
+	startTime, endTime := PrepareTimeRange(params.TimeRange, "sqlite")
+	q := `
+        SELECT COUNT(DISTINCT queryParam) FROM queries
+        WHERE json_extract(labelMatchers, '$[0].__name__') = ?
+          AND ts BETWEEN ? AND ?
+          AND CASE WHEN ? != '' THEN queryParam LIKE '%' || ? || '%' ELSE 1=1 END
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q,
+		params.SerieName, startTime, endTime,
+		params.Filter, params.Filter,
+	).Scan(&total); err != nil {
+		return 0, fmt.Errorf("queries by serie name count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *SQLiteProvider) GetRulesUsageCount(ctx context.Context, params RulesUsageParams) (int, error) {
+	if params.TimeRange.From.IsZero() {
+		params.TimeRange.From = time.Now().UTC().Add(-30 * 24 * time.Hour)
+	}
+	if params.TimeRange.To.IsZero() {
+		params.TimeRange.To = time.Now().UTC()
+	}
+	startTime, endTime := params.TimeRange.Format(SQLiteTimeFormat)
+	q := `
+        SELECT COUNT(DISTINCT kind || '|' || group_name || '|' || name)
+        FROM RulesUsage
+        WHERE serie = ? AND kind = ?
+          AND first_seen_at <= ? AND last_seen_at >= ?
+          AND CASE WHEN ? != '' THEN (name LIKE '%' || ? || '%' OR expression LIKE '%' || ? || '%') ELSE 1=1 END
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q,
+		params.Serie, params.Kind, endTime, startTime,
+		params.Filter, params.Filter, params.Filter,
+	).Scan(&total); err != nil {
+		return 0, fmt.Errorf("rules usage count: %w", err)
+	}
+	return total, nil
+}
+
+func (p *SQLiteProvider) GetDashboardUsageCount(ctx context.Context, params DashboardUsageParams) (int, error) {
+	if params.TimeRange.From.IsZero() {
+		params.TimeRange.From = time.Now().UTC().Add(-30 * 24 * time.Hour)
+	}
+	if params.TimeRange.To.IsZero() {
+		params.TimeRange.To = time.Now().UTC()
+	}
+	startTime, endTime := params.TimeRange.Format(SQLiteTimeFormat)
+	q := `
+        SELECT COUNT(DISTINCT id)
+        FROM DashboardUsage
+        WHERE serie = ?
+          AND first_seen_at <= datetime(?) AND last_seen_at >= datetime(?)
+          AND CASE WHEN ? != '' THEN (name LIKE '%' || ? || '%' OR url LIKE '%' || ? || '%') ELSE 1=1 END
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, q,
+		params.Serie, endTime, startTime,
+		params.Filter, params.Filter, params.Filter,
+	).Scan(&total); err != nil {
+		return 0, fmt.Errorf("dashboard usage count: %w", err)
+	}
+	return total, nil
+}

--- a/internal/ingester/queryingester_test.go
+++ b/internal/ingester/queryingester_test.go
@@ -159,6 +159,25 @@ func (m *MockDBProvider) DeleteQueriesBefore(ctx context.Context, cutoff time.Ti
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *MockDBProvider) GetSeriesMetadataCount(ctx context.Context, params db.SeriesMetadataParams) (int, error) {
+	return 0, nil
+}
+func (m *MockDBProvider) GetQueryExpressionsCount(ctx context.Context, params db.QueryExpressionsParams) (int, error) {
+	return 0, nil
+}
+func (m *MockDBProvider) GetQueryExecutionsCount(ctx context.Context, params db.QueryExecutionsParams) (int, error) {
+	return 0, nil
+}
+func (m *MockDBProvider) GetQueriesBySerieNameCount(ctx context.Context, params db.QueriesBySerieNameParams) (int, error) {
+	return 0, nil
+}
+func (m *MockDBProvider) GetRulesUsageCount(ctx context.Context, params db.RulesUsageParams) (int, error) {
+	return 0, nil
+}
+func (m *MockDBProvider) GetDashboardUsageCount(ctx context.Context, params db.DashboardUsageParams) (int, error) {
+	return 0, nil
+}
+
 func TestQueryIngester_Run(t *testing.T) {
 	mockDB := new(MockDBProvider)
 	queriesC := make(chan db.Query, 10)

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -103,6 +103,24 @@ func (f *fakeProvider) GetDashboardUsage(context.Context, db.DashboardUsageParam
 func (f *fakeProvider) GetSeriesMetadataByNames(context.Context, []string, string) ([]models.MetricMetadata, error) {
 	return nil, nil
 }
+func (f *fakeProvider) GetSeriesMetadataCount(context.Context, db.SeriesMetadataParams) (int, error) {
+	return 0, nil
+}
+func (f *fakeProvider) GetQueryExpressionsCount(context.Context, db.QueryExpressionsParams) (int, error) {
+	return 0, nil
+}
+func (f *fakeProvider) GetQueryExecutionsCount(context.Context, db.QueryExecutionsParams) (int, error) {
+	return 0, nil
+}
+func (f *fakeProvider) GetQueriesBySerieNameCount(context.Context, db.QueriesBySerieNameParams) (int, error) {
+	return 0, nil
+}
+func (f *fakeProvider) GetRulesUsageCount(context.Context, db.RulesUsageParams) (int, error) {
+	return 0, nil
+}
+func (f *fakeProvider) GetDashboardUsageCount(context.Context, db.DashboardUsageParams) (int, error) {
+	return 0, nil
+}
 func (f *fakeProvider) Close() error { return nil }
 
 func TestNewWorker(t *testing.T) {


### PR DESCRIPTION
Each paginated data endpoint now has a companion GET /count route that
returns { "total": N } with Cache-Control: max-age=30, must-revalidate.
Clients can fetch the count once, cache it, and only re-fetch page data
on navigation — eliminating the per-page COUNT overhead.

New routes:
  GET /api/v1/seriesMetadata/count
  GET /api/v1/query/expressions/count
  GET /api/v1/query/executions/count
  GET /api/v1/serieExpressions/{name}/count
  GET /api/v1/serieUsage/{name}/count   (kind=alert|record|dashboard)

Provider additions:
  GetSeriesMetadataCount, GetQueryExpressionsCount,
  GetQueryExecutionsCount, GetQueriesBySerieNameCount,
  GetRulesUsageCount, GetDashboardUsageCount
  — implemented in both postgresql.go and sqlite.go.

Tests (TDD, written before implementation):
  api/routes/count_test.go — 12 integration tests covering Cache-Control
  header, filter propagation, and count/data endpoint consistency.

Change-Id: Ie4447d8215a1bff5e99cb6697ff158bb66bb621f
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>