### PR TITLE
feat: add producers analytics page

### DIFF
--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -33,8 +33,8 @@ func (p *benchDBProvider) GetSeriesMetadataByNames(_ context.Context, _ []string
 	return p.data, nil
 }
 
-func (p *benchDBProvider) Close() error                    { return nil }
-func (p *benchDBProvider) WithDB(_ func(*sql.DB))          {}
+func (p *benchDBProvider) Close() error                                 { return nil }
+func (p *benchDBProvider) WithDB(_ func(*sql.DB))                       {}
 func (p *benchDBProvider) Insert(_ context.Context, _ []db.Query) error { return nil }
 func (p *benchDBProvider) InsertRulesUsage(_ context.Context, _ []db.RulesUsage) error {
 	return nil
@@ -55,6 +55,9 @@ func (p *benchDBProvider) UpsertMetricsJobIndex(_ context.Context, _ []db.Metric
 	return nil
 }
 func (p *benchDBProvider) ListJobs(_ context.Context) ([]string, error) { return nil, nil }
+func (p *benchDBProvider) GetProducerStats(_ context.Context, _ db.ProducerStatsParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
+}
 func (p *benchDBProvider) GetQueryTypes(_ context.Context, _ db.TimeRange, _ string) (*db.QueryTypesResult, error) {
 	return nil, nil
 }

--- a/api/routes/openapi_models.go
+++ b/api/routes/openapi_models.go
@@ -25,6 +25,16 @@ type SeriesMetadataResponse struct {
 	Data       []models.MetricMetadata `json:"data"`
 }
 
+type ProducerStatsResponse struct {
+	TotalPages int                `json:"totalPages"`
+	Total      int                `json:"total"`
+	Data       []db.ProducerStats `json:"data"`
+}
+
+type FeaturesResponse struct {
+	ProducerStatsEnabled bool `json:"producer_stats_enabled"`
+}
+
 type SerieExpressionsResponse struct {
 	TotalPages int                           `json:"totalPages"`
 	Total      int                           `json:"total"`

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -130,11 +130,13 @@ func WithHandlers(uiFS fs.FS, registry *prometheus.Registry, isTracingEnabled bo
 		mux.Handle("/api/v1/serieExpressions/{name}", http.HandlerFunc(r.serieExpressions))
 		mux.Handle("/api/v1/serieUsage/{name}", http.HandlerFunc(r.GetMetricUsage))
 		mux.Handle("/api/v1/jobs", http.HandlerFunc(r.listJobs))
+		mux.Handle("/api/v1/producers", http.HandlerFunc(r.listProducers))
 		mux.Handle("/api/v1/metrics/unused", http.HandlerFunc(r.metricsUnused))
 
 		// endpoint for perses metrics usage push from the client
 		mux.Handle("/api/v1/metrics", http.HandlerFunc(r.PushMetricsUsage))
 		mux.Handle("/api/v1/configs", http.HandlerFunc(r.getConfigs))
+		mux.Handle("/api/v1/features", http.HandlerFunc(r.getFeatures))
 
 		mux.Handle("/api/v1/query/push", http.HandlerFunc(r.queryPush))
 
@@ -1335,11 +1337,25 @@ func (r *routes) getConfigs(w http.ResponseWriter, req *http.Request) {
 		writeErrorResponse(req, w, fmt.Errorf("failed to marshal YAML: %w", err), http.StatusInternalServerError)
 		return
 	}
+
 	w.Header().Set("Content-Type", "application/yaml")
 	if _, err := w.Write(yamlData); err != nil {
 		writeErrorResponse(req, w, fmt.Errorf("failed to write response: %w", err), http.StatusInternalServerError)
 		return
 	}
+}
+
+// @Summary Get UI feature availability
+// @Description Return backend capabilities used to gate optional UI features.
+// @Tags config
+// @Produce json
+// @Success 200 {object} FeaturesResponse
+// @Router /api/v1/features [get]
+func (r *routes) getFeatures(w http.ResponseWriter, req *http.Request) {
+	producerStatsEnabled := r.config != nil &&
+		r.config.Inventory.Enabled &&
+		r.config.Inventory.JobSyncEnabled
+	writeJSONResponse(req, w, FeaturesResponse{ProducerStatsEnabled: producerStatsEnabled})
 }
 
 // @Summary List jobs
@@ -1361,6 +1377,50 @@ func (r *routes) listJobs(w http.ResponseWriter, req *http.Request) {
 	writeJSONResponse(req, w, struct {
 		Data []string `json:"data"`
 	}{Data: jobs})
+}
+
+// @Summary List producer statistics
+// @Description Get paginated producer metrics and usage contribution statistics.
+// @Tags metrics
+// @Produce json
+// @Param page query int false "Page number (default 1)"
+// @Param pageSize query int false "Page size (default 10, max 100)"
+// @Param sortBy query string false "Sort field (job, metricCount, usedMetricCount, unusedMetricCount, contribution)"
+// @Param sortOrder query string false "Sort order (asc or desc)"
+// @Param filter query string false "Filter by producer or metric name"
+// @Success 200 {object} ProducerStatsResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/producers [get]
+func (r *routes) listProducers(w http.ResponseWriter, req *http.Request) {
+	params := db.ProducerStatsParams{
+		Page:      1,
+		PageSize:  10,
+		SortBy:    "metricCount",
+		SortOrder: "desc",
+		Filter:    req.FormValue("filter"),
+	}
+	if page, err := getQueryParamAsInt(req, "page", 1); err == nil {
+		params.Page = page
+	}
+	if pageSize, err := getQueryParamAsInt(req, "pageSize", 10); err == nil {
+		params.PageSize = pageSize
+	}
+	if sortBy := req.FormValue("sortBy"); sortBy != "" {
+		params.SortBy = sortBy
+	}
+	if sortOrder := req.FormValue("sortOrder"); sortOrder != "" {
+		params.SortOrder = sortOrder
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), 5*time.Second)
+	defer cancel()
+	producers, err := r.dbProvider.GetProducerStats(ctx, params)
+	if err != nil {
+		slog.Error("unable to list producer statistics", "err", err)
+		writeErrorResponse(req, w, fmt.Errorf("unable to list producer statistics: %w", err), http.StatusInternalServerError)
+		return
+	}
+	writeJSONResponse(req, w, producers)
 }
 
 // @Summary Check unused metrics

--- a/api/routes/routes_test.go
+++ b/api/routes/routes_test.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -11,10 +12,56 @@ import (
 	"time"
 
 	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestGetFeaturesGatesProducerStats(t *testing.T) {
+	tests := []struct {
+		name                    string
+		config                  *config.Config
+		wantProducerStatsEnable bool
+	}{
+		{name: "missing config"},
+		{
+			name: "inventory disabled",
+			config: &config.Config{
+				Inventory: config.InventoryConfig{JobSyncEnabled: true},
+			},
+		},
+		{
+			name: "job sync disabled",
+			config: &config.Config{
+				Inventory: config.InventoryConfig{Enabled: true},
+			},
+		},
+		{
+			name: "inventory and job sync enabled",
+			config: &config.Config{
+				Inventory: config.InventoryConfig{Enabled: true, JobSyncEnabled: true},
+			},
+			wantProducerStatsEnable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &routes{config: tt.config}
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/features", nil)
+			w := httptest.NewRecorder()
+
+			r.getFeatures(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			var response FeaturesResponse
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			assert.Equal(t, tt.wantProducerStatsEnable, response.ProducerStatsEnabled)
+		})
+	}
+}
 
 func TestSeriesMetadata_DBBacked(t *testing.T) {
 	// Use SQLite provider for an integration-style test
@@ -169,6 +216,73 @@ type captureSeriesMetadataProvider struct {
 func (p *captureSeriesMetadataProvider) GetSeriesMetadata(_ context.Context, params db.SeriesMetadataParams) (db.PagedResult, error) {
 	p.captured = params
 	return db.PagedResult{}, nil
+}
+
+type captureProducerStatsProvider struct {
+	benchDBProvider
+	captured db.ProducerStatsParams
+	result   db.PagedResult
+}
+
+func (p *captureProducerStatsProvider) GetProducerStats(_ context.Context, params db.ProducerStatsParams) (db.PagedResult, error) {
+	p.captured = params
+	return p.result, nil
+}
+
+func TestListProducersRoute(t *testing.T) {
+	upstream, _ := url.Parse("http://127.0.0.1")
+	uiFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("ok")}}
+	expected := []db.ProducerStats{{
+		Job:               "node",
+		MetricCount:       2,
+		UsedMetricCount:   1,
+		UnusedMetricCount: 1,
+		Contribution:      66.6667,
+	}}
+	spy := &captureProducerStatsProvider{
+		result: db.PagedResult{
+			Total:      1,
+			TotalPages: 1,
+			Data:       expected,
+		},
+	}
+	r, err := NewRoutes(
+		WithDBProvider(spy),
+		WithProxy(upstream),
+		WithPromAPI(upstream),
+		WithHandlers(uiFS, prometheus.NewRegistry(), false),
+	)
+	if err != nil {
+		t.Fatalf("NewRoutes: %v", err)
+	}
+
+	req := httptest.NewRequest(
+		"GET",
+		"/api/v1/producers?page=2&pageSize=25&sortBy=unusedMetricCount&sortOrder=asc&filter=cpu",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, db.ProducerStatsParams{
+		Page:      2,
+		PageSize:  25,
+		SortBy:    "unusedMetricCount",
+		SortOrder: "asc",
+		Filter:    "cpu",
+	}, spy.captured)
+	assert.JSONEq(t, `{
+		"total": 1,
+		"totalPages": 1,
+		"data": [{
+			"job": "node",
+			"metricCount": 2,
+			"usedMetricCount": 1,
+			"unusedMetricCount": 1,
+			"contribution": 66.6667
+		}]
+	}`, w.Body.String())
 }
 
 func TestSeriesMetadataPageSizeClamp(t *testing.T) {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -49,6 +49,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/features": {
+            "get": {
+                "description": "Return backend capabilities used to gate optional UI features.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "config"
+                ],
+                "summary": "Get UI feature availability",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.FeaturesResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/jobs": {
             "get": {
                 "description": "Get list of distinct job labels from stored series.",
@@ -258,6 +278,64 @@ const docTemplate = `{
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/producers": {
+            "get": {
+                "description": "Get paginated producer metrics and usage contribution statistics.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "metrics"
+                ],
+                "summary": "List producer statistics",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (default 10, max 100)",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort field (job, metricCount, usedMetricCount, unusedMetricCount, contribution)",
+                        "name": "sortBy",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order (asc or desc)",
+                        "name": "sortOrder",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by producer or metric name",
+                        "name": "filter",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ProducerStatsResponse"
                         }
                     },
                     "500": {
@@ -1362,6 +1440,26 @@ const docTemplate = `{
                 }
             }
         },
+        "db.ProducerStats": {
+            "type": "object",
+            "properties": {
+                "contribution": {
+                    "type": "number"
+                },
+                "job": {
+                    "type": "string"
+                },
+                "metricCount": {
+                    "type": "integer"
+                },
+                "unusedMetricCount": {
+                    "type": "integer"
+                },
+                "usedMetricCount": {
+                    "type": "integer"
+                }
+            }
+        },
         "db.QueriesBySerieNameResult": {
             "type": "object",
             "properties": {
@@ -1765,6 +1863,14 @@ const docTemplate = `{
                 }
             }
         },
+        "routes.FeaturesResponse": {
+            "type": "object",
+            "properties": {
+                "producer_stats_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "routes.MetricUsageItem": {
             "type": "object",
             "properties": {
@@ -1810,6 +1916,23 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/routes.MetricUsageItem"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "routes.ProducerStatsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/db.ProducerStats"
                     }
                 },
                 "total": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -42,6 +42,26 @@
                 }
             }
         },
+        "/api/v1/features": {
+            "get": {
+                "description": "Return backend capabilities used to gate optional UI features.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "config"
+                ],
+                "summary": "Get UI feature availability",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.FeaturesResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/jobs": {
             "get": {
                 "description": "Get list of distinct job labels from stored series.",
@@ -251,6 +271,64 @@
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/producers": {
+            "get": {
+                "description": "Get paginated producer metrics and usage contribution statistics.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "metrics"
+                ],
+                "summary": "List producer statistics",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (default 10, max 100)",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort field (job, metricCount, usedMetricCount, unusedMetricCount, contribution)",
+                        "name": "sortBy",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order (asc or desc)",
+                        "name": "sortOrder",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by producer or metric name",
+                        "name": "filter",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ProducerStatsResponse"
                         }
                     },
                     "500": {
@@ -1355,6 +1433,26 @@
                 }
             }
         },
+        "db.ProducerStats": {
+            "type": "object",
+            "properties": {
+                "contribution": {
+                    "type": "number"
+                },
+                "job": {
+                    "type": "string"
+                },
+                "metricCount": {
+                    "type": "integer"
+                },
+                "unusedMetricCount": {
+                    "type": "integer"
+                },
+                "usedMetricCount": {
+                    "type": "integer"
+                }
+            }
+        },
         "db.QueriesBySerieNameResult": {
             "type": "object",
             "properties": {
@@ -1758,6 +1856,14 @@
                 }
             }
         },
+        "routes.FeaturesResponse": {
+            "type": "object",
+            "properties": {
+                "producer_stats_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "routes.MetricUsageItem": {
             "type": "object",
             "properties": {
@@ -1803,6 +1909,23 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/routes.MetricUsageItem"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "routes.ProducerStatsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/db.ProducerStats"
                     }
                 },
                 "total": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -52,6 +52,19 @@ definitions:
       totalRecords:
         type: integer
     type: object
+  db.ProducerStats:
+    properties:
+      contribution:
+        type: number
+      job:
+        type: string
+      metricCount:
+        type: integer
+      unusedMetricCount:
+        type: integer
+      usedMetricCount:
+        type: integer
+    type: object
   db.QueriesBySerieNameResult:
     properties:
       avgDuration:
@@ -314,6 +327,11 @@ definitions:
       record_count:
         type: integer
     type: object
+  routes.FeaturesResponse:
+    properties:
+      producer_stats_enabled:
+        type: boolean
+    type: object
   routes.MetricUsageItem:
     properties:
       created_at:
@@ -344,6 +362,17 @@ definitions:
       data:
         items:
           $ref: '#/definitions/routes.MetricUsageItem'
+        type: array
+      total:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
+  routes.ProducerStatsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/db.ProducerStats'
         type: array
       total:
         type: integer
@@ -443,6 +472,19 @@ paths:
           schema:
             $ref: '#/definitions/models.ErrorResponse'
       summary: Get configuration
+      tags:
+      - config
+  /api/v1/features:
+    get:
+      description: Return backend capabilities used to gate optional UI features.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.FeaturesResponse'
+      summary: Get UI feature availability
       tags:
       - config
   /api/v1/jobs:
@@ -592,6 +634,45 @@ paths:
           schema:
             $ref: '#/definitions/models.ErrorResponse'
       summary: Check unused metrics
+      tags:
+      - metrics
+  /api/v1/producers:
+    get:
+      description: Get paginated producer metrics and usage contribution statistics.
+      parameters:
+      - description: Page number (default 1)
+        in: query
+        name: page
+        type: integer
+      - description: Page size (default 10, max 100)
+        in: query
+        name: pageSize
+        type: integer
+      - description: Sort field (job, metricCount, usedMetricCount, unusedMetricCount,
+          contribution)
+        in: query
+        name: sortBy
+        type: string
+      - description: Sort order (asc or desc)
+        in: query
+        name: sortOrder
+        type: string
+      - description: Filter by producer or metric name
+        in: query
+        name: filter
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.ProducerStatsResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      summary: List producer statistics
       tags:
       - metrics
   /api/v1/query:

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -1225,6 +1225,122 @@ func (p *PostGreSQLProvider) ListJobs(ctx context.Context) ([]string, error) {
 	return jobs, nil
 }
 
+func (p *PostGreSQLProvider) GetProducerStats(ctx context.Context, params ProducerStatsParams) (PagedResult, error) {
+	ValidatePagination(&params.Page, &params.PageSize, 10)
+	ValidateSortField(&params.SortBy, &params.SortOrder, ValidProducerStatsSortFields, "metricCount")
+
+	const countQuery = `
+		SELECT COUNT(*)
+		FROM (
+			SELECT j.job
+			FROM metrics_job_index j
+			JOIN metrics_usage_summary s ON s.name = j.name
+			GROUP BY j.job
+			HAVING $1 = ''
+				OR j.job ILIKE '%' || $1 || '%'
+				OR EXISTS (
+					SELECT 1
+					FROM metrics_job_index search_idx
+					JOIN metrics_usage_summary search_summary ON search_summary.name = search_idx.name
+					WHERE search_idx.job = j.job
+					  AND search_idx.name ILIKE '%' || $1 || '%'
+				)
+		) filtered_producers
+	`
+
+	var total int
+	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter).Scan(&total); err != nil {
+		return PagedResult{}, fmt.Errorf("failed to count producers: %w", err)
+	}
+	if total == 0 {
+		return PagedResult{Total: 0, TotalPages: 0, Data: []ProducerStats{}}, nil
+	}
+
+	const baseQuery = `
+		WITH producer_stats AS (
+			SELECT
+				j.job,
+				COUNT(*) AS metric_count,
+				SUM(CASE WHEN s.is_unused = FALSE THEN 1 ELSE 0 END) AS used_metric_count,
+				SUM(CASE WHEN s.is_unused = TRUE THEN 1 ELSE 0 END) AS unused_metric_count
+			FROM metrics_job_index j
+			JOIN metrics_usage_summary s ON s.name = j.name
+			GROUP BY j.job
+		),
+		totals AS (
+			SELECT COUNT(*) AS total_metric_assignments
+			FROM metrics_job_index j
+			JOIN metrics_usage_summary s ON s.name = j.name
+		)
+		SELECT
+			ps.job,
+			ps.metric_count,
+			ps.used_metric_count,
+			ps.unused_metric_count,
+			CASE
+				WHEN totals.total_metric_assignments = 0 THEN 0
+				ELSE (100.0 * ps.metric_count) / totals.total_metric_assignments
+			END AS contribution
+		FROM producer_stats ps
+		CROSS JOIN totals
+		WHERE $1 = ''
+			OR ps.job ILIKE '%' || $1 || '%'
+			OR EXISTS (
+				SELECT 1
+				FROM metrics_job_index search_idx
+				JOIN metrics_usage_summary search_summary ON search_summary.name = search_idx.name
+				WHERE search_idx.job = ps.job
+				  AND search_idx.name ILIKE '%' || $1 || '%'
+			)
+	`
+
+	query := BuildSafeQueryWithOrderBy(
+		baseQuery,
+		"",
+		" LIMIT $2 OFFSET $3",
+		params.SortBy,
+		params.SortOrder,
+		ValidProducerStatsSortFields,
+		"metricCount",
+		ProducerStatsSortAliases,
+	)
+	rows, err := p.db.QueryContext(
+		ctx,
+		query,
+		params.Filter,
+		params.PageSize,
+		(params.Page-1)*params.PageSize,
+	)
+	if err != nil {
+		return PagedResult{}, fmt.Errorf("failed to query producers: %w", err)
+	}
+	defer CloseResource(rows)
+
+	producers := make([]ProducerStats, 0, params.PageSize)
+	for rows.Next() {
+		var producer ProducerStats
+		if err := rows.Scan(
+			&producer.Job,
+			&producer.MetricCount,
+			&producer.UsedMetricCount,
+			&producer.UnusedMetricCount,
+			&producer.Contribution,
+		); err != nil {
+			return PagedResult{}, fmt.Errorf("scan producer: %w", err)
+		}
+		producers = append(producers, producer)
+	}
+	if err := rows.Err(); err != nil {
+		return PagedResult{}, fmt.Errorf("iter producers: %w", err)
+	}
+
+	return PagedResult{
+		Total:      total,
+		TotalPages: CalculateTotalPages(total, params.PageSize),
+		Data:       producers,
+	}, nil
+}
+
 func (p *PostGreSQLProvider) GetQueryTypes(ctx context.Context, tr TimeRange, fingerprint string) (*QueryTypesResult, error) {
 	SetDefaultTimeRange(&tr)
 	startTime, endTime := PrepareTimeRange(tr, "postgresql")

--- a/internal/db/provider.go
+++ b/internal/db/provider.go
@@ -47,6 +47,7 @@ type Provider interface {
 	RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error
 	UpsertMetricsJobIndex(ctx context.Context, items []MetricJobIndexItem) error
 	ListJobs(ctx context.Context) ([]string, error)
+	GetProducerStats(ctx context.Context, params ProducerStatsParams) (PagedResult, error)
 
 	GetQueryTypes(ctx context.Context, tr TimeRange, fingerprint string) (*QueryTypesResult, error)
 	GetAverageDuration(ctx context.Context, tr TimeRange, fingerprint string) (*AverageDurationResult, error)
@@ -87,6 +88,22 @@ var ValidSeriesMetadataSortFields = map[string]bool{
 	"recordCount":    true,
 	"dashboardCount": true,
 	"queryCount":     true,
+}
+
+var ValidProducerStatsSortFields = map[string]bool{
+	"job":               true,
+	"metricCount":       true,
+	"usedMetricCount":   true,
+	"unusedMetricCount": true,
+	"contribution":      true,
+}
+
+var ProducerStatsSortAliases = map[string]string{
+	"job":               "job",
+	"metricCount":       "metric_count",
+	"usedMetricCount":   "used_metric_count",
+	"unusedMetricCount": "unused_metric_count",
+	"contribution":      "contribution",
 }
 
 // SeriesMetadataSortAliases maps sort fields to their SQL expression with the correct table alias.
@@ -369,6 +386,22 @@ type MetricCatalogItem struct {
 type MetricJobIndexItem struct {
 	Name string
 	Job  string
+}
+
+type ProducerStatsParams struct {
+	Page      int
+	PageSize  int
+	SortBy    string
+	SortOrder string
+	Filter    string
+}
+
+type ProducerStats struct {
+	Job               string  `json:"job"`
+	MetricCount       int     `json:"metricCount"`
+	UsedMetricCount   int     `json:"usedMetricCount"`
+	UnusedMetricCount int     `json:"unusedMetricCount"`
+	Contribution      float64 `json:"contribution"`
 }
 
 type TimeRange struct {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -1169,6 +1169,124 @@ func (p *SQLiteProvider) ListJobs(ctx context.Context) ([]string, error) {
 	return jobs, nil
 }
 
+func (p *SQLiteProvider) GetProducerStats(ctx context.Context, params ProducerStatsParams) (PagedResult, error) {
+	ValidatePagination(&params.Page, &params.PageSize, 10)
+	ValidateSortField(&params.SortBy, &params.SortOrder, ValidProducerStatsSortFields, "metricCount")
+
+	const countQuery = `
+		SELECT COUNT(*)
+		FROM (
+			SELECT j.job
+			FROM metrics_job_index j
+			JOIN metrics_usage_summary s ON s.name = j.name
+			GROUP BY j.job
+			HAVING ? = ''
+				OR j.job LIKE '%' || ? || '%'
+				OR EXISTS (
+					SELECT 1
+					FROM metrics_job_index search_idx
+					JOIN metrics_usage_summary search_summary ON search_summary.name = search_idx.name
+					WHERE search_idx.job = j.job
+					  AND search_idx.name LIKE '%' || ? || '%'
+				)
+		) filtered_producers
+	`
+
+	var total int
+	if err := p.db.QueryRowContext(ctx, countQuery, params.Filter, params.Filter, params.Filter).Scan(&total); err != nil {
+		return PagedResult{}, fmt.Errorf("failed to count producers: %w", err)
+	}
+	if total == 0 {
+		return PagedResult{Total: 0, TotalPages: 0, Data: []ProducerStats{}}, nil
+	}
+
+	const baseQuery = `
+		WITH producer_stats AS (
+			SELECT
+				j.job,
+				COUNT(*) AS metric_count,
+				SUM(CASE WHEN s.is_unused = 0 THEN 1 ELSE 0 END) AS used_metric_count,
+				SUM(CASE WHEN s.is_unused = 1 THEN 1 ELSE 0 END) AS unused_metric_count
+			FROM metrics_job_index j
+			JOIN metrics_usage_summary s ON s.name = j.name
+			GROUP BY j.job
+		),
+		totals AS (
+			SELECT COUNT(*) AS total_metric_assignments
+			FROM metrics_job_index j
+			JOIN metrics_usage_summary s ON s.name = j.name
+		)
+		SELECT
+			ps.job,
+			ps.metric_count,
+			ps.used_metric_count,
+			ps.unused_metric_count,
+			CASE
+				WHEN totals.total_metric_assignments = 0 THEN 0
+				ELSE (100.0 * ps.metric_count) / totals.total_metric_assignments
+			END AS contribution
+		FROM producer_stats ps
+		CROSS JOIN totals
+		WHERE ? = ''
+			OR ps.job LIKE '%' || ? || '%'
+			OR EXISTS (
+				SELECT 1
+				FROM metrics_job_index search_idx
+				JOIN metrics_usage_summary search_summary ON search_summary.name = search_idx.name
+				WHERE search_idx.job = ps.job
+				  AND search_idx.name LIKE '%' || ? || '%'
+			)
+	`
+
+	query := BuildSafeQueryWithOrderBy(
+		baseQuery,
+		"",
+		" LIMIT ? OFFSET ?",
+		params.SortBy,
+		params.SortOrder,
+		ValidProducerStatsSortFields,
+		"metricCount",
+		ProducerStatsSortAliases,
+	)
+	rows, err := p.db.QueryContext(
+		ctx,
+		query,
+		params.Filter,
+		params.Filter,
+		params.Filter,
+		params.PageSize,
+		(params.Page-1)*params.PageSize,
+	)
+	if err != nil {
+		return PagedResult{}, fmt.Errorf("failed to query producers: %w", err)
+	}
+	defer CloseResource(rows)
+
+	producers := make([]ProducerStats, 0, params.PageSize)
+	for rows.Next() {
+		var producer ProducerStats
+		if err := rows.Scan(
+			&producer.Job,
+			&producer.MetricCount,
+			&producer.UsedMetricCount,
+			&producer.UnusedMetricCount,
+			&producer.Contribution,
+		); err != nil {
+			return PagedResult{}, fmt.Errorf("scan producer: %w", err)
+		}
+		producers = append(producers, producer)
+	}
+	if err := rows.Err(); err != nil {
+		return PagedResult{}, fmt.Errorf("iter producers: %w", err)
+	}
+
+	return PagedResult{
+		Total:      total,
+		TotalPages: CalculateTotalPages(total, params.PageSize),
+		Data:       producers,
+	}, nil
+}
+
 func (p *SQLiteProvider) RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error {
 	from, to := PrepareTimeRange(tr, "sqlite")
 	query := `

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -394,6 +394,92 @@ func TestSQLite_MetricsJobIndex_And_ListJobs(t *testing.T) {
 	assert.Equal(t, []string{"node", "prometheus"}, jobs)
 }
 
+func TestSQLite_GetProducerStats(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "up", Type: "gauge"},
+		{Name: "process_cpu_seconds_total", Type: "counter"},
+	})
+	mustUpsertJobIndex(t, p, []MetricJobIndexItem{
+		{Name: "up", Job: "prometheus"},
+		{Name: "up", Job: "node"},
+		{Name: "process_cpu_seconds_total", Job: "node"},
+		// Job-index-only metrics have no reliable usage classification and must
+		// not be counted as unused.
+		{Name: "not_in_usage_summary", Job: "unsummarized"},
+	})
+
+	now := time.Now().UTC()
+	mustInsertQueries(t, p, []Query{{
+		TS:            now.Add(-time.Minute),
+		QueryParam:    "up",
+		TimeParam:     now,
+		Duration:      time.Millisecond,
+		StatusCode:    200,
+		LabelMatchers: LabelMatchers{{"__name__": "up"}},
+		Type:          QueryTypeInstant,
+	}})
+	assert.NoError(t, p.RefreshMetricsUsageSummary(context.Background(), TimeRange{
+		From: now.Add(-time.Hour),
+		To:   now,
+	}))
+
+	result, err := p.GetProducerStats(context.Background(), ProducerStatsParams{
+		Page:      1,
+		PageSize:  10,
+		SortBy:    "metricCount",
+		SortOrder: "desc",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, result.Total)
+	assert.Equal(t, 1, result.TotalPages)
+
+	producers, ok := result.Data.([]ProducerStats)
+	if assert.True(t, ok) && assert.Len(t, producers, 2) {
+		assert.Equal(t, ProducerStats{
+			Job:               "node",
+			MetricCount:       2,
+			UsedMetricCount:   1,
+			UnusedMetricCount: 1,
+			Contribution:      producers[0].Contribution,
+		}, producers[0])
+		assert.InDelta(t, 66.6667, producers[0].Contribution, 0.001)
+		assert.Equal(t, "prometheus", producers[1].Job)
+		assert.Equal(t, 1, producers[1].MetricCount)
+		assert.Equal(t, 1, producers[1].UsedMetricCount)
+		assert.Equal(t, 0, producers[1].UnusedMetricCount)
+		assert.InDelta(t, 33.3333, producers[1].Contribution, 0.001)
+	}
+
+	filtered, err := p.GetProducerStats(context.Background(), ProducerStatsParams{
+		Page:      1,
+		PageSize:  10,
+		SortBy:    "job",
+		SortOrder: "asc",
+		Filter:    "cpu",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, filtered.Total)
+	filteredProducers, ok := filtered.Data.([]ProducerStats)
+	if assert.True(t, ok) && assert.Len(t, filteredProducers, 1) {
+		assert.Equal(t, "node", filteredProducers[0].Job)
+		assert.Equal(t, 2, filteredProducers[0].MetricCount)
+	}
+
+	unsummarized, err := p.GetProducerStats(context.Background(), ProducerStatsParams{
+		Page:      1,
+		PageSize:  10,
+		SortBy:    "job",
+		SortOrder: "asc",
+		Filter:    "not_in_usage_summary",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, unsummarized.Total)
+	assert.Empty(t, unsummarized.Data)
+}
+
 func TestSQLite_RefreshMetricsUsageSummary_And_GetSeriesMetadata(t *testing.T) {
 	p, cleanup := newTestSQLiteProvider(t)
 	defer cleanup()

--- a/internal/ingester/queryingester_test.go
+++ b/internal/ingester/queryingester_test.go
@@ -25,6 +25,10 @@ func (m *MockDBProvider) ListJobs(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
+func (m *MockDBProvider) GetProducerStats(context.Context, db.ProducerStatsParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
+}
+
 // Satisfy new Provider method; tests don't use it
 func (m *MockDBProvider) GetQueryExpressions(ctx context.Context, params db.QueryExpressionsParams) (db.PagedResult, error) {
 	return db.PagedResult{}, nil

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -55,6 +55,9 @@ func (f *fakeProvider) UpsertMetricsJobIndex(context.Context, []db.MetricJobInde
 	return nil
 }
 func (f *fakeProvider) ListJobs(context.Context) ([]string, error) { return nil, nil }
+func (f *fakeProvider) GetProducerStats(context.Context, db.ProducerStatsParams) (db.PagedResult, error) {
+	return db.PagedResult{}, nil
+}
 func (f *fakeProvider) GetQueryTypes(context.Context, db.TimeRange, string) (*db.QueryTypesResult, error) {
 	return nil, nil
 }

--- a/ui/src/api/metrics.test.ts
+++ b/ui/src/api/metrics.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getProducerStats } from "./metrics";
+
+describe("getProducerStats", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests paginated producer statistics with search and sorting", async () => {
+    const response = {
+      total: 1,
+      totalPages: 1,
+      data: [
+        {
+          job: "node-exporter",
+          metricCount: 42,
+          usedMetricCount: 30,
+          unusedMetricCount: 12,
+          contribution: 25,
+        },
+      ],
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(response),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      getProducerStats(2, 25, "unusedMetricCount", "asc", "node"),
+    ).resolves.toEqual(response);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/producers?page=2&pageSize=25&sortBy=unusedMetricCount&sortOrder=asc&filter=node",
+    );
+  });
+});

--- a/ui/src/api/metrics.ts
+++ b/ui/src/api/metrics.ts
@@ -2,6 +2,7 @@ import {
   MetricQueryPerformanceStatistics,
   MetricStatistics,
   PagedResult,
+  ProducerStats,
 } from "@/lib/types";
 import { MetricMetadata } from "@/lib/types";
 import { toUTC } from "@/lib/utils/date-utils";
@@ -41,6 +42,8 @@ interface ApiConfig {
     serieExpressions: string;
     metricUsage: string;
     producers: string;
+    producerStats: string;
+    features: string;
   };
 }
 
@@ -69,6 +72,8 @@ const API_CONFIG: ApiConfig = {
     serieExpressions: "/api/v1/serieExpressions",
     metricUsage: "/api/v1/serieUsage",
     producers: "/api/v1/jobs",
+    producerStats: "/api/v1/producers",
+    features: "/api/v1/features",
   },
 };
 
