### PR TITLE
feat(postgresql): add server-side statement_timeout option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,17 +51,18 @@ type ServerConfig struct {
 }
 
 type PostgreSQLConfig struct {
-	Addr            string        `yaml:"addr,omitempty"`
-	Database        string        `yaml:"database,omitempty"`
-	DialTimeout     time.Duration `yaml:"dial_timeout,omitempty"`
-	Password        string        `yaml:"password,omitempty"`
-	Port            int           `yaml:"port,omitempty"`
-	SSLMode         string        `yaml:"sslmode,omitempty"`
-	User            string        `yaml:"user,omitempty"`
-	MaxOpenConns    int           `yaml:"max_open_conns,omitempty"`
-	MaxIdleConns    int           `yaml:"max_idle_conns,omitempty"`
-	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime,omitempty"`
-	ConnMaxIdleTime time.Duration `yaml:"conn_max_idle_time,omitempty"`
+	Addr             string        `yaml:"addr,omitempty"`
+	Database         string        `yaml:"database,omitempty"`
+	DialTimeout      time.Duration `yaml:"dial_timeout,omitempty"`
+	Password         string        `yaml:"password,omitempty"`
+	Port             int           `yaml:"port,omitempty"`
+	SSLMode          string        `yaml:"sslmode,omitempty"`
+	User             string        `yaml:"user,omitempty"`
+	MaxOpenConns     int           `yaml:"max_open_conns,omitempty"`
+	MaxIdleConns     int           `yaml:"max_idle_conns,omitempty"`
+	ConnMaxLifetime  time.Duration `yaml:"conn_max_lifetime,omitempty"`
+	ConnMaxIdleTime  time.Duration `yaml:"conn_max_idle_time,omitempty"`
+	StatementTimeout time.Duration `yaml:"statement_timeout,omitempty"`
 }
 
 type SQLiteConfig struct {

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -49,13 +49,35 @@ func RegisterPostGreSQLFlags(flagSet *flag.FlagSet) {
 	flagSet.IntVar(&config.DefaultConfig.Database.PostgreSQL.MaxIdleConns, "postgresql-max-idle-conns", 0, "Maximum number of idle connections in the pool (0 = use default 10).")
 	flagSet.DurationVar(&config.DefaultConfig.Database.PostgreSQL.ConnMaxLifetime, "postgresql-conn-max-lifetime", 0, "Maximum amount of time a connection may be reused (0 = use default 30m).")
 	flagSet.DurationVar(&config.DefaultConfig.Database.PostgreSQL.ConnMaxIdleTime, "postgresql-conn-max-idle-time", 0, "Maximum amount of time a connection may be idle before being closed (0 = use default 5m).")
+	flagSet.DurationVar(&config.DefaultConfig.Database.PostgreSQL.StatementTimeout, "postgresql-statement-timeout", 0,
+		"Server-side per-statement timeout enforced by PostgreSQL on every pooled connection. "+
+			"When a single query exceeds this, PostgreSQL aborts it (SQLSTATE 57014) and frees the connection slot "+
+			"before the HTTP client can cancel it - useful as a load-shedder under saturation. "+
+			"Set just under the expected client per-call deadline (e.g. 4500ms when clients use 5s). 0 disables.")
 }
 
 func newPostGreSQLProvider(ctx context.Context) (Provider, error) {
 	postgresConfig := config.DefaultConfig.Database.PostgreSQL
 
+	// statement_timeout is set via the connection-string 'options' parameter
+	// so it takes effect on every connection the pool opens, with no
+	// per-checkout overhead. lib/pq preserves the space inside the single-
+	// quoted value, and postgres then parses '-c' and 'statement_timeout=...'
+	// as two separate command-line arguments at connection start.
+	// Round up to the nearest millisecond so a sub-ms configured duration
+	// doesn't silently truncate to 0, which PostgreSQL interprets as
+	// "disabled" - the opposite of the operator's intent.
+	statementTimeoutOpt := ""
+	if postgresConfig.StatementTimeout > 0 {
+		ms := (postgresConfig.StatementTimeout + time.Millisecond - 1) / time.Millisecond
+		statementTimeoutOpt = fmt.Sprintf(
+			" options='-c statement_timeout=%d'",
+			ms,
+		)
+	}
+
 	psqlInfo := fmt.Sprintf(
-		"host='%s' port=%d user='%s' password='%s' dbname='%s' sslmode='%s' connect_timeout=%d application_name=prom-analytics-proxy",
+		"host='%s' port=%d user='%s' password='%s' dbname='%s' sslmode='%s' connect_timeout=%d application_name=prom-analytics-proxy%s",
 		postgresConfig.Addr,
 		postgresConfig.Port,
 		postgresConfig.User,
@@ -63,6 +85,7 @@ func newPostGreSQLProvider(ctx context.Context) (Provider, error) {
 		postgresConfig.Database,
 		postgresConfig.SSLMode,
 		int(postgresConfig.DialTimeout.Seconds()),
+		statementTimeoutOpt,
 	)
 
 	db, err := otelsql.Open("postgres", psqlInfo, otelsql.WithAttributes(semconv.DBSystemPostgreSQL))

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -917,3 +917,33 @@ func TestPostgreSQLProvider_DeleteQueriesBefore(t *testing.T) {
 	assert.NoError(t, err, "count queries after cutoff")
 	assert.Equal(t, 2, remainingCount, "all remaining queries should be after cutoff")
 }
+
+func TestPostgreSQL_StatementTimeoutAborts(t *testing.T) {
+	// Configure a short server-side statement timeout BEFORE spinning the
+	// provider, so the helper's call to newPostGreSQLProvider picks it up
+	// and bakes it into the connection-string options.
+	config.DefaultConfig.Database.PostgreSQL.StatementTimeout = 500 * time.Millisecond
+	t.Cleanup(func() {
+		// Reset to zero so other tests sharing the global config aren't
+		// affected by this one's setting.
+		config.DefaultConfig.Database.PostgreSQL.StatementTimeout = 0
+	})
+
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	// Sanity: a fast query still succeeds.
+	var fast int
+	err := p.(*PostGreSQLProvider).db.QueryRowContext(context.Background(), "SELECT 1").Scan(&fast)
+	assert.NoError(t, err, "fast query under the budget should succeed")
+	assert.Equal(t, 1, fast)
+
+	// Now a query that deliberately sleeps past the configured timeout.
+	// PostgreSQL should abort it server-side with SQLSTATE 57014
+	// (query_canceled), surfaced by lib/pq with the canonical message
+	// "pq: canceling statement due to statement timeout".
+	_, err = p.(*PostGreSQLProvider).db.ExecContext(context.Background(), "SELECT pg_sleep(2)")
+	assert.Error(t, err, "query exceeding statement_timeout should fail")
+	assert.Contains(t, err.Error(), "statement timeout",
+		"error should identify the server-side timeout source")
+}


### PR DESCRIPTION
Give operators a server-side safety net for long-running PostgreSQL queries that can outlive their HTTP caller. Today, if a query hangs past the client deadline, the HTTP context is cancelled but the backend keeps churning and the connection slot stays pinned — under saturation this snowballs into
  pool exhaustion. A PostgreSQL-enforced `statement_timeout` cuts the query at the source, returns the slot, and turns a slow degradation into a fast, visible failure (SQLSTATE 57014).

  ## Summary

  - New `--postgresql-statement-timeout` flag / `statement_timeout` YAML field on `PostgreSQLConfig`. Default `0` (disabled) preserves existing behavior.
  - Threaded into the connection string via the `options='-c statement_timeout=…'` parameter so PostgreSQL applies it at connection startup for every pooled connection — no per-checkout `SET` round-trip, no application-side bookkeeping.
  - Sub-millisecond configured durations round **up** to 1ms so a non-zero value never silently truncates to `0` (which PostgreSQL interprets as "disabled" — the opposite of intent).
  - Integration test (`TestPostgreSQL_StatementTimeoutAborts`) covers both the fast-path success and the timeout-driven abort against a real PostgreSQL container.

  ## Operator guidance
  Set just below the expected client per-call deadline (e.g. `4500ms` when callers use a 5s deadline). Leaving headroom under the client deadline ensures the server aborts before the client gives up, so the failure mode is a clean cancelled-statement error rather than a stranded backend.
