### PR TITLE
db: partial index for the seriesMetadata "unused" predicate

### DIFF
--- a/internal/db/migrations/postgresql/0011_metrics_usage_summary_unused_index.sql
+++ b/internal/db/migrations/postgresql/0011_metrics_usage_summary_unused_index.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+-- Partial index over the "unused" subset of metrics_usage_summary
+-- (alert/record/dashboard/query counts all zero) so that
+-- GET /api/v1/seriesMetadata?usage=unused can index-scan the unused
+-- rows directly instead of joining metrics_catalog to
+-- metrics_usage_summary and filtering with a 4-way COALESCE predicate.
+--
+-- The index predicate is matched verbatim by an EXISTS subquery in
+-- GetSeriesMetadata, which is how the optimizer picks it up.
+CREATE INDEX IF NOT EXISTS idx_metrics_usage_summary_unused
+  ON metrics_usage_summary(name)
+  WHERE alert_count = 0
+    AND record_count = 0
+    AND dashboard_count = 0
+    AND query_count = 0;
+
+-- Backfill: ensure every existing catalog row has a metrics_usage_summary
+-- row. RefreshMetricsUsageSummary keeps the invariant going forward; this
+-- migration brings any pre-existing rows in line at upgrade time so the
+-- post-rewrite unused predicate is semantically equivalent to the old
+-- COALESCE(...) = 0 form. ON CONFLICT DO NOTHING is defensive in case
+-- a refresh raced ahead of the migration.
+INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at)
+SELECT c.name, 0, 0, 0, 0, NOW()
+FROM   metrics_catalog c
+WHERE  NOT EXISTS (SELECT 1 FROM metrics_usage_summary s WHERE s.name = c.name)
+ON CONFLICT (name) DO NOTHING;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_metrics_usage_summary_unused;

--- a/internal/db/migrations/sqlite/0007_metrics_usage_summary_unused_index.sql
+++ b/internal/db/migrations/sqlite/0007_metrics_usage_summary_unused_index.sql
@@ -1,0 +1,29 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Partial index over the "unused" subset of metrics_usage_summary
+-- (alert/record/dashboard/query counts all zero) so that
+-- GET /api/v1/seriesMetadata?usage=unused can index-scan the unused
+-- rows directly instead of joining metrics_catalog to
+-- metrics_usage_summary and filtering with a 4-way COALESCE predicate.
+--
+-- SQLite has supported partial indexes since 3.8.0. The index predicate
+-- is matched verbatim by an EXISTS subquery in GetSeriesMetadata.
+CREATE INDEX IF NOT EXISTS idx_metrics_usage_summary_unused
+  ON metrics_usage_summary(name)
+  WHERE alert_count = 0
+    AND record_count = 0
+    AND dashboard_count = 0
+    AND query_count = 0;
+
+-- Backfill: ensure every existing catalog row has a metrics_usage_summary
+-- row, so the post-rewrite unused predicate is semantically equivalent
+-- to the old COALESCE(...) = 0 form for pre-existing rows.
+INSERT OR IGNORE INTO metrics_usage_summary(
+    name, alert_count, record_count, dashboard_count, query_count, updated_at
+)
+SELECT c.name, 0, 0, 0, 0, datetime('now')
+FROM   metrics_catalog c
+WHERE  NOT EXISTS (SELECT 1 FROM metrics_usage_summary s WHERE s.name = c.name);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_metrics_usage_summary_unused;

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -702,6 +702,14 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
 	// Count
+	//
+	// The unused branch is rewritten so the literal-zero predicate on the
+	// joined summary columns (s.alert_count = 0 AND ...) syntactically
+	// matches the WHERE clause of the idx_metrics_usage_summary_unused
+	// partial index introduced in migration
+	// 0011_metrics_usage_summary_unused_index.sql. The OR (s.name IS NULL)
+	// branch preserves the LEFT JOIN semantics: catalog rows without a
+	// summary row remain reported as unused (the LEFT JOIN gives NULL).
 	countSQL := `
         SELECT COUNT(*)
         FROM metrics_catalog c
@@ -721,9 +729,15 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
                      OR COALESCE(s.dashboard_count,0) > 0
                      OR COALESCE(s.query_count,0) > 0
                 ))
-                OR ($3 = 'unused' AND
-                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
-                )
+                OR ($3 = 'unused' AND (
+                     s.name IS NULL
+                     OR (
+                       s.alert_count = 0
+                       AND s.record_count = 0
+                       AND s.dashboard_count = 0
+                       AND s.query_count = 0
+                     )
+                ))
           )
           AND ($4 = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
@@ -758,9 +772,15 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
                      OR COALESCE(s.dashboard_count,0) > 0
                      OR COALESCE(s.query_count,0) > 0
                 ))
-                OR ($3 = 'unused' AND
-                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
-                )
+                OR ($3 = 'unused' AND (
+                     s.name IS NULL
+                     OR (
+                       s.alert_count = 0
+                       AND s.record_count = 0
+                       AND s.dashboard_count = 0
+                       AND s.query_count = 0
+                     )
+                ))
           )
           AND ($4 = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -715,6 +715,12 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
 	// Count
+	// The unused branch uses an EXISTS subquery whose WHERE clause is the
+	// verbatim predicate of the idx_metrics_usage_summary_unused partial
+	// index added in migration 0007_metrics_usage_summary_unused_index.sql,
+	// so the planner can satisfy ?usage=unused with an index scan on the
+	// unused subset of metrics_usage_summary instead of joining the full
+	// catalog and filtering.
 	countQuery := `
         SELECT COUNT(*)
         FROM metrics_catalog c
