### PR TITLE
Feat/unused metrics is unused column

### DIFF
--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -164,6 +164,16 @@ var pageSizeCases = []int{100, 500, 1000, 5000, 10000}
 // alert_count >= 1 and are excluded from ?usage=unused results; everything
 // outside [fromIdx, toIdx) remains unused. Uses the production code paths
 // so the same helper works on both SQLite and PostgreSQL.
+//
+// After the refresh we run ANALYZE on the affected tables so the query
+// planner has accurate row-count statistics. Without this, PostgreSQL's
+// planner uses default 50%-selectivity estimates and picks a Hash Join
+// over Seq Scans instead of a Nested Loop driven from the unused subset,
+// which is ~100x slower at 240k rows. In production, autovacuum's
+// autoanalyze covers the same ground between Refresh cycles; the bench
+// calls ANALYZE explicitly to model that production-realistic state
+// rather than the worst-case "just refreshed, autoanalyze hasn't run
+// yet" snapshot.
 func seedSummaryUsedRows(b *testing.B, provider db.Provider, fromIdx, toIdx int) {
 	b.Helper()
 	if fromIdx >= toIdx {
@@ -191,6 +201,17 @@ func seedSummaryUsedRows(b *testing.B, provider db.Provider, fromIdx, toIdx int)
 	}
 	if err := provider.RefreshMetricsUsageSummary(ctx, tr); err != nil {
 		b.Fatalf("RefreshMetricsUsageSummary: %v", err)
+	}
+
+	var rawDB *sql.DB
+	provider.WithDB(func(d *sql.DB) { rawDB = d })
+	if rawDB == nil {
+		return
+	}
+	for _, table := range []string{"metrics_usage_summary", "metrics_catalog", "metrics_job_index"} {
+		if _, err := rawDB.ExecContext(ctx, "ANALYZE "+table); err != nil {
+			b.Fatalf("ANALYZE %s: %v", table, err)
+		}
 	}
 }
 

