### PR TITLE
refactor: Extract postgresql configuration into a parameter

### DIFF
--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -198,34 +198,29 @@ func startBenchPostgres(b *testing.B) (db.Provider, func()) {
 		_ = pgc.Terminate(ctx)
 		b.Fatalf("container port: %v", err)
 	}
-
-	prevDB := config.DefaultConfig.Database
-
-	config.DefaultConfig.Database.Provider = "postgresql"
-	config.DefaultConfig.Database.PostgreSQL.Addr = host
 	portNum, err := strconv.Atoi(port.Port())
 	if err != nil {
-		config.DefaultConfig.Database = prevDB
 		_ = pgc.Terminate(ctx)
 		b.Fatalf("parse port: %v", err)
 	}
-	config.DefaultConfig.Database.PostgreSQL.Port = portNum
-	config.DefaultConfig.Database.PostgreSQL.User = "testuser"
-	config.DefaultConfig.Database.PostgreSQL.Password = "testpass"
-	config.DefaultConfig.Database.PostgreSQL.Database = "testdb"
-	config.DefaultConfig.Database.PostgreSQL.SSLMode = "disable"
-	config.DefaultConfig.Database.PostgreSQL.DialTimeout = 5 * time.Second
 
-	prov, err := db.GetDbProvider(ctx, db.PostGreSQL)
+	pgCfg := config.PostgreSQLConfig{
+		Addr:        host,
+		Port:        portNum,
+		User:        "testuser",
+		Password:    "testpass",
+		Database:    "testdb",
+		SSLMode:     "disable",
+		DialTimeout: 5 * time.Second,
+	}
+	prov, err := db.NewPostgreSQLProvider(ctx, pgCfg)
 	if err != nil {
-		config.DefaultConfig.Database = prevDB
 		_ = pgc.Terminate(ctx)
 		b.Fatalf("db provider: %v", err)
 	}
 	return prov, func() {
 		_ = prov.Close()
 		_ = pgc.Terminate(ctx)
-		config.DefaultConfig.Database = prevDB
 	}
 }
 

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -56,9 +56,7 @@ func RegisterPostGreSQLFlags(flagSet *flag.FlagSet) {
 			"Set just under the expected client per-call deadline (e.g. 4500ms when clients use 5s). 0 disables.")
 }
 