@@ -273,4 +278,25 @@ export async function getProducers(): Promise<string[]> {
   if (!res.ok) throw new Error(`Failed to fetch producers: ${res.status}`);
   const body = (await res.json()) as { data: string[] };
   return body.data || [];
+}
+
+export async function getProducerStats(
+  page: number = 1,
+  pageSize: number = 10,
+  sortBy: string = "metricCount",
+  sortOrder: string = "desc",
+  filter: string = "",
+): Promise<PagedResult<ProducerStats>> {
+  return fetchApiData<PagedResult<ProducerStats>>(
+    API_CONFIG.endpoints.producerStats,
+    { page, pageSize, sortBy, sortOrder, filter },
+  );
+}
+
+export interface Features {
+  producer_stats_enabled: boolean;
+}
+
+export async function getFeatures(): Promise<Features> {
+  return fetchApiData<Features>(API_CONFIG.endpoints.features);
 }

--- a/ui/src/app/metrics/index.tsx
+++ b/ui/src/app/metrics/index.tsx
@@ -5,6 +5,7 @@ import { useSeriesMetadataTable } from "./use-metrics-data";
 import { TableState } from "@/lib/types";
 import { LoadingState } from "./loading";
 import { useDebounce } from "@/hooks/use-debounce";
+import { useSearchState } from "@/hooks/use-search-state";
 
 export default function MetricsExplorer() {
   const [searchQuery, setSearchQuery] = useState("");
@@ -12,7 +13,7 @@ export default function MetricsExplorer() {
   const [usageFilter, setUsageFilter] = useState<"all" | "used" | "unused">(
     "all",
   );
-  const [producerFilter, setProducerFilter] = useState<string>("");
+  const [producerFilter, setProducerFilter] = useSearchState("job", "");
   const [tableState, setTableState] = useState<TableState>({
     page: 1,
     pageSize: 10,

--- a/ui/src/app/producers/index.tsx
+++ b/ui/src/app/producers/index.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import { DataTable, DataTableColumnHeader } from "@/components/data-table";
+import { useDebounce } from "@/hooks/use-debounce";
+import { useSearchNumberState, useSearchState } from "@/hooks/use-search-state";
+import { getProducerStats } from "@/api/metrics";
+import { ROUTES } from "@/lib/routes";
+import type { PagedResult, ProducerStats } from "@/lib/types";
+import { LoadingState } from "./loading";
+
+const SEARCH_KEY = "producersPageSearch";
+const PAGE_KEY = "producersPagePage";
+
+export default function ProducersPage() {
+  const [, setLocation] = useLocation();
+  const [searchQuery, setSearchQuery] = useSearchState(SEARCH_KEY, "");
+  const [page, setPage] = useSearchNumberState(PAGE_KEY, 1);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "metricCount", desc: true },
+  ]);
+  const debouncedSearch = useDebounce(searchQuery, 750);
+  const pageSize = 10;
+
+  const { data, isLoading, error } = useQuery<PagedResult<ProducerStats>>({
+    queryKey: [
+      "producerStats",
+      page,
+      pageSize,
+      sorting[0]?.id,
+      sorting[0]?.desc,
+      debouncedSearch,
+    ],
+    queryFn: () =>
+      getProducerStats(
+        page,
+        pageSize,
+        sorting[0]?.id || "metricCount",
+        sorting[0]?.desc ? "desc" : "asc",
+        debouncedSearch,
+      ),
+  });
+
+  const openProducer = (job: string) => {
+    const params = new URLSearchParams({ job });
+    setLocation(`${ROUTES.METRICS_EXPLORER}?${params.toString()}`);
+  };
+
+  const columns: ColumnDef<ProducerStats>[] = [
+    {
+      accessorKey: "job",
+      size: 320,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Producer" />
+      ),
+      cell: ({ row }) => (
+        <span className="font-medium" title={row.original.job}>
+          {row.original.job}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "contribution",
+      size: 240,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Contribution" />
+      ),
+      cell: ({ row }) => {
+        const value = row.original.contribution;
+        return (
+          <div className="flex min-w-[180px] items-center gap-3">
+            <Progress value={value} className="h-2 flex-1" />
+            <span className="w-14 text-right tabular-nums">
+              {value.toFixed(1)}%
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "metricCount",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Metrics" />
+      ),
+      cell: ({ row }) => (
+        <div className="text-right tabular-nums">
+          {row.original.metricCount.toLocaleString()}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "usedMetricCount",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Used" />
+      ),
+      cell: ({ row }) => (
+        <div className="text-right tabular-nums">
+          {row.original.usedMetricCount.toLocaleString()}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "unusedMetricCount",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Unused" />
+      ),
+      cell: ({ row }) => (
+        <div className="text-right tabular-nums">
+          {row.original.unusedMetricCount.toLocaleString()}
+        </div>
+      ),
+    },
+  ];
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return <div className="p-4">Error: {error.message}</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <div className="mb-4">
+        <h1 className="text-2xl font-bold">Producers</h1>
+        <p className="text-sm text-muted-foreground">
+          Compare the metrics contributed by each producer and identify unused
+          instrumentation.
+        </p>
+      </div>
+      <Input
+        placeholder="Search producers or metrics..."
+        className="mb-4 sm:max-w-[300px]"
+        value={searchQuery}
+        onChange={(event) => {
+          setSearchQuery(event.target.value);
+          setPage(1);
+        }}
+      />
+      <DataTable<ProducerStats>
+        data={data?.data || []}
+        columns={columns}
+        pagination={true}
+        pageSize={pageSize}
+        className="w-full"
+        serverSide={true}
+        sortingState={sorting}
+        filterValue={debouncedSearch}
+        currentPage={page}
+        totalPages={data?.totalPages || 1}
+        onSortingChange={(nextSorting) => {
+          setSorting(nextSorting);
+          setPage(1);
+        }}
+        onFilterChange={setSearchQuery}
+        onPaginationChange={setPage}
+        onRowClick={(row) => openProducer(row.job)}
+      />
+    </div>
+  );
+}