--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -158,9 +158,61 @@ func seedCatalogAndJobIndex(b *testing.B, provider db.Provider, n int, job strin
 // variants. 100 is the old cap (baseline); the rest exercise the new limit.
 var pageSizeCases = []int{100, 500, 1000, 5000, 10000}
 
+// seedSummaryUsedRows marks the catalog rows metric_<fromIdx> through
+// metric_<toIdx-1> as used by inserting one RulesUsage entry per metric and
+// then refreshing metrics_usage_summary. After this call those metrics have
+// alert_count >= 1 and are excluded from ?usage=unused results; everything
+// outside [fromIdx, toIdx) remains unused. Uses the production code paths
+// so the same helper works on both SQLite and PostgreSQL.
+func seedSummaryUsedRows(b *testing.B, provider db.Provider, fromIdx, toIdx int) {
+	b.Helper()
+	if fromIdx >= toIdx {
+		return
+	}
+	ctx := context.Background()
+
+	rules := make([]db.RulesUsage, 0, toIdx-fromIdx)
+	for i := fromIdx; i < toIdx; i++ {
+		rules = append(rules, db.RulesUsage{
+			Serie:      fmt.Sprintf("metric_%d", i),
+			GroupName:  "g",
+			Name:       "r",
+			Expression: "e",
+			Kind:       "alert",
+		})
+	}
+	if err := provider.InsertRulesUsage(ctx, rules); err != nil {
+		b.Fatalf("InsertRulesUsage: %v", err)
+	}
+
+	tr := db.TimeRange{
+		From: time.Now().Add(-time.Hour),
+		To:   time.Now().Add(time.Hour),
+	}
+	if err := provider.RefreshMetricsUsageSummary(ctx, tr); err != nil {
+		b.Fatalf("RefreshMetricsUsageSummary: %v", err)
+	}
+}
+
 // totalMetrics is the production scenario used by the pagination benchmarks:
 // the number of unused metrics the operator must sweep through.
 const totalMetrics = 2400
+
+// scaleUpTotals are the catalog sizes swept by the ScaleUp benchmarks. The
+// number of unused metrics is held constant across all sizes so any change
+// in latency reflects how the unused query scales with the catalog size
+// rather than with the unused subset size.
+var scaleUpTotals = []int{2400, 24000, 240000}
+
+// scaleUpUnusedN is the constant number of unused metrics across all
+// ScaleUp benchmark sizes. The remaining metric_<i> rows are marked as
+// used by seeding RulesUsage and refreshing metrics_usage_summary.
+const scaleUpUnusedN = 100
+
+// scaleUpPageSize is large enough that scaleUpUnusedN unused metrics fit on
+// a single page, so the benchmark measures one indexed lookup rather than
+// pagination overhead.
+const scaleUpPageSize = 1000
 
 // pagesFor returns the number of pages needed to cover total metrics at pageSize.
 func pagesFor(pageSize int) int {
@@ -479,6 +531,97 @@ func BenchmarkSeriesMetadataUnused_PostgreSQL_Pagination(b *testing.B) {
 					if w.Code != http.StatusOK {
 						b.Fatalf("page %d: unexpected status %d: %s", pg+1, w.Code, w.Body.String())
 					}
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSeriesMetadataUnused_SQLite_ScaleUp varies the *total* catalog
+// size while holding the number of unused metrics constant. The driving
+// question for any ?usage=unused optimization is whether per-request
+// latency scales with the unused subset (good) or with the total catalog
+// (bad — the planner is still walking metrics_catalog). The baseline on
+// main scales linearly with the total: this benchmark is the gate any
+// proposed fix must clear.
+func BenchmarkSeriesMetadataUnused_SQLite_ScaleUp(b *testing.B) {
+	const job = "test-job"
+
+	upstream, _ := url.Parse("http://127.0.0.1")
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+
+	for _, totalN := range scaleUpTotals {
+		b.Run(fmt.Sprintf("total%d", totalN), func(b *testing.B) {
+			provider, err := db.GetDbProvider(context.Background(), db.SQLite)
+			if err != nil {
+				b.Skipf("sqlite unavailable: %v", err)
+			}
+			defer func() { _ = provider.Close() }()
+
+			seedCatalogAndJobIndex(b, provider, totalN, job)
+			seedSummaryUsedRows(b, provider, scaleUpUnusedN, totalN)
+
+			handler, err := NewRoutes(
+				WithDBProvider(provider),
+				WithProxy(upstream),
+				WithPromAPI(upstream),
+				WithHandlers(uiFS, prometheus.NewRegistry(), false),
+			)
+			if err != nil {
+				b.Fatalf("NewRoutes: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet,
+					fmt.Sprintf("/api/v1/seriesMetadata?type=all&unused=true&job=%s&page=1&pageSize=%d", job, scaleUpPageSize), nil)
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					b.Fatalf("status %d: %s", w.Code, w.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSeriesMetadataUnused_PostgreSQL_ScaleUp is the PostgreSQL
+// counterpart to the SQLite ScaleUp benchmark. See that benchmark's
+// comment for the rationale.
+func BenchmarkSeriesMetadataUnused_PostgreSQL_ScaleUp(b *testing.B) {
+	const job = "test-job"
+
+	upstream, _ := url.Parse("http://127.0.0.1")
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+
+	for _, totalN := range scaleUpTotals {
+		b.Run(fmt.Sprintf("total%d", totalN), func(b *testing.B) {
+			provider, cleanup := startBenchPostgres(b)
+			defer cleanup()
+
+			seedCatalogAndJobIndex(b, provider, totalN, job)
+			seedSummaryUsedRows(b, provider, scaleUpUnusedN, totalN)
+
+			handler, err := NewRoutes(
+				WithDBProvider(provider),
+				WithProxy(upstream),
+				WithPromAPI(upstream),
+				WithHandlers(uiFS, prometheus.NewRegistry(), false),
+			)
+			if err != nil {
+				b.Fatalf("NewRoutes: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet,
+					fmt.Sprintf("/api/v1/seriesMetadata?type=all&unused=true&job=%s&page=1&pageSize=%d", job, scaleUpPageSize), nil)
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					b.Fatalf("status %d: %s", w.Code, w.Body.String())
 				}
 			}
 		})

--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -796,3 +796,121 @@ func BenchmarkSeriesMetadataUnused_PostgreSQL_JobScopedScaleUp(b *testing.B) {
 		})
 	}
 }
+
+// denseUnusedPageSizes are the page sizes swept by the DenseUnusedScaleUp
+// benchmarks. These mirror what the dashboard/CLI actually requests when
+// listing "all unused" without a job filter: small probes (10), typical
+// list responses (1000), and the operator's "give me everything I can
+// drop" sweep (10000, matching MaxSeriesMetadataPageSize).
+var denseUnusedPageSizes = []int{10, 1000, 10000}
+
+// BenchmarkSeriesMetadataUnused_SQLite_DenseUnusedScaleUp benches
+// ?usage=unused without a job filter when most of the catalog is unused -
+// the dashboard / CLI shape, and the inverse of both ScaleUp (sparse
+// unused) and JobScopedScaleUp (sparse job-match). cx10 reported 18.8s
+// for ?usage=unused&pageSize=10000 on ~139k unused metrics after PR #550
+// deployed; this bench reproduces that shape locally so any fix can be
+// verified without round-tripping to the cluster.
+//
+// Seeds totalN catalog rows, then marks only the first 100 as used. The
+// remaining totalN-100 stay unused, mirroring "everything is unused"
+// in production. The bench varies pageSize because the regression
+// suspicion is sort-cost: every unused row has query_count=0, so the
+// default ORDER BY queryCount DESC has to sort the full unused set
+// before the LIMIT applies. Larger pageSize materialises more of that
+// sort.
+func BenchmarkSeriesMetadataUnused_SQLite_DenseUnusedScaleUp(b *testing.B) {
+	const job = "test-job"
+	const usedN = 100
+
+	upstream, _ := url.Parse("http://127.0.0.1")
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+
+	for _, totalN := range scaleUpTotals {
+		b.Run(fmt.Sprintf("total%d", totalN), func(b *testing.B) {
+			provider, err := db.GetDbProvider(context.Background(), db.SQLite)
+			if err != nil {
+				b.Skipf("sqlite unavailable: %v", err)
+			}
+			defer func() { _ = provider.Close() }()
+
+			seedCatalogAndJobIndex(b, provider, totalN, job)
+			// Mark the first usedN metrics as used; the remaining
+			// (totalN - usedN) are left unused.
+			seedSummaryUsedRows(b, provider, 0, usedN)
+
+			handler, err := NewRoutes(
+				WithDBProvider(provider),
+				WithProxy(upstream),
+				WithPromAPI(upstream),
+				WithHandlers(uiFS, prometheus.NewRegistry(), false),
+			)
+			if err != nil {
+				b.Fatalf("NewRoutes: %v", err)
+			}
+
+			for _, ps := range denseUnusedPageSizes {
+				b.Run(fmt.Sprintf("pageSize%d", ps), func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for b.Loop() {
+						req := httptest.NewRequest(http.MethodGet,
+							fmt.Sprintf("/api/v1/seriesMetadata?type=all&unused=true&page=1&pageSize=%d", ps), nil)
+						w := httptest.NewRecorder()
+						handler.ServeHTTP(w, req)
+						if w.Code != http.StatusOK {
+							b.Fatalf("status %d: %s", w.Code, w.Body.String())
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkSeriesMetadataUnused_PostgreSQL_DenseUnusedScaleUp is the
+// PostgreSQL counterpart to the SQLite DenseUnusedScaleUp benchmark.
+// See that benchmark's comment for the rationale.
+func BenchmarkSeriesMetadataUnused_PostgreSQL_DenseUnusedScaleUp(b *testing.B) {
+	const job = "test-job"
+	const usedN = 100
+
+	upstream, _ := url.Parse("http://127.0.0.1")
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+
+	for _, totalN := range scaleUpTotals {
+		b.Run(fmt.Sprintf("total%d", totalN), func(b *testing.B) {
+			provider, cleanup := startBenchPostgres(b)
+			defer cleanup()
+
+			seedCatalogAndJobIndex(b, provider, totalN, job)
+			seedSummaryUsedRows(b, provider, 0, usedN)
+
+			handler, err := NewRoutes(
+				WithDBProvider(provider),
+				WithProxy(upstream),
+				WithPromAPI(upstream),
+				WithHandlers(uiFS, prometheus.NewRegistry(), false),
+			)
+			if err != nil {
+				b.Fatalf("NewRoutes: %v", err)
+			}
+
+			for _, ps := range denseUnusedPageSizes {
+				b.Run(fmt.Sprintf("pageSize%d", ps), func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for b.Loop() {
+						req := httptest.NewRequest(http.MethodGet,
+							fmt.Sprintf("/api/v1/seriesMetadata?type=all&unused=true&page=1&pageSize=%d", ps), nil)
+						w := httptest.NewRecorder()
+						handler.ServeHTTP(w, req)
+						if w.Code != http.StatusOK {
+							b.Fatalf("status %d: %s", w.Code, w.Body.String())
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -158,6 +158,38 @@ func seedCatalogAndJobIndex(b *testing.B, provider db.Provider, n int, job strin
 // variants. 100 is the old cap (baseline); the rest exercise the new limit.
 var pageSizeCases = []int{100, 500, 1000, 5000, 10000}
 
+// seedCatalogAndSparseJobIndex seeds n catalog rows where only the first
+// targetN are tagged with the target job; the rest are tagged with a noise
+// job. The catalog stays fully unused (no RulesUsage / Refresh). This is
+// the shape ?unused=true&job=<target> hits in production: a large unused
+// universe across many jobs, with only a sparse subset under the operator's
+// requested job. seedCatalogAndJobIndex puts every metric under one job and
+// therefore cannot exercise this access pattern.
+func seedCatalogAndSparseJobIndex(b *testing.B, provider db.Provider, n, targetN int, targetJob, noiseJob string) {
+	b.Helper()
+	ctx := context.Background()
+
+	catalog := make([]db.MetricCatalogItem, n)
+	for i := range n {
+		catalog[i] = db.MetricCatalogItem{Name: fmt.Sprintf("metric_%d", i), Type: "gauge"}
+	}
+	if err := provider.UpsertMetricsCatalog(ctx, catalog); err != nil {
+		b.Fatalf("UpsertMetricsCatalog: %v", err)
+	}
+
+	jobIdx := make([]db.MetricJobIndexItem, n)
+	for i := range n {
+		job := noiseJob
+		if i < targetN {
+			job = targetJob
+		}
+		jobIdx[i] = db.MetricJobIndexItem{Name: fmt.Sprintf("metric_%d", i), Job: job}
+	}
+	if err := provider.UpsertMetricsJobIndex(ctx, jobIdx); err != nil {
+		b.Fatalf("UpsertMetricsJobIndex: %v", err)
+	}
+}
+
 // seedSummaryUsedRows marks the catalog rows metric_<fromIdx> through
 // metric_<toIdx-1> as used by inserting one RulesUsage entry per metric and
 // then refreshing metrics_usage_summary. After this call those metrics have
@@ -639,6 +671,122 @@ func BenchmarkSeriesMetadataUnused_PostgreSQL_ScaleUp(b *testing.B) {
 			for b.Loop() {
 				req := httptest.NewRequest(http.MethodGet,
 					fmt.Sprintf("/api/v1/seriesMetadata?type=all&unused=true&job=%s&page=1&pageSize=%d", job, scaleUpPageSize), nil)
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					b.Fatalf("status %d: %s", w.Code, w.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSeriesMetadataUnused_SQLite_JobScopedScaleUp models the production
+// hot path that broke on cx10 (PR #550 deploy): ?usage=unused&job=<name>
+// where the unused universe is large but only a sparse subset is tagged with
+// the requested job. ScaleUp varies the total catalog while holding the
+// target-job match count constant; if the planner drives from the job
+// index, latency stays roughly flat. If it drives from is_unused=TRUE and
+// EXISTS-probes the job index per row, latency scales with total.
+func BenchmarkSeriesMetadataUnused_SQLite_JobScopedScaleUp(b *testing.B) {
+	const targetJob = "target-job"
+	const noiseJob = "noise-job"
+
+	upstream, _ := url.Parse("http://127.0.0.1")
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+
+	for _, totalN := range scaleUpTotals {
+		b.Run(fmt.Sprintf("total%d", totalN), func(b *testing.B) {
+			provider, err := db.GetDbProvider(context.Background(), db.SQLite)
+			if err != nil {
+				b.Skipf("sqlite unavailable: %v", err)
+			}
+			defer func() { _ = provider.Close() }()
+
+			seedCatalogAndSparseJobIndex(b, provider, totalN, scaleUpUnusedN, targetJob, noiseJob)
+			// No seedSummaryUsedRows call: every catalog row stays unused.
+			// UpsertMetricsCatalog already creates default-unused summary
+			// rows, so the unused predicate matches every metric.
+
+			var rawDB *sql.DB
+			provider.WithDB(func(d *sql.DB) { rawDB = d })
+			if rawDB != nil {
+				ctx := context.Background()
+				for _, t := range []string{"metrics_usage_summary", "metrics_catalog", "metrics_job_index"} {
+					if _, err := rawDB.ExecContext(ctx, "ANALYZE "+t); err != nil {
+						b.Fatalf("ANALYZE %s: %v", t, err)
+					}
+				}
+			}
+
+			handler, err := NewRoutes(
+				WithDBProvider(provider),
+				WithProxy(upstream),
+				WithPromAPI(upstream),
+				WithHandlers(uiFS, prometheus.NewRegistry(), false),
+			)
+			if err != nil {
+				b.Fatalf("NewRoutes: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet,
+					fmt.Sprintf("/api/v1/seriesMetadata?type=all&unused=true&job=%s&page=1&pageSize=%d", targetJob, scaleUpPageSize), nil)
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					b.Fatalf("status %d: %s", w.Code, w.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSeriesMetadataUnused_PostgreSQL_JobScopedScaleUp is the PostgreSQL
+// counterpart to the SQLite JobScopedScaleUp benchmark. See that benchmark's
+// comment for the rationale.
+func BenchmarkSeriesMetadataUnused_PostgreSQL_JobScopedScaleUp(b *testing.B) {
+	const targetJob = "target-job"
+	const noiseJob = "noise-job"
+
+	upstream, _ := url.Parse("http://127.0.0.1")
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+
+	for _, totalN := range scaleUpTotals {
+		b.Run(fmt.Sprintf("total%d", totalN), func(b *testing.B) {
+			provider, cleanup := startBenchPostgres(b)
+			defer cleanup()
+
+			seedCatalogAndSparseJobIndex(b, provider, totalN, scaleUpUnusedN, targetJob, noiseJob)
+
+			var rawDB *sql.DB
+			provider.WithDB(func(d *sql.DB) { rawDB = d })
+			if rawDB != nil {
+				ctx := context.Background()
+				for _, t := range []string{"metrics_usage_summary", "metrics_catalog", "metrics_job_index"} {
+					if _, err := rawDB.ExecContext(ctx, "ANALYZE "+t); err != nil {
+						b.Fatalf("ANALYZE %s: %v", t, err)
+					}
+				}
+			}
+
+			handler, err := NewRoutes(
+				WithDBProvider(provider),
+				WithProxy(upstream),
+				WithPromAPI(upstream),
+				WithHandlers(uiFS, prometheus.NewRegistry(), false),
+			)
+			if err != nil {
+				b.Fatalf("NewRoutes: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				req := httptest.NewRequest(http.MethodGet,
+					fmt.Sprintf("/api/v1/seriesMetadata?type=all&unused=true&job=%s&page=1&pageSize=%d", targetJob, scaleUpPageSize), nil)
 				w := httptest.NewRecorder()
 				handler.ServeHTTP(w, req)
 				if w.Code != http.StatusOK {

--- a/internal/db/migrations/postgresql/0011_metrics_usage_summary_is_unused.sql
+++ b/internal/db/migrations/postgresql/0011_metrics_usage_summary_is_unused.sql
@@ -10,11 +10,16 @@
 ALTER TABLE metrics_usage_summary
     ADD COLUMN IF NOT EXISTS is_unused BOOLEAN NOT NULL DEFAULT TRUE;
 
+-- ADD COLUMN ... DEFAULT TRUE already initializes every row to the unused
+-- value, which is correct for any row with all-zero counts. Only the
+-- used rows need flipping, so scope the UPDATE to that subset; otherwise
+-- we rewrite the whole table for no semantic change.
 UPDATE metrics_usage_summary
-SET is_unused = (alert_count = 0
-                 AND record_count = 0
-                 AND dashboard_count = 0
-                 AND query_count = 0);
+SET is_unused = FALSE
+WHERE alert_count > 0
+   OR record_count > 0
+   OR dashboard_count > 0
+   OR query_count > 0;
 
 -- Backfill: ensure every catalog row has a summary row so the new unused
 -- query can INNER JOIN safely. ON CONFLICT DO NOTHING is defensive in case

--- a/internal/db/migrations/postgresql/0011_metrics_usage_summary_is_unused.sql
+++ b/internal/db/migrations/postgresql/0011_metrics_usage_summary_is_unused.sql
@@ -30,23 +30,11 @@ FROM   metrics_catalog c
 WHERE  NOT EXISTS (SELECT 1 FROM metrics_usage_summary s WHERE s.name = c.name)
 ON CONFLICT (name) DO NOTHING;
 
--- Partial index over the unused subset. The predicate is matched verbatim by
--- the unused branch of GetSeriesMetadata so the planner can satisfy the scan
--- from this index.
---
--- No in-line ANALYZE here. Earlier versions of this migration ran ANALYZE
--- on metrics_usage_summary and metrics_catalog at the end of the goose
--- transaction; combined with the same pattern in migration 0012 that
--- deadlocked on cx10, in-tx ANALYZE against a concurrent INSERT from the
--- inventory syncer fails when the syncer's RowExclusiveLock cannot release
--- past ANALYZE's ShareUpdateExclusiveLock. Production autovacuum refreshes
--- stats on its normal cadence; the ?usage=unused query degrades to a Hash
--- Join for at most a few minutes after deploy, which is preferable to a
--- deadlocked migration that fails the rollout.
-CREATE INDEX IF NOT EXISTS idx_metrics_usage_summary_is_unused
-    ON metrics_usage_summary(name)
-    WHERE is_unused = TRUE;
+-- The partial index over the unused subset is built in a separate migration
+-- (0013) with CREATE INDEX CONCURRENTLY so the build does not block writes
+-- from the inventory syncer. CONCURRENTLY cannot run inside a transaction
+-- block, which is why it lives in its own non-transactional migration
+-- rather than at the end of this one.
 
 -- +goose Down
-DROP INDEX IF EXISTS idx_metrics_usage_summary_is_unused;
 ALTER TABLE metrics_usage_summary DROP COLUMN IF EXISTS is_unused;

--- a/internal/db/migrations/postgresql/0011_metrics_usage_summary_is_unused.sql
+++ b/internal/db/migrations/postgresql/0011_metrics_usage_summary_is_unused.sql
@@ -33,16 +33,19 @@ ON CONFLICT (name) DO NOTHING;
 -- Partial index over the unused subset. The predicate is matched verbatim by
 -- the unused branch of GetSeriesMetadata so the planner can satisfy the scan
 -- from this index.
+--
+-- No in-line ANALYZE here. Earlier versions of this migration ran ANALYZE
+-- on metrics_usage_summary and metrics_catalog at the end of the goose
+-- transaction; combined with the same pattern in migration 0012 that
+-- deadlocked on cx10, in-tx ANALYZE against a concurrent INSERT from the
+-- inventory syncer fails when the syncer's RowExclusiveLock cannot release
+-- past ANALYZE's ShareUpdateExclusiveLock. Production autovacuum refreshes
+-- stats on its normal cadence; the ?usage=unused query degrades to a Hash
+-- Join for at most a few minutes after deploy, which is preferable to a
+-- deadlocked migration that fails the rollout.
 CREATE INDEX IF NOT EXISTS idx_metrics_usage_summary_is_unused
     ON metrics_usage_summary(name)
     WHERE is_unused = TRUE;
-
--- Refresh planner stats so the new index is used immediately rather than
--- waiting for autoanalyze. Without this, the first ?usage=unused queries
--- after the migration may pick a hash join or seq scan instead of the
--- partial-index path.
-ANALYZE metrics_usage_summary;
-ANALYZE metrics_catalog;
 
 -- +goose Down
 DROP INDEX IF EXISTS idx_metrics_usage_summary_is_unused;

--- a/internal/db/migrations/postgresql/0011_metrics_usage_summary_is_unused.sql
+++ b/internal/db/migrations/postgresql/0011_metrics_usage_summary_is_unused.sql
@@ -1,0 +1,44 @@
+-- +goose Up
+-- Add is_unused as a directly indexable property of metrics_usage_summary so
+-- that GET /api/v1/seriesMetadata?usage=unused can be driven from the summary
+-- table via a partial index instead of scanning metrics_catalog and filtering
+-- with a four-way COALESCE-on-zero predicate.
+--
+-- Default TRUE: a brand-new row with all counts zero is unused by definition.
+-- RefreshMetricsUsageSummary maintains the column going forward; the UPDATE
+-- below brings any rows that existed before this migration into alignment.
+ALTER TABLE metrics_usage_summary
+    ADD COLUMN IF NOT EXISTS is_unused BOOLEAN NOT NULL DEFAULT TRUE;
+
+UPDATE metrics_usage_summary
+SET is_unused = (alert_count = 0
+                 AND record_count = 0
+                 AND dashboard_count = 0
+                 AND query_count = 0);
+
+-- Backfill: ensure every catalog row has a summary row so the new unused
+-- query can INNER JOIN safely. ON CONFLICT DO NOTHING is defensive in case
+-- a refresh races the migration.
+INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused)
+SELECT c.name, 0, 0, 0, 0, NOW(), TRUE
+FROM   metrics_catalog c
+WHERE  NOT EXISTS (SELECT 1 FROM metrics_usage_summary s WHERE s.name = c.name)
+ON CONFLICT (name) DO NOTHING;
+
+-- Partial index over the unused subset. The predicate is matched verbatim by
+-- the unused branch of GetSeriesMetadata so the planner can satisfy the scan
+-- from this index.
+CREATE INDEX IF NOT EXISTS idx_metrics_usage_summary_is_unused
+    ON metrics_usage_summary(name)
+    WHERE is_unused = TRUE;
+
+-- Refresh planner stats so the new index is used immediately rather than
+-- waiting for autoanalyze. Without this, the first ?usage=unused queries
+-- after the migration may pick a hash join or seq scan instead of the
+-- partial-index path.
+ANALYZE metrics_usage_summary;
+ANALYZE metrics_catalog;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_metrics_usage_summary_is_unused;
+ALTER TABLE metrics_usage_summary DROP COLUMN IF EXISTS is_unused;

--- a/internal/db/migrations/postgresql/0012_metrics_job_index_job_name.sql
+++ b/internal/db/migrations/postgresql/0012_metrics_job_index_job_name.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- Composite index over (job, name) on metrics_job_index. The existing
+-- idx_metrics_job_index_job covers j.job lookups but only stores rowids;
+-- joining to metrics_usage_summary / metrics_catalog by j.name still
+-- requires a heap fetch per outer row. (job, name) lets the job-scoped
+-- ?usage=unused query do an index-only scan over the job's metrics and
+-- feed names directly into the nested-loop joins to summary and catalog.
+--
+-- Without this index a query like
+--   FROM metrics_job_index j
+--   JOIN metrics_usage_summary s ON s.name = j.name
+--   JOIN metrics_catalog c ON c.name = j.name
+--   WHERE j.job = $3 AND s.is_unused = TRUE
+-- still works but pays a heap fetch per j.name; with it, the planner can
+-- pick an index-only scan on metrics_job_index for the j.job=... probe
+-- and join straight to summary/catalog by PK.
+CREATE INDEX IF NOT EXISTS idx_metrics_job_index_job_name
+    ON metrics_job_index(job, name);
+
+ANALYZE metrics_job_index;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_metrics_job_index_job_name;

--- a/internal/db/migrations/postgresql/0012_metrics_job_index_job_name.sql
+++ b/internal/db/migrations/postgresql/0012_metrics_job_index_job_name.sql
@@ -1,3 +1,4 @@
+-- +goose NO TRANSACTION
 -- +goose Up
 -- Composite index over (job, name) on metrics_job_index. The existing
 -- idx_metrics_job_index_job covers j.job lookups but only stores rowids;
@@ -14,10 +15,17 @@
 -- still works but pays a heap fetch per j.name; with it, the planner can
 -- pick an index-only scan on metrics_job_index for the j.job=... probe
 -- and join straight to summary/catalog by PK.
-CREATE INDEX IF NOT EXISTS idx_metrics_job_index_job_name
+--
+-- CREATE INDEX CONCURRENTLY (which is why this migration disables the
+-- goose-wrapping transaction) so the index build does not block writes
+-- from the inventory syncer while the migration runs. An earlier form
+-- of this migration ran transactional CREATE INDEX followed by ANALYZE
+-- and deadlocked on cx10: a concurrent INSERT into metrics_job_index
+-- held a RowExclusiveLock that the in-tx ANALYZE's
+-- ShareUpdateExclusiveLock could not acquire. Planner stats refresh
+-- via autovacuum on its normal cadence; no in-line ANALYZE here.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metrics_job_index_job_name
     ON metrics_job_index(job, name);
 
-ANALYZE metrics_job_index;
-
 -- +goose Down
-DROP INDEX IF EXISTS idx_metrics_job_index_job_name;
+DROP INDEX CONCURRENTLY IF EXISTS idx_metrics_job_index_job_name;

--- a/internal/db/migrations/postgresql/0012_metrics_job_index_job_name.sql
+++ b/internal/db/migrations/postgresql/0012_metrics_job_index_job_name.sql
@@ -27,5 +27,14 @@
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metrics_job_index_job_name
     ON metrics_job_index(job, name);
 
+-- Drop the redundant single-column index from migration 0008. PostgreSQL
+-- uses the leftmost prefix of a composite index for single-column lookups,
+-- so idx_metrics_job_index_job_name(job, name) covers every plan that
+-- idx_metrics_job_index_job(job) covered. Keeping both costs disk and
+-- write amplification with no read-side benefit.
+DROP INDEX CONCURRENTLY IF EXISTS idx_metrics_job_index_job;
+
 -- +goose Down
 DROP INDEX CONCURRENTLY IF EXISTS idx_metrics_job_index_job_name;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metrics_job_index_job
+    ON metrics_job_index(job);

--- a/internal/db/migrations/postgresql/0013_metrics_usage_summary_is_unused_index.sql
+++ b/internal/db/migrations/postgresql/0013_metrics_usage_summary_is_unused_index.sql
@@ -1,0 +1,22 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Partial index over the unused subset of metrics_usage_summary. The
+-- predicate matches the unused branch of GetSeriesMetadata verbatim so the
+-- planner can satisfy the scan from this index instead of walking the full
+-- summary table.
+--
+-- CREATE INDEX CONCURRENTLY (which is why this migration disables the
+-- goose-wrapping transaction) so the index build does not block writes
+-- from the inventory syncer while the migration runs. Mirrors migration
+-- 0012's pattern. An earlier form ran the index build in 0011's transaction
+-- alongside ADD COLUMN + UPDATE + INSERT, which combined with in-tx ANALYZE
+-- deadlocked on cx10: a concurrent INSERT from the inventory syncer held a
+-- RowExclusiveLock that the in-tx ANALYZE's ShareUpdateExclusiveLock could
+-- not acquire. No in-line ANALYZE here; production autovacuum refreshes
+-- stats on its normal cadence.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metrics_usage_summary_is_unused
+    ON metrics_usage_summary(name)
+    WHERE is_unused = TRUE;
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_metrics_usage_summary_is_unused;

--- a/internal/db/migrations/sqlite/0007_metrics_usage_summary_is_unused.sql
+++ b/internal/db/migrations/sqlite/0007_metrics_usage_summary_is_unused.sql
@@ -1,0 +1,39 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Add is_unused as a directly indexable property of metrics_usage_summary so
+-- that GET /api/v1/seriesMetadata?usage=unused can be driven from the summary
+-- table via a partial index instead of scanning metrics_catalog and filtering
+-- with a four-way COALESCE-on-zero predicate.
+--
+-- Default TRUE: a brand-new row with all counts zero is unused by definition.
+-- RefreshMetricsUsageSummary maintains the column going forward; the UPDATE
+-- below brings any rows that existed before this migration into alignment.
+ALTER TABLE metrics_usage_summary
+    ADD COLUMN is_unused BOOLEAN NOT NULL DEFAULT TRUE;
+
+UPDATE metrics_usage_summary
+SET is_unused = (alert_count = 0
+                 AND record_count = 0
+                 AND dashboard_count = 0
+                 AND query_count = 0);
+
+-- Backfill: ensure every catalog row has a summary row so the new unused
+-- query can INNER JOIN safely. INSERT OR IGNORE is defensive in case a
+-- refresh races the migration.
+INSERT OR IGNORE INTO metrics_usage_summary(
+    name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused
+)
+SELECT c.name, 0, 0, 0, 0, datetime('now'), 1
+FROM   metrics_catalog c
+WHERE  NOT EXISTS (SELECT 1 FROM metrics_usage_summary s WHERE s.name = c.name);
+
+-- Partial index over the unused subset. The predicate is matched verbatim by
+-- the unused branch of GetSeriesMetadata so the planner can satisfy the scan
+-- from this index. SQLite has supported partial indexes since 3.8.0.
+CREATE INDEX IF NOT EXISTS idx_metrics_usage_summary_is_unused
+    ON metrics_usage_summary(name)
+    WHERE is_unused = TRUE;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_metrics_usage_summary_is_unused;
+ALTER TABLE metrics_usage_summary DROP COLUMN is_unused;

--- a/internal/db/migrations/sqlite/0007_metrics_usage_summary_is_unused.sql
+++ b/internal/db/migrations/sqlite/0007_metrics_usage_summary_is_unused.sql
@@ -1,4 +1,3 @@
--- +goose NO TRANSACTION
 -- +goose Up
 -- Add is_unused as a directly indexable property of metrics_usage_summary so
 -- that GET /api/v1/seriesMetadata?usage=unused can be driven from the summary
@@ -11,11 +10,16 @@
 ALTER TABLE metrics_usage_summary
     ADD COLUMN is_unused BOOLEAN NOT NULL DEFAULT TRUE;
 
+-- ADD COLUMN ... DEFAULT TRUE already initializes every row to the unused
+-- value, which is correct for any row with all-zero counts. Only the
+-- used rows need flipping, so scope the UPDATE to that subset; otherwise
+-- we rewrite the whole table for no semantic change.
 UPDATE metrics_usage_summary
-SET is_unused = (alert_count = 0
-                 AND record_count = 0
-                 AND dashboard_count = 0
-                 AND query_count = 0);
+SET is_unused = FALSE
+WHERE alert_count > 0
+   OR record_count > 0
+   OR dashboard_count > 0
+   OR query_count > 0;
 
 -- Backfill: ensure every catalog row has a summary row so the new unused
 -- query can INNER JOIN safely. INSERT OR IGNORE is defensive in case a

--- a/internal/db/migrations/sqlite/0008_metrics_job_index_job_name.sql
+++ b/internal/db/migrations/sqlite/0008_metrics_job_index_job_name.sql
@@ -11,5 +11,14 @@
 CREATE INDEX IF NOT EXISTS idx_metrics_job_index_job_name
     ON metrics_job_index(job, name);
 
+-- Drop the redundant single-column index from migration 0005. SQLite uses
+-- the leftmost prefix of a composite index for single-column lookups, so
+-- idx_metrics_job_index_job_name(job, name) covers every plan that
+-- idx_metrics_job_index_job(job) covered. Keeping both costs disk and
+-- write amplification with no read-side benefit.
+DROP INDEX IF EXISTS idx_metrics_job_index_job;
+
 -- +goose Down
 DROP INDEX IF EXISTS idx_metrics_job_index_job_name;
+CREATE INDEX IF NOT EXISTS idx_metrics_job_index_job
+    ON metrics_job_index(job);

--- a/internal/db/migrations/sqlite/0008_metrics_job_index_job_name.sql
+++ b/internal/db/migrations/sqlite/0008_metrics_job_index_job_name.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- Composite index over (job, name) on metrics_job_index. The existing
+-- idx_metrics_job_index_job covers j.job lookups but only stores rowids;
+-- joining to metrics_usage_summary / metrics_catalog by j.name still
+-- requires a row fetch per outer row. (job, name) lets the job-scoped
+-- ?usage=unused query do a covering scan over the job's metrics and feed
+-- names directly into the nested-loop joins to summary and catalog.
+--
+-- SQLite has supported partial and composite indexes since well before
+-- our minimum version.
+CREATE INDEX IF NOT EXISTS idx_metrics_job_index_job_name
+    ON metrics_job_index(job, name);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_metrics_job_index_job_name;

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -721,8 +721,54 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 	}
 	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
-	// Count
-	countSQL := `
+	// When usage == "unused" we drive the query from metrics_usage_summary
+	// filtered by the is_unused partial index, then INNER JOIN metrics_catalog.
+	// This lets the planner satisfy the unused subset with an index scan
+	// instead of walking metrics_catalog and filtering. For used/all we keep
+	// the catalog-driven LEFT JOIN shape that the existing branches expect.
+	var countSQL, baseQuery, limitClause string
+	var countArgs, selectArgs []any
+	if params.Usage == SeriesMetadataUsageUnused {
+		countSQL = `
+        SELECT COUNT(*)
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+          AND ($3 = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = $3
+          ))
+    `
+		baseQuery = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+          AND ($3 = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = $3
+          ))
+    `
+		limitClause = " LIMIT $4 OFFSET $5"
+		countArgs = []any{params.Filter, params.Type, params.Job}
+		selectArgs = []any{params.Filter, params.Type, params.Job, params.PageSize, (params.Page - 1) * params.PageSize}
+	} else {
+		countSQL = `
         SELECT COUNT(*)
         FROM metrics_catalog c
         LEFT JOIN metrics_usage_summary s ON s.name = c.name
@@ -741,24 +787,13 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
                      OR COALESCE(s.dashboard_count,0) > 0
                      OR COALESCE(s.query_count,0) > 0
                 ))
-                OR ($3 = 'unused' AND
-                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
-                )
           )
           AND ($4 = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
                 WHERE j.name = c.name AND j.job = $4
           ))
     `
-	var total int
-	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Usage, params.Job).Scan(&total); err != nil {
-		return nil, fmt.Errorf("count: %w", err)
-	}
-	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
-	}
-
-	baseQuery := `
+		baseQuery = `
         SELECT c.name, c.type, c.help, c.unit,
                COALESCE(s.alert_count,0), COALESCE(s.record_count,0), COALESCE(s.dashboard_count,0), COALESCE(s.query_count,0), s.last_queried_at
         FROM metrics_catalog c
@@ -778,19 +813,29 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
                      OR COALESCE(s.dashboard_count,0) > 0
                      OR COALESCE(s.query_count,0) > 0
                 ))
-                OR ($3 = 'unused' AND
-                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
-                )
           )
           AND ($4 = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
                 WHERE j.name = c.name AND j.job = $4
           ))
     `
-	// Build complete query with safe ORDER BY clause to prevent SQL injection
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $5 OFFSET $6", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+		limitClause = " LIMIT $5 OFFSET $6"
+		countArgs = []any{params.Filter, params.Type, params.Usage, params.Job}
+		selectArgs = []any{params.Filter, params.Type, params.Usage, params.Job, params.PageSize, (params.Page - 1) * params.PageSize}
+	}
 
-	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Usage, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
+	var total int
+	if err := p.db.QueryRowContext(ctx, countSQL, countArgs...).Scan(&total); err != nil {
+		return nil, fmt.Errorf("count: %w", err)
+	}
+	if total == 0 {
+		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+	}
+
+	// Build complete query with safe ORDER BY clause to prevent SQL injection
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", limitClause, params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+
+	rows, err := p.db.QueryContext(ctx, query, selectArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("select: %w", err)
 	}
@@ -904,10 +949,31 @@ func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []M
 		return fmt.Errorf("prepare: %w", err)
 	}
 	defer CloseResource(stmt)
+
+	// Co-write a default-unused summary row per catalog item so the
+	// metrics_catalog <-> metrics_usage_summary invariant holds before
+	// the next RefreshMetricsUsageSummary. ON CONFLICT DO NOTHING means
+	// existing rows with real counts are not clobbered. The new
+	// ?usage=unused query depends on this invariant to use an INNER JOIN.
+	summaryStmt, err := tx.PrepareContext(ctx, `
+        INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused)
+        VALUES ($1, 0, 0, 0, 0, NOW(), TRUE)
+        ON CONFLICT (name) DO NOTHING
+    `)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("prepare summary: %w", err)
+	}
+	defer CloseResource(summaryStmt)
+
 	for _, it := range items {
 		if _, err := stmt.ExecContext(ctx, it.Name, it.Type, it.Help, it.Unit); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("exec: %w", err)
+		}
+		if _, err := summaryStmt.ExecContext(ctx, it.Name); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("exec summary: %w", err)
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -919,14 +985,18 @@ func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []M
 func (p *PostGreSQLProvider) RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error {
 	from, to := PrepareTimeRange(tr, "postgresql")
 	query := `
-    INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, last_queried_at, updated_at)
+    INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, last_queried_at, updated_at, is_unused)
     SELECT c.name,
            COALESCE(ra.alert_count, 0),
            COALESCE(ra.record_count, 0),
            COALESCE(da.dashboard_count, 0),
            COALESCE(qa.query_count, 0),
            qa.last_queried_at,
-           NOW()
+           NOW(),
+           (COALESCE(ra.alert_count, 0) = 0
+            AND COALESCE(ra.record_count, 0) = 0
+            AND COALESCE(da.dashboard_count, 0) = 0
+            AND COALESCE(qa.query_count, 0) = 0)
     FROM metrics_catalog c
     LEFT JOIN (
         SELECT serie AS name,
@@ -957,7 +1027,8 @@ func (p *PostGreSQLProvider) RefreshMetricsUsageSummary(ctx context.Context, tr 
         dashboard_count=EXCLUDED.dashboard_count,
         query_count=EXCLUDED.query_count,
         last_queried_at=EXCLUDED.last_queried_at,
-        updated_at=EXCLUDED.updated_at;
+        updated_at=EXCLUDED.updated_at,
+        is_unused=EXCLUDED.is_unused;
     `
 	_, err := p.db.ExecContext(ctx, query, from, to)
 	if err != nil {

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -812,7 +812,18 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 // index scan instead of walking the full catalog and filtering. The two
 // SQL strings here are static literals; the conditional that picks this
 // method lives in GetSeriesMetadata.
+//
+// When a job filter is provided the optimal access pattern flips - driving
+// from is_unused=TRUE and EXISTS-probing metrics_job_index per row scales
+// with the entire unused universe rather than with the requested job, which
+// catastrophically misses for jobs that match a small slice of unused
+// metrics. The job case is therefore handled by getSeriesMetadataUnusedJobScoped,
+// which drives from metrics_job_index instead.
 func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+	if params.Job != "" {
+		return p.getSeriesMetadataUnusedJobScoped(ctx, params)
+	}
+
 	const countSQL = `
         SELECT COUNT(*)
         FROM metrics_usage_summary s
@@ -825,13 +836,9 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params
                   WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
                   ELSE c.type = $2
                 END)
-          AND ($3 = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = $3
-          ))
     `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Job).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type).Scan(&total); err != nil {
 		return nil, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
@@ -851,10 +858,69 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params
                   WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
                   ELSE c.type = $2
                 END)
-          AND ($3 = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = $3
-          ))
+    `
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $3 OFFSET $4", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.PageSize, (params.Page-1)*params.PageSize)
+	if err != nil {
+		return nil, fmt.Errorf("select: %w", err)
+	}
+	defer CloseResource(rows)
+
+	out, err := scanSeriesMetadataRows(rows, params.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	pages := (total + params.PageSize - 1) / params.PageSize
+	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+}
+
+// getSeriesMetadataUnusedJobScoped drives ?usage=unused&job=<X> from
+// metrics_job_index (filtered to the requested job via the composite
+// (job, name) index) and INNER JOINs to metrics_usage_summary (filtered by
+// is_unused=TRUE) and metrics_catalog. This makes per-request work scale
+// with the size of the requested job's metric set, not with the entire
+// unused universe - the latter is what cratered cx10 when the operator's
+// ?usage=unused&job=kube-state-metrics request hit 139k unused metrics
+// looking for a sparse 57-row match.
+func (p *PostGreSQLProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+	const countSQL = `
+        SELECT COUNT(*)
+        FROM metrics_job_index j
+        JOIN metrics_usage_summary s ON s.name = j.name
+        JOIN metrics_catalog c ON c.name = j.name
+        WHERE j.job = $3
+          AND s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Job).Scan(&total); err != nil {
+		return nil, fmt.Errorf("count: %w", err)
+	}
+	if total == 0 {
+		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+	}
+
+	const baseQuery = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_job_index j
+        JOIN metrics_usage_summary s ON s.name = j.name
+        JOIN metrics_catalog c ON c.name = j.name
+        WHERE j.job = $3
+          AND s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
     `
 	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $4 OFFSET $5", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Job, params.PageSize, (params.Page-1)*params.PageSize)

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -950,32 +950,34 @@ func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []M
 	}
 	defer CloseResource(stmt)
 
+	names := make([]string, len(items))
+	for i, it := range items {
+		if _, err := stmt.ExecContext(ctx, it.Name, it.Type, it.Help, it.Unit); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("exec: %w", err)
+		}
+		names[i] = it.Name
+	}
+
 	// Co-write a default-unused summary row per catalog item so the
 	// metrics_catalog <-> metrics_usage_summary invariant holds before
 	// the next RefreshMetricsUsageSummary. ON CONFLICT DO NOTHING means
 	// existing rows with real counts are not clobbered. The new
 	// ?usage=unused query depends on this invariant to use an INNER JOIN.
-	summaryStmt, err := tx.PrepareContext(ctx, `
+	//
+	// One bulk INSERT via unnest() instead of one statement per item -
+	// the syncer calls this with the full catalog inventory (~tens of
+	// thousands of rows on a real Prometheus), and per-item round-trips
+	// add up fast.
+	if _, err := tx.ExecContext(ctx, `
         INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused)
-        VALUES ($1, 0, 0, 0, 0, NOW(), TRUE)
+        SELECT n, 0, 0, 0, 0, NOW(), TRUE FROM unnest($1::text[]) AS n
         ON CONFLICT (name) DO NOTHING
-    `)
-	if err != nil {
+    `, pq.Array(names)); err != nil {
 		_ = tx.Rollback()
-		return fmt.Errorf("prepare summary: %w", err)
+		return fmt.Errorf("exec summary: %w", err)
 	}
-	defer CloseResource(summaryStmt)
 
-	for _, it := range items {
-		if _, err := stmt.ExecContext(ctx, it.Name, it.Type, it.Help, it.Unit); err != nil {
-			_ = tx.Rollback()
-			return fmt.Errorf("exec: %w", err)
-		}
-		if _, err := summaryStmt.ExecContext(ctx, it.Name); err != nil {
-			_ = tx.Rollback()
-			return fmt.Errorf("exec summary: %w", err)
-		}
-	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -859,7 +859,17 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params
                   ELSE c.type = $2
                 END)
     `
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $3 OFFSET $4", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	// Force ORDER BY c.name for the unused branch regardless of the
+	// client-supplied sortBy. Every unused row has alert_count =
+	// record_count = dashboard_count = query_count = 0, so sorting by any
+	// of those count columns is meaningless (all values tie at zero) and
+	// forces the planner to materialise the full unused subset before
+	// LIMIT can apply - which on cx10 (139k unused) cost seconds even for
+	// a 10-row page. Sorting by c.name lines up with the
+	// idx_metrics_usage_summary_is_unused partial index's name ordering,
+	// so the planner can index-scan + LIMIT in O(LIMIT) work. sortOrder is
+	// still honoured so ?sortOrder=desc inverts the alphabetical listing.
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $3 OFFSET $4", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("select: %w", err)
@@ -922,7 +932,11 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnusedJobScoped(ctx context.Contex
                   ELSE c.type = $2
                 END)
     `
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $4 OFFSET $5", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	// Force ORDER BY c.name; see getSeriesMetadataUnused for rationale.
+	// The same all-zero-counts pattern applies here, and consistency
+	// matters because clients page through both shapes against the same
+	// API contract.
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $4 OFFSET $5", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("select: %w", err)

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -721,54 +721,18 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 	}
 	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
-	// When usage == "unused" we drive the query from metrics_usage_summary
-	// filtered by the is_unused partial index, then INNER JOIN metrics_catalog.
-	// This lets the planner satisfy the unused subset with an index scan
-	// instead of walking metrics_catalog and filtering. For used/all we keep
-	// the catalog-driven LEFT JOIN shape that the existing branches expect.
-	var countSQL, baseQuery, limitClause string
-	var countArgs, selectArgs []any
+	// usage=unused is handled by a dedicated method with a distinct query
+	// shape (driven from metrics_usage_summary via the is_unused partial
+	// index, INNER JOIN metrics_catalog). Splitting it out keeps each path's
+	// SQL as a single static literal - this matters for code scanning,
+	// which otherwise flags QueryContext as having a query string that
+	// control-depends on the user-controlled Usage value.
 	if params.Usage == SeriesMetadataUsageUnused {
-		countSQL = `
-        SELECT COUNT(*)
-        FROM metrics_usage_summary s
-        JOIN metrics_catalog c ON c.name = s.name
-        WHERE s.is_unused = TRUE
-          AND ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
-          AND ($2 = 'all' OR
-               CASE
-                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                  ELSE c.type = $2
-                END)
-          AND ($3 = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = $3
-          ))
-    `
-		baseQuery = `
-        SELECT c.name, c.type, c.help, c.unit,
-               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
-        FROM metrics_usage_summary s
-        JOIN metrics_catalog c ON c.name = s.name
-        WHERE s.is_unused = TRUE
-          AND ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
-          AND ($2 = 'all' OR
-               CASE
-                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                  ELSE c.type = $2
-                END)
-          AND ($3 = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = $3
-          ))
-    `
-		limitClause = " LIMIT $4 OFFSET $5"
-		countArgs = []any{params.Filter, params.Type, params.Job}
-		selectArgs = []any{params.Filter, params.Type, params.Job, params.PageSize, (params.Page - 1) * params.PageSize}
-	} else {
-		countSQL = `
+		return p.getSeriesMetadataUnused(ctx, params)
+	}
+
+	// Used / all: catalog-driven LEFT JOIN shape.
+	const countSQL = `
         SELECT COUNT(*)
         FROM metrics_catalog c
         LEFT JOIN metrics_usage_summary s ON s.name = c.name
@@ -793,7 +757,15 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
                 WHERE j.name = c.name AND j.job = $4
           ))
     `
-		baseQuery = `
+	var total int
+	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Usage, params.Job).Scan(&total); err != nil {
+		return nil, fmt.Errorf("count: %w", err)
+	}
+	if total == 0 {
+		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+	}
+
+	const baseQuery = `
         SELECT c.name, c.type, c.help, c.unit,
                COALESCE(s.alert_count,0), COALESCE(s.record_count,0), COALESCE(s.dashboard_count,0), COALESCE(s.query_count,0), s.last_queried_at
         FROM metrics_catalog c
@@ -819,34 +791,98 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
                 WHERE j.name = c.name AND j.job = $4
           ))
     `
-		limitClause = " LIMIT $5 OFFSET $6"
-		countArgs = []any{params.Filter, params.Type, params.Usage, params.Job}
-		selectArgs = []any{params.Filter, params.Type, params.Usage, params.Job, params.PageSize, (params.Page - 1) * params.PageSize}
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $5 OFFSET $6", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Usage, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
+	if err != nil {
+		return nil, fmt.Errorf("select: %w", err)
 	}
+	defer CloseResource(rows)
 
+	out, err := scanSeriesMetadataRows(rows, params.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	pages := (total + params.PageSize - 1) / params.PageSize
+	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+}
+
+// getSeriesMetadataUnused drives the ?usage=unused query from
+// metrics_usage_summary via the is_unused partial index, INNER JOIN
+// metrics_catalog. This lets the planner satisfy the unused subset with an
+// index scan instead of walking the full catalog and filtering. The two
+// SQL strings here are static literals; the conditional that picks this
+// method lives in GetSeriesMetadata.
+func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+	const countSQL = `
+        SELECT COUNT(*)
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+          AND ($3 = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = $3
+          ))
+    `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countSQL, countArgs...).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Job).Scan(&total); err != nil {
 		return nil, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
 		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
-	// Build complete query with safe ORDER BY clause to prevent SQL injection
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", limitClause, params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
-
-	rows, err := p.db.QueryContext(ctx, query, selectArgs...)
+	const baseQuery = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+          AND ($3 = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = $3
+          ))
+    `
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $4 OFFSET $5", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("select: %w", err)
 	}
 	defer CloseResource(rows)
 
+	out, err := scanSeriesMetadataRows(rows, params.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	pages := (total + params.PageSize - 1) / params.PageSize
+	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+}
+
+// scanSeriesMetadataRows scans rows returned by either GetSeriesMetadata
+// branch into a slice of models.MetricMetadata. Both branches return the
+// same column layout (the unused branch drops the COALESCE wrappers since
+// the INNER JOIN guarantees non-NULL summary counts, but the scanned
+// Go types are identical).
+func scanSeriesMetadataRows(rows *sql.Rows, pageSize int) ([]models.MetricMetadata, error) {
 	type row struct {
 		name, mtype, help, unit     string
 		alert, record, dash, qcount int
 		last                        sql.NullTime
 	}
-	out := make([]models.MetricMetadata, 0, params.PageSize)
+	out := make([]models.MetricMetadata, 0, pageSize)
 	for rows.Next() {
 		var r row
 		if err := rows.Scan(&r.name, &r.mtype, &r.help, &r.unit, &r.alert, &r.record, &r.dash, &r.qcount, &r.last); err != nil {
@@ -856,15 +892,12 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 		if r.last.Valid {
 			mm.LastQueriedAt = r.last.Time.UTC().Format(time.RFC3339)
 		}
-
 		out = append(out, mm)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iter: %w", err)
 	}
-
-	pages := (total + params.PageSize - 1) / params.PageSize
-	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+	return out, nil
 }
 
 func (p *PostGreSQLProvider) GetSeriesMetadataByNames(ctx context.Context, names []string, job string) ([]models.MetricMetadata, error) {

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -23,6 +23,142 @@ type PostGreSQLProvider struct {
 	db *sql.DB
 }
 
+// SeriesMetadata SQL literals for the PostgreSQL backend.
+//
+// Each pair is the static SQL backing one branch of GetSeriesMetadata:
+//   - pgSeriesMetadataCountSQL / pgSeriesMetadataBaseSQL drive the used/all
+//     branch via the catalog-driven LEFT JOIN shape.
+//   - pgSeriesMetadataUnusedCountSQL / pgSeriesMetadataUnusedBaseSQL drive
+//     the ?usage=unused branch from metrics_usage_summary via the
+//     is_unused partial index, INNER JOIN metrics_catalog.
+//   - pgSeriesMetadataUnusedJobCountSQL / pgSeriesMetadataUnusedJobBaseSQL
+//     drive ?usage=unused&job=<X> from metrics_job_index so per-request
+//     work scales with the size of the requested job's metric set rather
+//     than the entire unused universe.
+//
+// These are exposed as named consts (rather than inlined) so the Go SQL
+// scanner sees QueryContext receiving a string that does not depend on
+// user input, and so the queries are addressable from unit tests that
+// assert their shape and that they prepare cleanly against PostgreSQL.
+// The `%%` sequences in the Base SQL strings survive through
+// BuildSafeQueryWithOrderBy's fmt.Sprintf as `%%` (Sprintf does not
+// re-interpret `%` in the argument); PostgreSQL collapses consecutive
+// `%` in a LIKE/ILIKE pattern so the matched range is unchanged.
+const pgSeriesMetadataCountSQL = `
+        SELECT COUNT(*)
+        FROM metrics_catalog c
+        LEFT JOIN metrics_usage_summary s ON s.name = c.name
+        WHERE ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+          AND (
+                $3 = 'all'
+                OR ($3 = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+          )
+          AND ($4 = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = $4
+          ))
+    `
+
+const pgSeriesMetadataBaseSQL = `
+        SELECT c.name, c.type, c.help, c.unit,
+               COALESCE(s.alert_count,0), COALESCE(s.record_count,0), COALESCE(s.dashboard_count,0), COALESCE(s.query_count,0), s.last_queried_at
+        FROM metrics_catalog c
+        LEFT JOIN metrics_usage_summary s ON s.name = c.name
+        WHERE ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+          AND (
+                $3 = 'all'
+                OR ($3 = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+          )
+          AND ($4 = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = $4
+          ))
+    `
+
+const pgSeriesMetadataUnusedCountSQL = `
+        SELECT COUNT(*)
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+    `
+
+const pgSeriesMetadataUnusedBaseSQL = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+    `
+
+const pgSeriesMetadataUnusedJobCountSQL = `
+        SELECT COUNT(*)
+        FROM metrics_job_index j
+        JOIN metrics_usage_summary s ON s.name = j.name
+        JOIN metrics_catalog c ON c.name = j.name
+        WHERE j.job = $3
+          AND s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+    `
+
+const pgSeriesMetadataUnusedJobBaseSQL = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_job_index j
+        JOIN metrics_usage_summary s ON s.name = j.name
+        JOIN metrics_catalog c ON c.name = j.name
+        WHERE j.job = $3
+          AND s.is_unused = TRUE
+          AND ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
+          AND ($2 = 'all' OR
+               CASE
+                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                  ELSE c.type = $2
+                END)
+    `
+
 // Non-breaking alias for future rename migration
 type PostgreSQLProvider = PostGreSQLProvider
 
@@ -732,66 +868,15 @@ func (p *PostGreSQLProvider) GetSeriesMetadata(ctx context.Context, params Serie
 	}
 
 	// Used / all: catalog-driven LEFT JOIN shape.
-	const countSQL = `
-        SELECT COUNT(*)
-        FROM metrics_catalog c
-        LEFT JOIN metrics_usage_summary s ON s.name = c.name
-        WHERE ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
-          AND ($2 = 'all' OR
-               CASE
-                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                  ELSE c.type = $2
-                END)
-          AND (
-                $3 = 'all'
-                OR ($3 = 'used' AND (
-                     COALESCE(s.alert_count,0) > 0
-                     OR COALESCE(s.record_count,0) > 0
-                     OR COALESCE(s.dashboard_count,0) > 0
-                     OR COALESCE(s.query_count,0) > 0
-                ))
-          )
-          AND ($4 = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = $4
-          ))
-    `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Usage, params.Job).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, pgSeriesMetadataCountSQL, params.Filter, params.Type, params.Usage, params.Job).Scan(&total); err != nil {
 		return nil, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
 		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
-	const baseQuery = `
-        SELECT c.name, c.type, c.help, c.unit,
-               COALESCE(s.alert_count,0), COALESCE(s.record_count,0), COALESCE(s.dashboard_count,0), COALESCE(s.query_count,0), s.last_queried_at
-        FROM metrics_catalog c
-        LEFT JOIN metrics_usage_summary s ON s.name = c.name
-        WHERE ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
-          AND ($2 = 'all' OR
-               CASE
-                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                  ELSE c.type = $2
-                END)
-          AND (
-                $3 = 'all'
-                OR ($3 = 'used' AND (
-                     COALESCE(s.alert_count,0) > 0
-                     OR COALESCE(s.record_count,0) > 0
-                     OR COALESCE(s.dashboard_count,0) > 0
-                     OR COALESCE(s.query_count,0) > 0
-                ))
-          )
-          AND ($4 = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = $4
-          ))
-    `
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $5 OFFSET $6", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	query := BuildSafeQueryWithOrderBy(pgSeriesMetadataBaseSQL, "c", " LIMIT $5 OFFSET $6", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Usage, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("select: %w", err)
@@ -824,41 +909,14 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params
 		return p.getSeriesMetadataUnusedJobScoped(ctx, params)
 	}
 
-	const countSQL = `
-        SELECT COUNT(*)
-        FROM metrics_usage_summary s
-        JOIN metrics_catalog c ON c.name = s.name
-        WHERE s.is_unused = TRUE
-          AND ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
-          AND ($2 = 'all' OR
-               CASE
-                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                  ELSE c.type = $2
-                END)
-    `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, pgSeriesMetadataUnusedCountSQL, params.Filter, params.Type).Scan(&total); err != nil {
 		return nil, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
 		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
-	const baseQuery = `
-        SELECT c.name, c.type, c.help, c.unit,
-               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
-        FROM metrics_usage_summary s
-        JOIN metrics_catalog c ON c.name = s.name
-        WHERE s.is_unused = TRUE
-          AND ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
-          AND ($2 = 'all' OR
-               CASE
-                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                  ELSE c.type = $2
-                END)
-    `
 	// Force ORDER BY c.name for the unused branch regardless of the
 	// client-supplied sortBy. Every unused row has alert_count =
 	// record_count = dashboard_count = query_count = 0, so sorting by any
@@ -869,7 +927,7 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params
 	// idx_metrics_usage_summary_is_unused partial index's name ordering,
 	// so the planner can index-scan + LIMIT in O(LIMIT) work. sortOrder is
 	// still honoured so ?sortOrder=desc inverts the alphabetical listing.
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $3 OFFSET $4", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
+	query := BuildSafeQueryWithOrderBy(pgSeriesMetadataUnusedBaseSQL, "c", " LIMIT $3 OFFSET $4", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("select: %w", err)
@@ -893,50 +951,19 @@ func (p *PostGreSQLProvider) getSeriesMetadataUnused(ctx context.Context, params
 // ?usage=unused&job=kube-state-metrics request hit 139k unused metrics
 // looking for a sparse 57-row match.
 func (p *PostGreSQLProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
-	const countSQL = `
-        SELECT COUNT(*)
-        FROM metrics_job_index j
-        JOIN metrics_usage_summary s ON s.name = j.name
-        JOIN metrics_catalog c ON c.name = j.name
-        WHERE j.job = $3
-          AND s.is_unused = TRUE
-          AND ($1 = '' OR c.name ILIKE '%' || $1 || '%' OR c.help ILIKE '%' || $1 || '%')
-          AND ($2 = 'all' OR
-               CASE
-                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                  ELSE c.type = $2
-                END)
-    `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countSQL, params.Filter, params.Type, params.Job).Scan(&total); err != nil {
+	if err := p.db.QueryRowContext(ctx, pgSeriesMetadataUnusedJobCountSQL, params.Filter, params.Type, params.Job).Scan(&total); err != nil {
 		return nil, fmt.Errorf("count: %w", err)
 	}
 	if total == 0 {
 		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
-	const baseQuery = `
-        SELECT c.name, c.type, c.help, c.unit,
-               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
-        FROM metrics_job_index j
-        JOIN metrics_usage_summary s ON s.name = j.name
-        JOIN metrics_catalog c ON c.name = j.name
-        WHERE j.job = $3
-          AND s.is_unused = TRUE
-          AND ($1 = '' OR c.name ILIKE '%%' || $1 || '%%' OR c.help ILIKE '%%' || $1 || '%%')
-          AND ($2 = 'all' OR
-               CASE
-                  WHEN $2 = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                  WHEN $2 = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                  ELSE c.type = $2
-                END)
-    `
 	// Force ORDER BY c.name; see getSeriesMetadataUnused for rationale.
 	// The same all-zero-counts pattern applies here, and consistency
 	// matters because clients page through both shapes against the same
 	// API contract.
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT $4 OFFSET $5", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
+	query := BuildSafeQueryWithOrderBy(pgSeriesMetadataUnusedJobBaseSQL, "c", " LIMIT $4 OFFSET $5", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query, params.Filter, params.Type, params.Job, params.PageSize, (params.Page-1)*params.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("select: %w", err)

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
 	"testing"
 	"time"
@@ -664,6 +665,48 @@ func TestPostgreSQL_GetSeriesMetadata_UsageFilters(t *testing.T) {
 			assert.ElementsMatch(t, tt.wantNames, names)
 		})
 	}
+}
+
+// TestPostgreSQL_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow pins the
+// invariant the new ?usage=unused query depends on: after UpsertMetricsCatalog,
+// every catalog row has a corresponding metrics_usage_summary row with
+// is_unused=TRUE and zero counts, even before any RefreshMetricsUsageSummary.
+// This invariant lets the unused query INNER JOIN safely instead of having to
+// fall back to a LEFT JOIN + IS NULL branch.
+func TestPostgreSQL_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "metric_a", Type: "gauge", Help: "a"},
+		{Name: "metric_b", Type: "counter", Help: "b"},
+	})
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	rows, err := rawDB.QueryContext(context.Background(),
+		`SELECT name, alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary ORDER BY name`)
+	assert.NoError(t, err, "query summary")
+	defer func() { _ = rows.Close() }()
+
+	type summaryRow struct {
+		name                              string
+		alert, record, dashboard, queries int
+		isUnused                          bool
+	}
+	var got []summaryRow
+	for rows.Next() {
+		var r summaryRow
+		assert.NoError(t, rows.Scan(&r.name, &r.alert, &r.record, &r.dashboard, &r.queries, &r.isUnused))
+		got = append(got, r)
+	}
+	assert.NoError(t, rows.Err())
+
+	assert.Equal(t, []summaryRow{
+		{name: "metric_a", isUnused: true},
+		{name: "metric_b", isUnused: true},
+	}, got)
 }
 
 func TestPostgreSQL_DashboardUsage(t *testing.T) {

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -29,6 +29,14 @@ const (
 	ThirtyDays     = 30 * 24 * time.Hour
 )
 
+// SQL ORDER BY direction literals. resolveSafeSortOrder narrows the
+// user-supplied sortOrder to one of these two constants so the ORDER BY
+// direction in generated SQL is never user-controlled.
+const (
+	sortOrderASC  = "ASC"
+	sortOrderDESC = "DESC"
+)
+
 type Provider interface {
 	WithDB(func(db *sql.DB))
 	Insert(ctx context.Context, queries []Query) error
@@ -241,9 +249,9 @@ func resolveSafeSortExpr(sortBy, tableAlias, defaultSort string, sortAliases ...
 // even though the input came from an HTTP query parameter.
 func resolveSafeSortOrder(sortOrder string) string {
 	if strings.EqualFold(strings.TrimSpace(sortOrder), "asc") {
-		return "ASC"
+		return sortOrderASC
 	}
-	return "DESC"
+	return sortOrderDESC
 }
 
 // BuildSafeOrderByClause constructs a safe ORDER BY clause using validated parameters

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -205,25 +205,55 @@ func ValidatePagination(page *int, pageSize *int, defaultPageSize int) {
 	}
 }
 
+// resolveSafeSortExpr returns a SQL fragment for the ORDER BY column. The
+// returned string is always either a value from the static sortAliases map
+// or a hardcoded literal — it never embeds the caller's sortBy string.
+// ValidateSortField has already constrained sortBy to a key from
+// validSortFields; this layer rebuilds the SQL fragment from that key as a
+// map lookup so static analysers can see that user input never reaches the
+// SQL text by string interpolation. The defaultSort fallback assumes
+// callers keep validSortFields, sortAliases, and defaultSort consistent
+// (i.e. defaultSort is a key in sortAliases when sortAliases is provided);
+// the final "1" guarantees we always emit a valid ORDER BY expression
+// even if those invariants are violated.
+func resolveSafeSortExpr(sortBy, tableAlias, defaultSort string, sortAliases ...map[string]string) string {
+	if len(sortAliases) > 0 && sortAliases[0] != nil {
+		if expr, ok := sortAliases[0][sortBy]; ok {
+			return expr
+		}
+		if expr, ok := sortAliases[0][defaultSort]; ok {
+			return expr
+		}
+	}
+	if tableAlias != "" && defaultSort != "" {
+		return tableAlias + "." + defaultSort
+	}
+	if defaultSort != "" {
+		return defaultSort
+	}
+	return "1"
+}
+
+// resolveSafeSortOrder collapses sortOrder to one of two literal constants
+// ("ASC" or "DESC"). ValidateSortField has already narrowed sortOrder to
+// "asc" or "desc"; this function rewrites it into a literal so static
+// analysers can see that the ORDER BY direction is not user-controlled
+// even though the input came from an HTTP query parameter.
+func resolveSafeSortOrder(sortOrder string) string {
+	if strings.EqualFold(strings.TrimSpace(sortOrder), "asc") {
+		return "ASC"
+	}
+	return "DESC"
+}
+
 // BuildSafeOrderByClause constructs a safe ORDER BY clause using validated parameters
 // tableAlias should be the table alias (e.g., "c") or empty string if not needed
 // sortAliases optionally maps field names to their full SQL expression (e.g., "alertCount" -> "COALESCE(s.alert_count, 0)")
 func BuildSafeOrderByClause(sortBy, sortOrder, tableAlias string, validSortFields map[string]bool, defaultSort string, sortAliases ...map[string]string) string {
 	ValidateSortField(&sortBy, &sortOrder, validSortFields, defaultSort)
-
-	var sortExpr string
-	if len(sortAliases) > 0 && sortAliases[0] != nil {
-		if expr, ok := sortAliases[0][sortBy]; ok {
-			sortExpr = expr
-		}
-	}
-	if sortExpr == "" && tableAlias != "" {
-		sortExpr = fmt.Sprintf("%s.%s", tableAlias, sortBy)
-	} else if sortExpr == "" {
-		sortExpr = sortBy
-	}
-
-	return fmt.Sprintf(" ORDER BY %s %s NULLS LAST", sortExpr, strings.ToUpper(sortOrder))
+	return fmt.Sprintf(" ORDER BY %s %s NULLS LAST",
+		resolveSafeSortExpr(sortBy, tableAlias, defaultSort, sortAliases...),
+		resolveSafeSortOrder(sortOrder))
 }
 
 // BuildSafeQueryWithOrderBy constructs a complete query with validated ORDER BY clause
@@ -231,21 +261,11 @@ func BuildSafeOrderByClause(sortBy, sortOrder, tableAlias string, validSortField
 // sortAliases optionally maps field names to their full SQL expression for mixed-table sorting
 func BuildSafeQueryWithOrderBy(baseQuery, tableAlias, limitClause string, sortBy, sortOrder string, validSortFields map[string]bool, defaultSort string, sortAliases ...map[string]string) string {
 	ValidateSortField(&sortBy, &sortOrder, validSortFields, defaultSort)
-
-	var sortExpr string
-	if len(sortAliases) > 0 && sortAliases[0] != nil {
-		if expr, ok := sortAliases[0][sortBy]; ok {
-			sortExpr = expr
-		}
-	}
-	if sortExpr == "" && tableAlias != "" {
-		sortExpr = fmt.Sprintf("%s.%s", tableAlias, sortBy)
-	} else if sortExpr == "" {
-		sortExpr = sortBy
-	}
-
 	return fmt.Sprintf("%s ORDER BY %s %s NULLS LAST%s",
-		baseQuery, sortExpr, strings.ToUpper(sortOrder), limitClause)
+		baseQuery,
+		resolveSafeSortExpr(sortBy, tableAlias, defaultSort, sortAliases...),
+		resolveSafeSortOrder(sortOrder),
+		limitClause)
 }
 
 func CalculateTotalPages(totalCount, pageSize int) int {

--- a/internal/db/series_metadata_sql_test.go
+++ b/internal/db/series_metadata_sql_test.go
@@ -1,0 +1,338 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSeriesMetadataSQLConsts_Shape asserts the structural fingerprints of
+// each named SQL constant backing GetSeriesMetadata. These tests are not
+// trying to validate semantics (the integration tests do that) - they exist
+// so that the SQL string accidentally drifting in a way the reviewer would
+// catch (e.g. losing the is_unused predicate, losing the job filter, or
+// drifting placeholder count) trips a fast unit-level check before any
+// container is spun up.
+func TestSeriesMetadataSQLConsts_Shape(t *testing.T) {
+	cases := []struct {
+		name     string
+		sql      string
+		wantSubs []string
+		// For PG we count $N placeholders; for SQLite we count `?`. Each
+		// const targets one backend, so we assert exactly one of those.
+		pgPlaceholderCount     int
+		sqlitePlaceholderCount int
+	}{
+		// PostgreSQL: used / all
+		{
+			name: "pgSeriesMetadataCountSQL",
+			sql:  pgSeriesMetadataCountSQL,
+			wantSubs: []string{
+				"SELECT COUNT(*)",
+				"FROM metrics_catalog c",
+				"LEFT JOIN metrics_usage_summary s",
+				"$1", "$2", "$3", "$4",
+				"COALESCE(s.alert_count,0) > 0",
+				"metrics_job_index j",
+				"j.job = $4",
+			},
+			pgPlaceholderCount: 4,
+		},
+		{
+			name: "pgSeriesMetadataBaseSQL",
+			sql:  pgSeriesMetadataBaseSQL,
+			wantSubs: []string{
+				"SELECT c.name, c.type, c.help, c.unit",
+				"FROM metrics_catalog c",
+				"LEFT JOIN metrics_usage_summary s",
+				"$1", "$2", "$3", "$4",
+				"j.job = $4",
+			},
+			pgPlaceholderCount: 4,
+		},
+		// PostgreSQL: unused
+		{
+			name: "pgSeriesMetadataUnusedCountSQL",
+			sql:  pgSeriesMetadataUnusedCountSQL,
+			wantSubs: []string{
+				"SELECT COUNT(*)",
+				"FROM metrics_usage_summary s",
+				"JOIN metrics_catalog c",
+				"s.is_unused = TRUE",
+				"$1", "$2",
+			},
+			pgPlaceholderCount: 2,
+		},
+		{
+			name: "pgSeriesMetadataUnusedBaseSQL",
+			sql:  pgSeriesMetadataUnusedBaseSQL,
+			wantSubs: []string{
+				"FROM metrics_usage_summary s",
+				"JOIN metrics_catalog c",
+				"s.is_unused = TRUE",
+				"$1", "$2",
+			},
+			pgPlaceholderCount: 2,
+		},
+		// PostgreSQL: unused + job
+		{
+			name: "pgSeriesMetadataUnusedJobCountSQL",
+			sql:  pgSeriesMetadataUnusedJobCountSQL,
+			wantSubs: []string{
+				"FROM metrics_job_index j",
+				"JOIN metrics_usage_summary s",
+				"JOIN metrics_catalog c",
+				"j.job = $3",
+				"s.is_unused = TRUE",
+				"$1", "$2", "$3",
+			},
+			pgPlaceholderCount: 3,
+		},
+		{
+			name: "pgSeriesMetadataUnusedJobBaseSQL",
+			sql:  pgSeriesMetadataUnusedJobBaseSQL,
+			wantSubs: []string{
+				"FROM metrics_job_index j",
+				"JOIN metrics_usage_summary s",
+				"JOIN metrics_catalog c",
+				"j.job = $3",
+				"s.is_unused = TRUE",
+				"$1", "$2", "$3",
+			},
+			pgPlaceholderCount: 3,
+		},
+		// SQLite: used / all
+		{
+			name: "sqliteSeriesMetadataCountSQL",
+			sql:  sqliteSeriesMetadataCountSQL,
+			wantSubs: []string{
+				"SELECT COUNT(*)",
+				"FROM metrics_catalog c",
+				"LEFT JOIN metrics_usage_summary s",
+				"COALESCE(s.alert_count,0) > 0",
+				"metrics_job_index j",
+				"j.job = ?",
+			},
+			sqlitePlaceholderCount: 11,
+		},
+		{
+			name: "sqliteSeriesMetadataBaseSQL",
+			sql:  sqliteSeriesMetadataBaseSQL,
+			wantSubs: []string{
+				"SELECT c.name, c.type, c.help, c.unit",
+				"FROM metrics_catalog AS c",
+				"LEFT JOIN metrics_usage_summary AS s",
+				"j.job = ?",
+			},
+			sqlitePlaceholderCount: 11,
+		},
+		// SQLite: unused
+		{
+			name: "sqliteSeriesMetadataUnusedCountSQL",
+			sql:  sqliteSeriesMetadataUnusedCountSQL,
+			wantSubs: []string{
+				"FROM metrics_usage_summary s",
+				"JOIN metrics_catalog c",
+				"s.is_unused = TRUE",
+			},
+			sqlitePlaceholderCount: 7,
+		},
+		{
+			name: "sqliteSeriesMetadataUnusedBaseSQL",
+			sql:  sqliteSeriesMetadataUnusedBaseSQL,
+			wantSubs: []string{
+				"FROM metrics_usage_summary AS s",
+				"JOIN metrics_catalog AS c",
+				"s.is_unused = TRUE",
+			},
+			sqlitePlaceholderCount: 7,
+		},
+		// SQLite: unused + job
+		{
+			name: "sqliteSeriesMetadataUnusedJobCountSQL",
+			sql:  sqliteSeriesMetadataUnusedJobCountSQL,
+			wantSubs: []string{
+				"FROM metrics_job_index j",
+				"JOIN metrics_usage_summary s",
+				"JOIN metrics_catalog c",
+				"j.job = ?",
+				"s.is_unused = TRUE",
+			},
+			sqlitePlaceholderCount: 8,
+		},
+		{
+			name: "sqliteSeriesMetadataUnusedJobBaseSQL",
+			sql:  sqliteSeriesMetadataUnusedJobBaseSQL,
+			wantSubs: []string{
+				"FROM metrics_job_index AS j",
+				"JOIN metrics_usage_summary AS s",
+				"JOIN metrics_catalog AS c",
+				"j.job = ?",
+				"s.is_unused = TRUE",
+			},
+			sqlitePlaceholderCount: 8,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, sub := range tc.wantSubs {
+				assert.Contains(t, tc.sql, sub, "missing expected substring")
+			}
+			if tc.pgPlaceholderCount > 0 {
+				// Highest $N must equal pgPlaceholderCount and every lower
+				// $i must appear at least once. The straight counter approach
+				// (count $1..$N occurrences) breaks under repeated use of
+				// the same placeholder, so we just assert presence/absence.
+				for i := 1; i <= tc.pgPlaceholderCount; i++ {
+					assert.Contains(t, tc.sql, "$"+strconv.Itoa(i),
+						"expected placeholder $%d in %s", i, tc.name)
+				}
+				assert.NotContains(t, tc.sql, "$"+strconv.Itoa(tc.pgPlaceholderCount+1),
+					"unexpected extra placeholder $%d in %s", tc.pgPlaceholderCount+1, tc.name)
+			}
+			if tc.sqlitePlaceholderCount > 0 {
+				got := strings.Count(tc.sql, "?")
+				assert.Equal(t, tc.sqlitePlaceholderCount, got,
+					"placeholder count mismatch in %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestSeriesMetadataSQLConsts_PreparesSQLite ensures every SQL const targeting
+// the SQLite backend (the static count strings and the dynamic
+// BuildSafeQueryWithOrderBy output applied to each base string) is accepted
+// by SQLite's parser against a real migrated schema. This catches regressions
+// where a const accidentally references a missing column or where the
+// dynamic ORDER BY emission produces a syntactically invalid query.
+func TestSeriesMetadataSQLConsts_PreparesSQLite(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	t.Cleanup(cleanup)
+
+	var rawDB *sql.DB
+	p.WithDB(func(db *sql.DB) { rawDB = db })
+	require.NotNil(t, rawDB, "WithDB must surface the underlying *sql.DB")
+
+	type row struct {
+		name string
+		sql  string
+	}
+	staticCounts := []row{
+		{"sqliteSeriesMetadataCountSQL", sqliteSeriesMetadataCountSQL},
+		{"sqliteSeriesMetadataUnusedCountSQL", sqliteSeriesMetadataUnusedCountSQL},
+		{"sqliteSeriesMetadataUnusedJobCountSQL", sqliteSeriesMetadataUnusedJobCountSQL},
+	}
+	for _, r := range staticCounts {
+		t.Run("count/"+r.name, func(t *testing.T) {
+			stmt, err := rawDB.PrepareContext(context.Background(), r.sql)
+			require.NoError(t, err, "%s must prepare against SQLite", r.name)
+			require.NoError(t, stmt.Close())
+		})
+	}
+
+	// Base queries always flow through BuildSafeQueryWithOrderBy before
+	// reaching the driver. Mirror the call-site arguments precisely so we
+	// catch breakage in either the const or the helper.
+	baseQueries := []struct {
+		name     string
+		built    string
+		expected string
+	}{
+		{
+			name: "sqliteSeriesMetadataBaseSQL",
+			built: BuildSafeQueryWithOrderBy(sqliteSeriesMetadataBaseSQL, "c",
+				" LIMIT ? OFFSET ?", "queryCount", "desc",
+				ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases),
+		},
+		{
+			name: "sqliteSeriesMetadataUnusedBaseSQL",
+			built: BuildSafeQueryWithOrderBy(sqliteSeriesMetadataUnusedBaseSQL, "c",
+				" LIMIT ? OFFSET ?", "name", "desc",
+				ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases),
+		},
+		{
+			name: "sqliteSeriesMetadataUnusedJobBaseSQL",
+			built: BuildSafeQueryWithOrderBy(sqliteSeriesMetadataUnusedJobBaseSQL, "c",
+				" LIMIT ? OFFSET ?", "name", "desc",
+				ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases),
+		},
+	}
+	for _, q := range baseQueries {
+		t.Run("base/"+q.name, func(t *testing.T) {
+			assert.Contains(t, q.built, "ORDER BY",
+				"built query must include ORDER BY clause")
+			assert.Contains(t, q.built, "LIMIT ? OFFSET ?",
+				"built query must include LIMIT clause")
+			stmt, err := rawDB.PrepareContext(context.Background(), q.built)
+			require.NoError(t, err, "%s must prepare against SQLite", q.name)
+			require.NoError(t, stmt.Close())
+		})
+	}
+}
+
+// TestSeriesMetadataSQLConsts_PreparesPostgreSQL mirrors the SQLite check
+// against a real PostgreSQL container. Skips automatically when Docker is
+// not available (matches the pattern used by the other postgresql_test.go
+// suites).
+func TestSeriesMetadataSQLConsts_PreparesPostgreSQL(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	t.Cleanup(cleanup)
+
+	var rawDB *sql.DB
+	p.WithDB(func(db *sql.DB) { rawDB = db })
+	require.NotNil(t, rawDB, "WithDB must surface the underlying *sql.DB")
+
+	staticCounts := []struct {
+		name string
+		sql  string
+	}{
+		{"pgSeriesMetadataCountSQL", pgSeriesMetadataCountSQL},
+		{"pgSeriesMetadataUnusedCountSQL", pgSeriesMetadataUnusedCountSQL},
+		{"pgSeriesMetadataUnusedJobCountSQL", pgSeriesMetadataUnusedJobCountSQL},
+	}
+	for _, r := range staticCounts {
+		t.Run("count/"+r.name, func(t *testing.T) {
+			stmt, err := rawDB.PrepareContext(context.Background(), r.sql)
+			require.NoError(t, err, "%s must prepare against PostgreSQL", r.name)
+			require.NoError(t, stmt.Close())
+		})
+	}
+
+	baseQueries := []struct {
+		name  string
+		built string
+	}{
+		{
+			name: "pgSeriesMetadataBaseSQL",
+			built: BuildSafeQueryWithOrderBy(pgSeriesMetadataBaseSQL, "c",
+				" LIMIT $5 OFFSET $6", "queryCount", "desc",
+				ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases),
+		},
+		{
+			name: "pgSeriesMetadataUnusedBaseSQL",
+			built: BuildSafeQueryWithOrderBy(pgSeriesMetadataUnusedBaseSQL, "c",
+				" LIMIT $3 OFFSET $4", "name", "desc",
+				ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases),
+		},
+		{
+			name: "pgSeriesMetadataUnusedJobBaseSQL",
+			built: BuildSafeQueryWithOrderBy(pgSeriesMetadataUnusedJobBaseSQL, "c",
+				" LIMIT $4 OFFSET $5", "name", "desc",
+				ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases),
+		},
+	}
+	for _, q := range baseQueries {
+		t.Run("base/"+q.name, func(t *testing.T) {
+			assert.Contains(t, q.built, "ORDER BY")
+			stmt, err := rawDB.PrepareContext(context.Background(), q.built)
+			require.NoError(t, err, "%s must prepare against PostgreSQL", q.name)
+			require.NoError(t, stmt.Close())
+		})
+	}
+}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -714,62 +714,18 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 	}
 	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
-	// When usage == "unused" we drive the query from metrics_usage_summary
-	// filtered by the is_unused partial index, then INNER JOIN metrics_catalog.
-	// This lets the planner satisfy the unused subset with an index scan
-	// instead of walking metrics_catalog and filtering. For used/all we keep
-	// the catalog-driven LEFT JOIN shape that the existing branches expect.
-	var countQuery, baseQuery string
-	var countArgs, selectArgs []any
+	// usage=unused is handled by a dedicated method with a distinct query
+	// shape (driven from metrics_usage_summary via the is_unused partial
+	// index, INNER JOIN metrics_catalog). Splitting it out keeps each path's
+	// SQL as a single static literal - this matters for code scanning,
+	// which otherwise flags QueryContext as having a query string that
+	// control-depends on the user-controlled Usage value.
 	if params.Usage == SeriesMetadataUsageUnused {
-		countQuery = `
-        SELECT COUNT(*)
-        FROM metrics_usage_summary s
-        JOIN metrics_catalog c ON c.name = s.name
-        WHERE s.is_unused = TRUE
-          AND (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
-          AND (? = 'all' OR
-               CASE
-                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = ?
-                END)
-          AND (? = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = ?
-          ))
-    `
-		baseQuery = `
-        SELECT c.name, c.type, c.help, c.unit,
-               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
-        FROM metrics_usage_summary AS s
-        JOIN metrics_catalog AS c ON c.name = s.name
-        WHERE s.is_unused = TRUE
-          AND (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
-          AND (? = 'all' OR
-               CASE
-                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = ?
-                END)
-          AND (? = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = ?
-          ))
-    `
-		countArgs = []any{
-			params.Filter, params.Filter, params.Filter,
-			params.Type, params.Type, params.Type, params.Type,
-			params.Job, params.Job,
-		}
-		selectArgs = []any{
-			params.Filter, params.Filter, params.Filter,
-			params.Type, params.Type, params.Type, params.Type,
-			params.Job, params.Job,
-			params.PageSize, (params.Page - 1) * params.PageSize,
-		}
-	} else {
-		countQuery = `
+		return p.getSeriesMetadataUnused(ctx, params)
+	}
+
+	// Used / all: catalog-driven LEFT JOIN shape.
+	const countQuery = `
         SELECT COUNT(*)
         FROM metrics_catalog c
         LEFT JOIN metrics_usage_summary s ON s.name = c.name
@@ -794,7 +750,20 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                 WHERE j.name = c.name AND j.job = ?
           ))
     `
-		baseQuery = `
+	var total int
+	if err := p.db.QueryRowContext(ctx, countQuery,
+		params.Filter, params.Filter, params.Filter,
+		params.Type, params.Type, params.Type, params.Type,
+		params.Usage, params.Usage,
+		params.Job, params.Job,
+	).Scan(&total); err != nil {
+		return nil, fmt.Errorf("failed to count catalog: %w", err)
+	}
+	if total == 0 {
+		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+	}
+
+	const baseQuery = `
         SELECT c.name, c.type, c.help, c.unit,
                COALESCE(s.alert_count, 0), COALESCE(s.record_count, 0), COALESCE(s.dashboard_count, 0), COALESCE(s.query_count, 0), s.last_queried_at
         FROM metrics_catalog AS c
@@ -820,72 +789,99 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                 WHERE j.name = c.name AND j.job = ?
           ))
     `
-		countArgs = []any{
-			params.Filter, params.Filter, params.Filter,
-			params.Type, params.Type, params.Type, params.Type,
-			params.Usage, params.Usage,
-			params.Job, params.Job,
-		}
-		selectArgs = []any{
-			params.Filter, params.Filter, params.Filter,
-			params.Type, params.Type, params.Type, params.Type,
-			params.Usage, params.Usage,
-			params.Job, params.Job,
-			params.PageSize, (params.Page - 1) * params.PageSize,
-		}
-	}
-
-	var total int
-	if err := p.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total); err != nil {
-		return nil, fmt.Errorf("failed to count catalog: %w", err)
-	}
-
-	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
-	}
-
-	// Build complete query with safe ORDER BY clause to prevent SQL injection
 	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
-
-	rows, err := p.db.QueryContext(ctx, query, selectArgs...)
+	rows, err := p.db.QueryContext(ctx, query,
+		params.Filter, params.Filter, params.Filter,
+		params.Type, params.Type, params.Type, params.Type,
+		params.Usage, params.Usage,
+		params.Job, params.Job,
+		params.PageSize, (params.Page-1)*params.PageSize,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query series metadata: %w", err)
 	}
 	defer CloseResource(rows)
 
-	type row struct {
-		name, mtype, help, unit     string
-		alert, record, dash, qcount int
-		last                        sql.NullTime
+	out, err := scanSeriesMetadataRows(rows, params.PageSize)
+	if err != nil {
+		return nil, err
 	}
-	results := make([]models.MetricMetadata, 0, params.PageSize)
-	for rows.Next() {
-		var r row
-		if err := rows.Scan(&r.name, &r.mtype, &r.help, &r.unit, &r.alert, &r.record, &r.dash, &r.qcount, &r.last); err != nil {
-			return nil, fmt.Errorf("failed to scan row: %w", err)
-		}
-		mm := models.MetricMetadata{
-			Name:           r.name,
-			Type:           r.mtype,
-			Help:           r.help,
-			Unit:           r.unit,
-			AlertCount:     r.alert,
-			RecordCount:    r.record,
-			DashboardCount: r.dash,
-			QueryCount:     r.qcount,
-		}
-		if r.last.Valid {
-			mm.LastQueriedAt = r.last.Time.UTC().Format(time.RFC3339)
-		}
-
-		results = append(results, mm)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("row iteration error: %w", err)
-	}
-
 	pages := (total + params.PageSize - 1) / params.PageSize
-	return &PagedResult{Total: total, TotalPages: pages, Data: results}, nil
+	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+}
+
+// getSeriesMetadataUnused drives the ?usage=unused query from
+// metrics_usage_summary via the is_unused partial index, INNER JOIN
+// metrics_catalog. This lets the planner satisfy the unused subset with an
+// index scan instead of walking the full catalog and filtering. The two
+// SQL strings here are static literals; the conditional that picks this
+// method lives in GetSeriesMetadata.
+func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+	const countQuery = `
+        SELECT COUNT(*)
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, countQuery,
+		params.Filter, params.Filter, params.Filter,
+		params.Type, params.Type, params.Type, params.Type,
+		params.Job, params.Job,
+	).Scan(&total); err != nil {
+		return nil, fmt.Errorf("failed to count catalog: %w", err)
+	}
+	if total == 0 {
+		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+	}
+
+	const baseQuery = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_usage_summary AS s
+        JOIN metrics_catalog AS c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
+    `
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	rows, err := p.db.QueryContext(ctx, query,
+		params.Filter, params.Filter, params.Filter,
+		params.Type, params.Type, params.Type, params.Type,
+		params.Job, params.Job,
+		params.PageSize, (params.Page-1)*params.PageSize,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query series metadata: %w", err)
+	}
+	defer CloseResource(rows)
+
+	out, err := scanSeriesMetadataRows(rows, params.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	pages := (total + params.PageSize - 1) / params.PageSize
+	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
 }
 
 // GetSeriesMetadataByNames returns metadata and usage summary for a fixed list of names, optionally filtered by job.

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -816,7 +816,18 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 // index scan instead of walking the full catalog and filtering. The two
 // SQL strings here are static literals; the conditional that picks this
 // method lives in GetSeriesMetadata.
+//
+// When a job filter is provided the optimal access pattern flips - driving
+// from is_unused=TRUE and EXISTS-probing metrics_job_index per row scales
+// with the entire unused universe rather than with the requested job, which
+// catastrophically misses for jobs that match a small slice of unused
+// metrics. The job case is therefore handled by getSeriesMetadataUnusedJobScoped,
+// which drives from metrics_job_index instead.
 func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+	if params.Job != "" {
+		return p.getSeriesMetadataUnusedJobScoped(ctx, params)
+	}
+
 	const countQuery = `
         SELECT COUNT(*)
         FROM metrics_usage_summary s
@@ -829,16 +840,11 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
                  WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
                  ELSE c.type = ?
                 END)
-          AND (? = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = ?
-          ))
     `
 	var total int
 	if err := p.db.QueryRowContext(ctx, countQuery,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
-		params.Job, params.Job,
 	).Scan(&total); err != nil {
 		return nil, fmt.Errorf("failed to count catalog: %w", err)
 	}
@@ -859,16 +865,83 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
                  WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
                  ELSE c.type = ?
                 END)
-          AND (? = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = ?
-          ))
     `
 	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
-		params.Job, params.Job,
+		params.PageSize, (params.Page-1)*params.PageSize,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query series metadata: %w", err)
+	}
+	defer CloseResource(rows)
+
+	out, err := scanSeriesMetadataRows(rows, params.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	pages := (total + params.PageSize - 1) / params.PageSize
+	return &PagedResult{Total: total, TotalPages: pages, Data: out}, nil
+}
+
+// getSeriesMetadataUnusedJobScoped drives ?usage=unused&job=<X> from
+// metrics_job_index (filtered to the requested job via the composite
+// (job, name) index) and INNER JOINs to metrics_usage_summary (filtered by
+// is_unused=TRUE) and metrics_catalog. This makes per-request work scale
+// with the size of the requested job's metric set, not with the entire
+// unused universe - the latter is what cratered cx10 when the operator's
+// ?usage=unused&job=kube-state-metrics request hit 139k unused metrics
+// looking for a sparse 57-row match.
+func (p *SQLiteProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
+	const countQuery = `
+        SELECT COUNT(*)
+        FROM metrics_job_index j
+        JOIN metrics_usage_summary s ON s.name = j.name
+        JOIN metrics_catalog c ON c.name = j.name
+        WHERE j.job = ?
+          AND s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+    `
+	var total int
+	if err := p.db.QueryRowContext(ctx, countQuery,
+		params.Job,
+		params.Filter, params.Filter, params.Filter,
+		params.Type, params.Type, params.Type, params.Type,
+	).Scan(&total); err != nil {
+		return nil, fmt.Errorf("failed to count catalog: %w", err)
+	}
+	if total == 0 {
+		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+	}
+
+	const baseQuery = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_job_index AS j
+        JOIN metrics_usage_summary AS s ON s.name = j.name
+        JOIN metrics_catalog AS c ON c.name = j.name
+        WHERE j.job = ?
+          AND s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+    `
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	rows, err := p.db.QueryContext(ctx, query,
+		params.Job,
+		params.Filter, params.Filter, params.Filter,
+		params.Type, params.Type, params.Type, params.Type,
 		params.PageSize, (params.Page-1)*params.PageSize,
 	)
 	if err != nil {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -714,8 +714,62 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 	}
 	params.Usage = NormalizeSeriesMetadataUsage(params.Usage)
 
-	// Count
-	countQuery := `
+	// When usage == "unused" we drive the query from metrics_usage_summary
+	// filtered by the is_unused partial index, then INNER JOIN metrics_catalog.
+	// This lets the planner satisfy the unused subset with an index scan
+	// instead of walking metrics_catalog and filtering. For used/all we keep
+	// the catalog-driven LEFT JOIN shape that the existing branches expect.
+	var countQuery, baseQuery string
+	var countArgs, selectArgs []any
+	if params.Usage == SeriesMetadataUsageUnused {
+		countQuery = `
+        SELECT COUNT(*)
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
+    `
+		baseQuery = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_usage_summary AS s
+        JOIN metrics_catalog AS c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
+    `
+		countArgs = []any{
+			params.Filter, params.Filter, params.Filter,
+			params.Type, params.Type, params.Type, params.Type,
+			params.Job, params.Job,
+		}
+		selectArgs = []any{
+			params.Filter, params.Filter, params.Filter,
+			params.Type, params.Type, params.Type, params.Type,
+			params.Job, params.Job,
+			params.PageSize, (params.Page - 1) * params.PageSize,
+		}
+	} else {
+		countQuery = `
         SELECT COUNT(*)
         FROM metrics_catalog c
         LEFT JOIN metrics_usage_summary s ON s.name = c.name
@@ -734,26 +788,13 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                      OR COALESCE(s.dashboard_count,0) > 0
                      OR COALESCE(s.query_count,0) > 0
                 ))
-                OR (? = 'unused' AND
-                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
-                )
           )
           AND (? = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
                 WHERE j.name = c.name AND j.job = ?
           ))
     `
-	var total int
-	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter, params.Filter, params.Filter, params.Type, params.Type, params.Type, params.Type, params.Usage, params.Usage, params.Usage, params.Job, params.Job).Scan(&total); err != nil {
-		return nil, fmt.Errorf("failed to count catalog: %w", err)
-	}
-
-	if total == 0 {
-		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
-	}
-
-	// Query page with left join to usage summary
-	baseQuery := `
+		baseQuery = `
         SELECT c.name, c.type, c.help, c.unit,
                COALESCE(s.alert_count, 0), COALESCE(s.record_count, 0), COALESCE(s.dashboard_count, 0), COALESCE(s.query_count, 0), s.last_queried_at
         FROM metrics_catalog AS c
@@ -773,25 +814,40 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
                      OR COALESCE(s.dashboard_count,0) > 0
                      OR COALESCE(s.query_count,0) > 0
                 ))
-                OR (? = 'unused' AND
-                     COALESCE(s.alert_count,0)=0 AND COALESCE(s.record_count,0)=0 AND COALESCE(s.dashboard_count,0)=0 AND COALESCE(s.query_count,0)=0
-                )
           )
           AND (? = '' OR EXISTS (
                 SELECT 1 FROM metrics_job_index j
                 WHERE j.name = c.name AND j.job = ?
           ))
     `
+		countArgs = []any{
+			params.Filter, params.Filter, params.Filter,
+			params.Type, params.Type, params.Type, params.Type,
+			params.Usage, params.Usage,
+			params.Job, params.Job,
+		}
+		selectArgs = []any{
+			params.Filter, params.Filter, params.Filter,
+			params.Type, params.Type, params.Type, params.Type,
+			params.Usage, params.Usage,
+			params.Job, params.Job,
+			params.PageSize, (params.Page - 1) * params.PageSize,
+		}
+	}
+
+	var total int
+	if err := p.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total); err != nil {
+		return nil, fmt.Errorf("failed to count catalog: %w", err)
+	}
+
+	if total == 0 {
+		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
+	}
+
 	// Build complete query with safe ORDER BY clause to prevent SQL injection
 	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
 
-	rows, err := p.db.QueryContext(ctx, query,
-		params.Filter, params.Filter, params.Filter,
-		params.Type, params.Type, params.Type, params.Type,
-		params.Usage, params.Usage, params.Usage,
-		params.Job, params.Job,
-		params.PageSize, (params.Page-1)*params.PageSize,
-	)
+	rows, err := p.db.QueryContext(ctx, query, selectArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query series metadata: %w", err)
 	}
@@ -927,10 +983,31 @@ func (p *SQLiteProvider) UpsertMetricsCatalog(ctx context.Context, items []Metri
 		return fmt.Errorf("prepare: %w", err)
 	}
 	defer CloseResource(stmt)
+
+	// Co-write a default-unused summary row per catalog item so the
+	// metrics_catalog <-> metrics_usage_summary invariant holds before
+	// the next RefreshMetricsUsageSummary. ON CONFLICT DO NOTHING means
+	// existing rows with real counts are not clobbered. The new
+	// ?usage=unused query depends on this invariant to use an INNER JOIN.
+	summaryStmt, err := tx.PrepareContext(ctx, `
+        INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused)
+        VALUES(?, 0, 0, 0, 0, datetime('now'), TRUE)
+        ON CONFLICT(name) DO NOTHING
+    `)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("prepare summary: %w", err)
+	}
+	defer CloseResource(summaryStmt)
+
 	for _, it := range items {
 		if _, err := stmt.ExecContext(ctx, it.Name, it.Type, it.Help, it.Unit); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("exec: %w", err)
+		}
+		if _, err := summaryStmt.ExecContext(ctx, it.Name); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("exec summary: %w", err)
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -997,14 +1074,18 @@ func (p *SQLiteProvider) ListJobs(ctx context.Context) ([]string, error) {
 func (p *SQLiteProvider) RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error {
 	from, to := PrepareTimeRange(tr, "sqlite")
 	query := `
-    INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, last_queried_at, updated_at)
+    INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, last_queried_at, updated_at, is_unused)
     SELECT c.name,
            COALESCE(ra.alert_count, 0),
            COALESCE(ra.record_count, 0),
            COALESCE(da.dashboard_count, 0),
            COALESCE(qa.query_count, 0),
            qa.last_queried_at,
-           datetime('now')
+           datetime('now'),
+           (COALESCE(ra.alert_count, 0) = 0
+            AND COALESCE(ra.record_count, 0) = 0
+            AND COALESCE(da.dashboard_count, 0) = 0
+            AND COALESCE(qa.query_count, 0) = 0)
     FROM metrics_catalog c
     LEFT JOIN (
         SELECT serie AS name,
@@ -1035,7 +1116,8 @@ func (p *SQLiteProvider) RefreshMetricsUsageSummary(ctx context.Context, tr Time
         dashboard_count=excluded.dashboard_count,
         query_count=excluded.query_count,
         last_queried_at=excluded.last_queried_at,
-        updated_at=excluded.updated_at;
+        updated_at=excluded.updated_at,
+        is_unused=excluded.is_unused;
     `
 	_, err := p.db.ExecContext(ctx, query, to, from, to, from, from, to)
 	if err != nil {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -989,6 +989,10 @@ func (p *SQLiteProvider) UpsertMetricsCatalog(ctx context.Context, items []Metri
 	// the next RefreshMetricsUsageSummary. ON CONFLICT DO NOTHING means
 	// existing rows with real counts are not clobbered. The new
 	// ?usage=unused query depends on this invariant to use an INNER JOIN.
+	//
+	// Kept as a per-item prepared statement (vs. PG's bulk unnest) because
+	// SQLite is in-process: per-exec overhead is microseconds and there's
+	// no network round-trip to amortise.
 	summaryStmt, err := tx.PrepareContext(ctx, `
         INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused)
         VALUES(?, 0, 0, 0, 0, datetime('now'), TRUE)

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -25,6 +25,133 @@ type SQLiteProvider struct {
 
 // DDL creation moved to embedded Goose migrations.
 
+// SeriesMetadata SQL literals for the SQLite backend.
+//
+// Each pair is the static SQL backing one branch of GetSeriesMetadata,
+// mirroring the PostgreSQL constants above. SQLite uses '?' positional
+// placeholders instead of '$N' so the parameter shape and parameter
+// repetition differ from the PostgreSQL variants; see the QueryRowContext
+// / QueryContext call sites for the exact argument layout.
+//
+// These are exposed as named consts (rather than inlined) so the Go SQL
+// scanner sees QueryContext receiving a string that does not depend on
+// user input, and so the queries are addressable from unit tests that
+// assert their shape and that they prepare cleanly against SQLite.
+const sqliteSeriesMetadataCountSQL = `
+        SELECT COUNT(*)
+        FROM metrics_catalog c
+        LEFT JOIN metrics_usage_summary s ON s.name = c.name
+        WHERE (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+          AND (
+                ? = 'all'
+                OR (? = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+          )
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
+    `
+
+const sqliteSeriesMetadataBaseSQL = `
+        SELECT c.name, c.type, c.help, c.unit,
+               COALESCE(s.alert_count, 0), COALESCE(s.record_count, 0), COALESCE(s.dashboard_count, 0), COALESCE(s.query_count, 0), s.last_queried_at
+        FROM metrics_catalog AS c
+        LEFT JOIN metrics_usage_summary AS s ON s.name = c.name
+        WHERE (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+          AND (
+                ? = 'all'
+                OR (? = 'used' AND (
+                     COALESCE(s.alert_count,0) > 0
+                     OR COALESCE(s.record_count,0) > 0
+                     OR COALESCE(s.dashboard_count,0) > 0
+                     OR COALESCE(s.query_count,0) > 0
+                ))
+          )
+          AND (? = '' OR EXISTS (
+                SELECT 1 FROM metrics_job_index j
+                WHERE j.name = c.name AND j.job = ?
+          ))
+    `
+
+const sqliteSeriesMetadataUnusedCountSQL = `
+        SELECT COUNT(*)
+        FROM metrics_usage_summary s
+        JOIN metrics_catalog c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+    `
+
+const sqliteSeriesMetadataUnusedBaseSQL = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_usage_summary AS s
+        JOIN metrics_catalog AS c ON c.name = s.name
+        WHERE s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+    `
+
+const sqliteSeriesMetadataUnusedJobCountSQL = `
+        SELECT COUNT(*)
+        FROM metrics_job_index j
+        JOIN metrics_usage_summary s ON s.name = j.name
+        JOIN metrics_catalog c ON c.name = j.name
+        WHERE j.job = ?
+          AND s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+    `
+
+const sqliteSeriesMetadataUnusedJobBaseSQL = `
+        SELECT c.name, c.type, c.help, c.unit,
+               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
+        FROM metrics_job_index AS j
+        JOIN metrics_usage_summary AS s ON s.name = j.name
+        JOIN metrics_catalog AS c ON c.name = j.name
+        WHERE j.job = ?
+          AND s.is_unused = TRUE
+          AND (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
+          AND (? = 'all' OR
+               CASE
+                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
+                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
+                 ELSE c.type = ?
+                END)
+    `
+
 func RegisterSqliteFlags(flagSet *flag.FlagSet) {
 	flagSet.StringVar(&config.DefaultConfig.Database.SQLite.DatabasePath, "sqlite-database-path", "prom-analytics-proxy.db", "Path to the sqlite database.")
 }
@@ -725,33 +852,8 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 	}
 
 	// Used / all: catalog-driven LEFT JOIN shape.
-	const countQuery = `
-        SELECT COUNT(*)
-        FROM metrics_catalog c
-        LEFT JOIN metrics_usage_summary s ON s.name = c.name
-        WHERE (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
-          AND (? = 'all' OR
-               CASE
-                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = ?
-                END)
-          AND (
-                ? = 'all'
-                OR (? = 'used' AND (
-                     COALESCE(s.alert_count,0) > 0
-                     OR COALESCE(s.record_count,0) > 0
-                     OR COALESCE(s.dashboard_count,0) > 0
-                     OR COALESCE(s.query_count,0) > 0
-                ))
-          )
-          AND (? = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = ?
-          ))
-    `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countQuery,
+	if err := p.db.QueryRowContext(ctx, sqliteSeriesMetadataCountSQL,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
 		params.Usage, params.Usage,
@@ -763,33 +865,7 @@ func (p *SQLiteProvider) GetSeriesMetadata(ctx context.Context, params SeriesMet
 		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
-	const baseQuery = `
-        SELECT c.name, c.type, c.help, c.unit,
-               COALESCE(s.alert_count, 0), COALESCE(s.record_count, 0), COALESCE(s.dashboard_count, 0), COALESCE(s.query_count, 0), s.last_queried_at
-        FROM metrics_catalog AS c
-        LEFT JOIN metrics_usage_summary AS s ON s.name = c.name
-        WHERE (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
-          AND (? = 'all' OR
-               CASE
-                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = ?
-                END)
-          AND (
-                ? = 'all'
-                OR (? = 'used' AND (
-                     COALESCE(s.alert_count,0) > 0
-                     OR COALESCE(s.record_count,0) > 0
-                     OR COALESCE(s.dashboard_count,0) > 0
-                     OR COALESCE(s.query_count,0) > 0
-                ))
-          )
-          AND (? = '' OR EXISTS (
-                SELECT 1 FROM metrics_job_index j
-                WHERE j.name = c.name AND j.job = ?
-          ))
-    `
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	query := BuildSafeQueryWithOrderBy(sqliteSeriesMetadataBaseSQL, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
@@ -828,21 +904,8 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
 		return p.getSeriesMetadataUnusedJobScoped(ctx, params)
 	}
 
-	const countQuery = `
-        SELECT COUNT(*)
-        FROM metrics_usage_summary s
-        JOIN metrics_catalog c ON c.name = s.name
-        WHERE s.is_unused = TRUE
-          AND (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
-          AND (? = 'all' OR
-               CASE
-                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = ?
-                END)
-    `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countQuery,
+	if err := p.db.QueryRowContext(ctx, sqliteSeriesMetadataUnusedCountSQL,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
 	).Scan(&total); err != nil {
@@ -852,20 +915,6 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
 		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
-	const baseQuery = `
-        SELECT c.name, c.type, c.help, c.unit,
-               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
-        FROM metrics_usage_summary AS s
-        JOIN metrics_catalog AS c ON c.name = s.name
-        WHERE s.is_unused = TRUE
-          AND (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
-          AND (? = 'all' OR
-               CASE
-                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = ?
-                END)
-    `
 	// Force ORDER BY c.name for the unused branch regardless of the
 	// client-supplied sortBy. Every unused row has alert_count =
 	// record_count = dashboard_count = query_count = 0, so sorting by any
@@ -876,7 +925,7 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
 	// idx_metrics_usage_summary_is_unused partial index's name ordering,
 	// so the planner can index-scan + LIMIT in O(LIMIT) work. sortOrder is
 	// still honoured so ?sortOrder=desc inverts the alphabetical listing.
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
+	query := BuildSafeQueryWithOrderBy(sqliteSeriesMetadataUnusedBaseSQL, "c", " LIMIT ? OFFSET ?", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
@@ -904,23 +953,8 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
 // ?usage=unused&job=kube-state-metrics request hit 139k unused metrics
 // looking for a sparse 57-row match.
 func (p *SQLiteProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, params SeriesMetadataParams) (*PagedResult, error) {
-	const countQuery = `
-        SELECT COUNT(*)
-        FROM metrics_job_index j
-        JOIN metrics_usage_summary s ON s.name = j.name
-        JOIN metrics_catalog c ON c.name = j.name
-        WHERE j.job = ?
-          AND s.is_unused = TRUE
-          AND (? = '' OR c.name LIKE '%' || ? || '%' OR c.help LIKE '%' || ? || '%')
-          AND (? = 'all' OR
-               CASE
-                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = ?
-                END)
-    `
 	var total int
-	if err := p.db.QueryRowContext(ctx, countQuery,
+	if err := p.db.QueryRowContext(ctx, sqliteSeriesMetadataUnusedJobCountSQL,
 		params.Job,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
@@ -931,27 +965,11 @@ func (p *SQLiteProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, p
 		return &PagedResult{Total: 0, TotalPages: 0, Data: []models.MetricMetadata{}}, nil
 	}
 
-	const baseQuery = `
-        SELECT c.name, c.type, c.help, c.unit,
-               s.alert_count, s.record_count, s.dashboard_count, s.query_count, s.last_queried_at
-        FROM metrics_job_index AS j
-        JOIN metrics_usage_summary AS s ON s.name = j.name
-        JOIN metrics_catalog AS c ON c.name = j.name
-        WHERE j.job = ?
-          AND s.is_unused = TRUE
-          AND (? = '' OR c.name LIKE '%%' || ? || '%%' OR c.help LIKE '%%' || ? || '%%')
-          AND (? = 'all' OR
-               CASE
-                 WHEN ? = 'histogram' THEN c.type IN ('histogram_bucket', 'histogram_count', 'histogram_sum')
-                 WHEN ? = 'summary' THEN c.type IN ('summary', 'summary_count', 'summary_sum')
-                 ELSE c.type = ?
-                END)
-    `
 	// Force ORDER BY c.name; see getSeriesMetadataUnused for rationale.
 	// The same all-zero-counts pattern applies here, and consistency
 	// matters because clients page through both shapes against the same
 	// API contract.
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
+	query := BuildSafeQueryWithOrderBy(sqliteSeriesMetadataUnusedJobBaseSQL, "c", " LIMIT ? OFFSET ?", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Job,
 		params.Filter, params.Filter, params.Filter,

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -866,7 +866,17 @@ func (p *SQLiteProvider) getSeriesMetadataUnused(ctx context.Context, params Ser
                  ELSE c.type = ?
                 END)
     `
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	// Force ORDER BY c.name for the unused branch regardless of the
+	// client-supplied sortBy. Every unused row has alert_count =
+	// record_count = dashboard_count = query_count = 0, so sorting by any
+	// of those count columns is meaningless (all values tie at zero) and
+	// forces the planner to materialise the full unused subset before
+	// LIMIT can apply - which on cx10 (139k unused) cost seconds even for
+	// a 10-row page. Sorting by c.name lines up with the
+	// idx_metrics_usage_summary_is_unused partial index's name ordering,
+	// so the planner can index-scan + LIMIT in O(LIMIT) work. sortOrder is
+	// still honoured so ?sortOrder=desc inverts the alphabetical listing.
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Filter, params.Filter, params.Filter,
 		params.Type, params.Type, params.Type, params.Type,
@@ -937,7 +947,11 @@ func (p *SQLiteProvider) getSeriesMetadataUnusedJobScoped(ctx context.Context, p
                  ELSE c.type = ?
                 END)
     `
-	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", params.SortBy, params.SortOrder, ValidSeriesMetadataSortFields, "queryCount", SeriesMetadataSortAliases)
+	// Force ORDER BY c.name; see getSeriesMetadataUnused for rationale.
+	// The same all-zero-counts pattern applies here, and consistency
+	// matters because clients page through both shapes against the same
+	// API contract.
+	query := BuildSafeQueryWithOrderBy(baseQuery, "c", " LIMIT ? OFFSET ?", "name", params.SortOrder, ValidSeriesMetadataSortFields, "name", SeriesMetadataSortAliases)
 	rows, err := p.db.QueryContext(ctx, query,
 		params.Job,
 		params.Filter, params.Filter, params.Filter,

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"sort"
 	"testing"
@@ -743,6 +744,48 @@ func TestSQLite_GetSeriesMetadata_UsageFilters(t *testing.T) {
 			assert.ElementsMatch(t, tt.wantNames, names)
 		})
 	}
+}
+
+// TestSQLite_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow pins the
+// invariant the new ?usage=unused query depends on: after UpsertMetricsCatalog,
+// every catalog row has a corresponding metrics_usage_summary row with
+// is_unused=TRUE and zero counts, even before any RefreshMetricsUsageSummary.
+// This invariant lets the unused query INNER JOIN safely instead of having to
+// fall back to a LEFT JOIN + IS NULL branch.
+func TestSQLite_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "metric_a", Type: "gauge", Help: "a"},
+		{Name: "metric_b", Type: "counter", Help: "b"},
+	})
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	rows, err := rawDB.QueryContext(context.Background(),
+		`SELECT name, alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary ORDER BY name`)
+	assert.NoError(t, err, "query summary")
+	defer func() { _ = rows.Close() }()
+
+	type summaryRow struct {
+		name                              string
+		alert, record, dashboard, queries int
+		isUnused                          bool
+	}
+	var got []summaryRow
+	for rows.Next() {
+		var r summaryRow
+		assert.NoError(t, rows.Scan(&r.name, &r.alert, &r.record, &r.dashboard, &r.queries, &r.isUnused))
+		got = append(got, r)
+	}
+	assert.NoError(t, rows.Err())
+
+	assert.Equal(t, []summaryRow{
+		{name: "metric_a", isUnused: true},
+		{name: "metric_b", isUnused: true},
+	}, got)
 }
 
 // TestSQLite_DashboardUsage verifies dashboard usage time range filtering


### PR DESCRIPTION
This pull request introduces significant improvements to how unused metrics are queried and indexed in both PostgreSQL and SQLite backends. The main focus is to optimize the performance of the `?usage=unused` filter in the `/api/v1/seriesMetadata` endpoint, especially for large datasets and job-scoped queries. It does so by adding a directly indexable `is_unused` column, creating new partial and composite indexes, and updating the query logic to leverage these changes. Additionally, new and enhanced benchmarks are added to validate the performance improvements.

**Database schema and indexing improvements:**

* Added an `is_unused` boolean column to the `metrics_usage_summary` table in both PostgreSQL and SQLite, allowing direct and efficient indexing of unused metrics. This is maintained by the refresh logic and backfilled for existing data. [[1]](diffhunk://#diff-ed40596336c585fdb9754887488c5510cb0c082fa2b1bb97cc147d99139eda09R1-R49) [[2]](diffhunk://#diff-93edc55d832790f9dfa39a0ba8de3913e179009f19de6b92fa05fd45a28b1fcfR1-R43)
* Created a partial index on the `metrics_usage_summary` table for rows where `is_unused = TRUE`, enabling fast queries for unused metrics. [[1]](diffhunk://#diff-ed40596336c585fdb9754887488c5510cb0c082fa2b1bb97cc147d99139eda09R1-R49) [[2]](diffhunk://#diff-93edc55d832790f9dfa39a0ba8de3913e179009f19de6b92fa05fd45a28b1fcfR1-R43)
* Added a composite index on `(job, name)` to the `metrics_job_index` table in both PostgreSQL and SQLite, allowing efficient job-scoped queries and index-only scans. [[1]](diffhunk://#diff-d7b4cfd8f4148a35ca434a0ee15dd2d87093e5dce6b592142c94ba785a5b6f5fR1-R23) [[2]](diffhunk://#diff-d029748f42d793a835d95d457a61a93adb17ec01c610b33c77328bf4170d5bacR1-R15)

**Query and code path changes:**

* Refactored the PostgreSQL provider's `GetSeriesMetadata` method to use a dedicated query path for the `usage=unused` case, leveraging the new `is_unused` column and index for improved performance and code clarity. [[1]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL724-R735) [[2]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL744-L746) [[3]](diffhunk://#diff-2f8ed2aab15376ff8db6d728a049627c42466d761714f2c9bd62e2c4f59d738dL761-R768)

**Benchmarking and test enhancements:**

* Added new helper functions and constants in `bench_test.go` to seed test data with realistic usage patterns, including sparse job tagging and partial usage marking.
* Introduced new benchmarks for both SQLite and PostgreSQL that specifically measure the scalability and efficiency of unused-metric queries, including job-scoped scenarios and catalog size scaling.