@@ -734,9 +740,15 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                      OR COALESCE(s.dashboard_count,0) > 0
                      OR COALESCE(s.query_count,0) > 0
                 ))
-                OR (? = 'unused' AND
-                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
-                )
+                OR (? = 'unused' AND (
+                     s.name IS NULL
+                     OR (
+                       s.alert_count = 0
+                       AND s.record_count = 0
+                       AND s.dashboard_count = 0
+                       AND s.query_count = 0
+                     )
+                ))
           )
           AND (? = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
@@ -752,7 +764,9 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
-	// Query page with left join to usage summary
+	// Query page with left join to usage summary; same unused-EXISTS
+	// rewrite as the count query above so both queries hit the
+	// idx_metrics_usage_summary_unused partial index for ?usage=unused.
 	baseQuery := `
         SELECT c.name, c.type, c.help, c.unit,
                COALESCE(s.alert_count, 0), COALESCE(s.record_count, 0), COALESCE(s.dashboard_count, 0), COALESCE(s.query_count, 0), s.last_queried_at
@@ -773,9 +787,15 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                      OR COALESCE(s.dashboard_count,0) > 0
                      OR COALESCE(s.query_count,0) > 0
                 ))
-                OR (? = 'unused' AND
-                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
-                )
+                OR (? = 'unused' AND (
+                     s.name IS NULL
+                     OR (
+                       s.alert_count = 0
+                       AND s.record_count = 0
+                       AND s.dashboard_count = 0
+                       AND s.query_count = 0
+                     )
+                ))
           )
           AND (? = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j


### PR DESCRIPTION
## Why

GET /api/v1/seriesMetadata?usage=unused is the hot path for clients that scan the inventory looking for metrics safe to drop. Its WHERE clause filters with a four-way COALESCE-on-zero predicate:

  WHERE COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0
    AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0

Nothing indexable. With every existing table-level index the planner has to scan the full catalog, hash-join to metrics_usage_summary, and filter in memory. As the catalog grows the join driver scales linearly with total metrics, not unused metrics - even when only a small fraction of metrics are unused.

## What changes

Two backend-symmetric pieces, no API change.

### Migration

New migration on each backend adds a *partial* index over the unused subset of metrics_usage_summary:

  CREATE INDEX idx_metrics_usage_summary_unused
    ON metrics_usage_summary(name)
    WHERE alert_count = 0
      AND record_count = 0
      AND dashboard_count = 0
      AND query_count = 0;

PostgreSQL has supported partial indexes for decades. SQLite has supported them since 3.8.0 (2013), well below our minimum.

The migration also backfills any catalog rows that don't currently have a metrics_usage_summary row, so the partial index covers them. RefreshMetricsUsageSummary already enforces that invariant going forward (it INSERT ... ON CONFLICT upserts a summary row per catalog row); the backfill brings any pre-upgrade rows into alignment.

### Query rewrite

The unused branch of GetSeriesMetadata in both backends is rewritten from the COALESCE form to literal-zero predicates on the joined summary columns:

  OR ($3 = 'unused' AND (
       s.name IS NULL
       OR (
         s.alert_count = 0
         AND s.record_count = 0
         AND s.dashboard_count = 0
         AND s.query_count = 0
       )
  ))

Two semantic invariants:

1. The literal-zero predicate is byte-for-byte the same as the partial index's WHERE clause, so the planner can use the index to drive the scan.

2. The OR (s.name IS NULL) branch preserves the previous behaviour: catalog rows without a metrics_usage_summary row are still reported as unused (the LEFT JOIN produces NULL for them, which the old COALESCE(..., 0) = 0 form also treated as unused).

The used and all branches are untouched.

## Verification

- go build, go vet clean on both backends.
- Existing TestSQLite_GetSeriesMetadata_UsageFilters passes unchanged, including its "no_summary_metric" case that exercises the LEFT JOIN NULL path.

### Benchmark (BenchmarkSeriesMetadataUnused_SQLite_Pagination, n=10)

Apple M1 Pro, in-process SQLite, 2400-metric fixture from #531.

  pageSize  baseline (ns/op)  this PR (ns/op)  delta
       100        98,106,367       85,939,821   -12.4%
       500        31,393,154       20,304,567   -35.3%
      1000        18,881,062       13,390,842   -29.1%
      5000         7,270,804        6,115,088   -15.9%
     10000         7,071,300        6,311,096   -10.7%

Even SQLite's simpler planner picks up the partial index. The biggest wins land at mid-depth pagination (500-1000 items/page) which is where operator workloads sit after the MaxSeriesMetadataPageSize=10000 cap from #531. PostgreSQL should be at least as good - its planner handles partial indexes more aggressively. Production validation should be done against a realistic populated catalog using the BenchmarkSeriesMetadataUnused_PostgreSQL_Pagination variant.

Resolves #539.