-func newPostGreSQLProvider(ctx context.Context) (Provider, error) {
-	postgresConfig := config.DefaultConfig.Database.PostgreSQL
-
+func NewPostgreSQLProvider(ctx context.Context, postgresConfig config.PostgreSQLConfig) (Provider, error) {
 	// statement_timeout is set via the connection-string 'options' parameter
 	// so it takes effect on every connection the pool opens, with no
 	// per-checkout overhead. lib/pq preserves the space inside the single-
@@ -75,7 +73,6 @@ func newPostGreSQLProvider(ctx context.Context) (Provider, error) {
 			ms,
 		)
 	}
-
 	psqlInfo := fmt.Sprintf(
 		"host='%s' port=%d user='%s' password='%s' dbname='%s' sslmode='%s' connect_timeout=%d application_name=prom-analytics-proxy%s",
 		postgresConfig.Addr,

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -27,7 +27,7 @@ func newTestPostgreSQLProvider(t *testing.T) (Provider, func()) {
 		postgres.WithUsername("testuser"),
 		postgres.WithPassword("testpass"),
 		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").WithOccurrence(1).WithStartupTimeout(60*time.Second),
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second),
 		),
 	)
 	if err != nil {
@@ -42,20 +42,15 @@ func newTestPostgreSQLProvider(t *testing.T) (Provider, func()) {
 	portNum, err := strconv.Atoi(port.Port())
 	assert.NoError(t, err, "container port number")
 
-	// Configure config.DefaultConfig for provider.
-	config.DefaultConfig.Database.Provider = "postgresql"
-	config.DefaultConfig.Database.PostgreSQL.Addr = host
-	config.DefaultConfig.Database.PostgreSQL.Port = portNum
-	config.DefaultConfig.Database.PostgreSQL.User = "testuser"
-	config.DefaultConfig.Database.PostgreSQL.Password = "testpass"
-	config.DefaultConfig.Database.PostgreSQL.Database = "testdb"
-	config.DefaultConfig.Database.PostgreSQL.SSLMode = "disable"
-	config.DefaultConfig.Database.PostgreSQL.DialTimeout = 5 * time.Second
-
-	// Give PostgreSQL a moment to fully initialize after the ready log
-	time.Sleep(2 * time.Second)
-
-	p, err := newPostGreSQLProvider(ctx)
+	p, err := NewPostgreSQLProvider(ctx, config.PostgreSQLConfig{
+		Addr:        host,
+		Port:        portNum,
+		User:        "testuser",
+		Password:    "testpass",
+		Database:    "testdb",
+		SSLMode:     "disable",
+		DialTimeout: 5 * time.Second,
+	})
 	if err != nil {
 		_ = pgContainer.Terminate(ctx)
 		assert.NoError(t, err, "failed to init postgres provider")
@@ -69,6 +64,24 @@ func newTestPostgreSQLProvider(t *testing.T) (Provider, func()) {
 		_ = pgContainer.Terminate(ctx)
 	}
 	return p, cleanup
+}
+
+// TestNewPostgreSQLProvider_DoesNotMutateGlobalConfig verifies that
+// NewPostgreSQLProvider uses only the supplied config and leaves
+// config.DefaultConfig untouched.
+func TestNewPostgreSQLProvider_DoesNotMutateGlobalConfig(t *testing.T) {
+	prov, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	before := config.DefaultConfig.Database
+	// Round-trip a trivial query to confirm the provider is functional.
+	_, err := prov.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if config.DefaultConfig.Database != before {
+		t.Fatal("NewPostgreSQLProvider must not mutate config.DefaultConfig")
+	}
 }
 
 func TestPostgreSQL_GetQueryTypes(t *testing.T) {

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -932,22 +932,46 @@ func TestPostgreSQLProvider_DeleteQueriesBefore(t *testing.T) {
 }
 
 func TestPostgreSQL_StatementTimeoutAborts(t *testing.T) {
-	// Configure a short server-side statement timeout BEFORE spinning the
-	// provider, so the helper's call to newPostGreSQLProvider picks it up
-	// and bakes it into the connection-string options.
-	config.DefaultConfig.Database.PostgreSQL.StatementTimeout = 500 * time.Millisecond
-	t.Cleanup(func() {
-		// Reset to zero so other tests sharing the global config aren't
-		// affected by this one's setting.
-		config.DefaultConfig.Database.PostgreSQL.StatementTimeout = 0
-	})
+	ctx := context.Background()
+	pgContainer, err := postgres.Run(ctx, "postgres:16",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("Skipping PostgreSQL container tests (Docker not available): %v", err)
+	}
+	defer func() { _ = pgContainer.Terminate(ctx) }()
 
-	p, cleanup := newTestPostgreSQLProvider(t)
-	defer cleanup()
+	host, err := pgContainer.Host(ctx)
+	assert.NoError(t, err)
+	port, err := pgContainer.MappedPort(ctx, "5432/tcp")
+	assert.NoError(t, err)
+	portNum, err := strconv.Atoi(port.Port())
+	assert.NoError(t, err)
+
+	p, err := NewPostgreSQLProvider(ctx, config.PostgreSQLConfig{
+		Addr:             host,
+		Port:             portNum,
+		User:             "testuser",
+		Password:         "testpass",
+		Database:         "testdb",
+		SSLMode:          "disable",
+		DialTimeout:      5 * time.Second,
+		StatementTimeout: 500 * time.Millisecond,
+	})
+	if !assert.NoError(t, err, "failed to init postgres provider") {
+		return
+	}
+	defer func() { _ = p.Close() }()
 
 	// Sanity: a fast query still succeeds.
 	var fast int
-	err := p.(*PostGreSQLProvider).db.QueryRowContext(context.Background(), "SELECT 1").Scan(&fast)
+	err = p.(*PostGreSQLProvider).db.QueryRowContext(ctx, "SELECT 1").Scan(&fast)
 	assert.NoError(t, err, "fast query under the budget should succeed")
 	assert.Equal(t, 1, fast)
 
@@ -955,7 +979,7 @@ func TestPostgreSQL_StatementTimeoutAborts(t *testing.T) {
 	// PostgreSQL should abort it server-side with SQLSTATE 57014
 	// (query_canceled), surfaced by lib/pq with the canonical message
 	// "pq: canceling statement due to statement timeout".
-	_, err = p.(*PostGreSQLProvider).db.ExecContext(context.Background(), "SELECT pg_sleep(2)")
+	_, err = p.(*PostGreSQLProvider).db.ExecContext(ctx, "SELECT pg_sleep(2)")
 	assert.Error(t, err, "query exceeding statement_timeout should fail")
 	assert.Contains(t, err.Error(), "statement timeout",
 		"error should identify the server-side timeout source")

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
 )
 
 // Common time formats
@@ -114,7 +115,7 @@ var ValidSortDirections = map[string]bool{
 func GetDbProvider(ctx context.Context, dbProvider DatabaseProvider) (Provider, error) {
 	switch dbProvider {
 	case PostGreSQL:
-		return newPostGreSQLProvider(ctx)
+		return NewPostgreSQLProvider(ctx, config.DefaultConfig.Database.PostgreSQL)
 	case SQLite:
 		return newSqliteProvider(ctx)
 	default:

--- a/internal/ingester/otlp_ingester_test.go
+++ b/internal/ingester/otlp_ingester_test.go
@@ -882,7 +882,7 @@ func runPostgres(t *testing.T) (db.Provider, func()) {
 		postgres.WithDatabase("testdb"),
 		postgres.WithUsername("testuser"),
 		postgres.WithPassword("testpass"),
-		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(1).WithStartupTimeout(60*time.Second)),
+		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
 	)
 	if err != nil {
 		t.Skipf("Skipping OTLP integration (Docker not available): %v", err)
@@ -894,18 +894,15 @@ func runPostgres(t *testing.T) (db.Provider, func()) {
 	portNum, err := strconv.Atoi(port.Port())
 	assert.NoError(t, err)
 
-	// Wire config for provider
-	config.DefaultConfig.Database.Provider = "postgresql"
-	config.DefaultConfig.Database.PostgreSQL.Addr = host
-	config.DefaultConfig.Database.PostgreSQL.Port = portNum
-	config.DefaultConfig.Database.PostgreSQL.User = "testuser"
-	config.DefaultConfig.Database.PostgreSQL.Password = "testpass"
-	config.DefaultConfig.Database.PostgreSQL.Database = "testdb"
-	config.DefaultConfig.Database.PostgreSQL.SSLMode = "disable"
-	config.DefaultConfig.Database.PostgreSQL.DialTimeout = 5 * time.Second
-
-	time.Sleep(2 * time.Second)
-	prov, err := db.GetDbProvider(ctx, db.DatabaseProvider(config.DefaultConfig.Database.Provider))
+	prov, err := db.NewPostgreSQLProvider(ctx, config.PostgreSQLConfig{
+		Addr:        host,
+		Port:        portNum,
+		User:        "testuser",
+		Password:    "testpass",
+		Database:    "testdb",
+		SSLMode:     "disable",
+		DialTimeout: 5 * time.Second,
+	})
 	if err != nil {
 		_ = pgc.Terminate(ctx)
 		t.Fatalf("db provider: %v", err)


### PR DESCRIPTION
Instead of mutating global postgresql configuration state in the tests, we make a copy of that configuration and pass it to every provider initialization. This allows us to set different configurations in different tests while running those tests in parallel.

Change-Id: Ia7352bf26a92c98a10b4d7369ec4deb24bae7689