--- a/ui/src/app/producers/loading.tsx
+++ b/ui/src/app/producers/loading.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function LoadingState() {
+  return (
+    <div className="p-4">
+      <div className="mb-4 space-y-2">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-4 w-[420px] max-w-full" />
+      </div>
+      <Skeleton className="mb-4 h-10 w-[300px] max-w-full" />
+      <div className="rounded-md border">
+        {Array.from({ length: 11 }).map((_, index) => (
+          <div
+            key={index}
+            className="flex h-12 items-center gap-6 border-b px-4 last:border-b-0"
+          >
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/app-sidebar.tsx
+++ b/ui/src/components/app-sidebar.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Settings } from "lucide-react";
 import { useLocation } from "wouter";
 import logo from "@/assets/logo.png";
 
+import { getFeatures } from "@/api/metrics";
 import { Navigation } from "@/components/navigation";
 import {
   Sidebar,
@@ -15,7 +17,7 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar";
 import { useSidebar } from "@/components/ui/sidebar-context";
-import { routeConfigs } from "@/lib/routes";
+import { routeConfigs, ROUTES } from "@/lib/routes";
 import { PreservedLink } from "@/components/preserved-link.tsx";
 
 const Logo: React.FC<{ className?: string }> = ({ className }) => {
@@ -28,20 +30,28 @@ const Logo: React.FC<{ className?: string }> = ({ className }) => {
   );
 };
 
-// Get navigation items from routes configuration
-const navigationItems = routeConfigs
-  .filter((route) => route.navigation?.showInSidebar)
-  .map((route) => ({
-    name: route.navigation!.name,
-    url: route.path,
-    icon: route.navigation!.icon,
-  }));
-
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const [location] = useLocation();
   const { state } = useSidebar();
+  const { data: features } = useQuery({
+    queryKey: ["features"],
+    queryFn: getFeatures,
+    staleTime: Infinity,
+  });
   const isSettingsActive = location === "/settings";
   const isCollapsed = state === "collapsed";
+  const producerStatsEnabled = features?.producer_stats_enabled ?? false;
+  const navigationItems = routeConfigs
+    .filter(
+      (route) =>
+        route.navigation?.showInSidebar &&
+        (route.path !== ROUTES.PRODUCERS || producerStatsEnabled),
+    )
+    .map((route) => ({
+      name: route.navigation!.name,
+      url: route.path,
+      icon: route.navigation!.icon,
+    }));
 
   return (
     <Sidebar collapsible="icon" {...props}>

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Frame, Map, Search } from "lucide-react";
+import { Factory, Frame, Map, Search } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { RouteComponentProps } from "wouter";
 import { Overview } from "@/app/overview";
@@ -21,6 +21,7 @@ const MetricsExplorer = lazy(() => import("@/app/metrics"));
 const MetricsDetails = lazy(() => import("@/app/metrics/details"));
 const SettingsPage = lazy(() => import("@/app/settings"));
 const QueriesPage = lazy(() => import("@/app/queries"));
+const ProducersPage = lazy(() => import("@/app/producers"));
 
 export const ROUTES = {
   HOME: "/",
@@ -31,6 +32,7 @@ export const ROUTES = {
   METRIC_DETAILS: "/metrics-explorer/:metric", // For backward compatibility
   SETTINGS: "/settings",
   QUERIES: "/queries",
+  PRODUCERS: "/producers",
 } as const;
 
 export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];
@@ -69,6 +71,18 @@ export const routeConfigs: readonly RouteConfig[] = [
     navigation: {
       name: "Metrics Catalog",
       icon: Map,
+      showInSidebar: true,
+    },
+  },
+  {
+    path: ROUTES.PRODUCERS,
+    component: ProducersPage,
+    breadcrumb: {
+      current: "Producers",
+    },
+    navigation: {
+      name: "Producers",
+      icon: Factory,
       showInSidebar: true,
     },
   },

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -90,6 +90,14 @@ export interface Producer {
   series: number;
 }
 
+export interface ProducerStats {
+  job: string;
+  metricCount: number;
+  usedMetricCount: number;
+  unusedMetricCount: number;
+  contribution: number;
+}
+
 export interface MetricStatistics {
   serieCount: number;
   labelCount: number;


### PR DESCRIPTION
## Summary

- add a paginated `/api/v1/producers` endpoint for producer metric, usage, and contribution statistics
- add a searchable and sortable Producers page with drill-through to the producer-filtered metrics catalog
- support SQLite and PostgreSQL, and regenerate the OpenAPI specification

## Tests

- `go test ./internal/db ./api/routes ./internal/ingester ./internal/retention`
- `npm test -- --run`
- `npm run check-types`
- `npm run lint`
- `npm run format:check`
- `npm run build`

Closes #471
