### PR TITLE
ci: add README Review action for PR quality

### DIFF
--- a/.github/workflows/readme-review.yml
+++ b/.github/workflows/readme-review.yml
@@ -1,0 +1,15 @@
+name: README Review
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: iteebz/readme-review@v1


### PR DESCRIPTION
prom-analytics-proxy has solid tooling already (checks, container image CI). Adding [README Review](https://github.com/iteebz/readme-review) as a lightweight complement — scores README quality on PRs that touch `README.md`, posts a letter grade + shields.io badge.

No API keys, heuristic only. Fires only when README changes.

**See your grade first:** [grade nicolastakashi/prom-analytics-proxy's README instantly](https://iteebz.github.io/readme-scorecard/?repo=nicolastakashi/prom-analytics-proxy) — same heuristic, no install, in your browser. If it's useful, this action runs it on every PR.