### PR TITLE
fix(ingester): don't silently drop batch on DB lookup error

### DIFF
--- a/internal/ingester/otlp/ingester.go
+++ b/internal/ingester/otlp/ingester.go
@@ -374,11 +374,7 @@ func (i *OtlpIngester) Export(ctx context.Context, req *metricspb.ExportMetricsS
 		i.bufferCatalogEntries(ctx, catalogMetrics)
 	}
 
-	unused, ok := i.lookupUnused(ctx, namesSet, histogramBases, summaryBases)
-	if !ok {
-		code = rpcOkCode
-		return &metricspb.ExportMetricsServiceResponse{}, nil
-	}
+	unused := i.lookupUnused(ctx, namesSet, histogramBases, summaryBases)
 	slog.DebugContext(ctx, "ingester.unused_metrics.count", "count", len(unused))
 
 	dryRun := i.config != nil && i.config.Ingester.DryRun
@@ -548,7 +544,7 @@ type histogramVariantState struct {
 	unusedSum    bool
 }
 
-func (i *OtlpIngester) lookupUnused(ctx context.Context, names map[string]struct{}, histogramBases, summaryBases map[string]struct{}) (map[string]struct{}, bool) {
+func (i *OtlpIngester) lookupUnused(ctx context.Context, names map[string]struct{}, histogramBases, summaryBases map[string]struct{}) map[string]struct{} {
 	unused := make(map[string]struct{})
 	histogramStates := i.initHistogramStates(histogramBases)
 	summaryStates := i.initSummaryStates(summaryBases)
@@ -556,40 +552,35 @@ func (i *OtlpIngester) lookupUnused(ctx context.Context, names map[string]struct
 	chunkSize := i.lookupChunkSize
 	batch := make([]string, 0, chunkSize)
 
-	flush := func() bool {
+	flush := func() {
 		if len(batch) == 0 {
-			return true
+			return
 		}
 
 		usedFromCache, unusedFromCache, misses := i.lookupCache(ctx, batch)
 		i.processCacheHits(usedFromCache, unusedFromCache, histogramBases, histogramStates, summaryBases, summaryStates, unused, ctx)
 
 		if len(misses) > 0 {
-			if !i.processDBMisses(ctx, misses, histogramBases, histogramStates, summaryBases, summaryStates, unused) {
-				return false
-			}
+			// A DB error for this chunk fails open (see processDBMisses) and does
+			// not stop the remaining chunks from being looked up.
+			i.processDBMisses(ctx, misses, histogramBases, histogramStates, summaryBases, summaryStates, unused)
 		}
 
 		batch = batch[:0]
-		return true
 	}
 
 	// Stream through names in chunks
 	for n := range names {
 		batch = append(batch, n)
 		if len(batch) == chunkSize {
-			if ok := flush(); !ok {
-				return nil, false
-			}
+			flush()
 		}
 	}
-	if ok := flush(); !ok {
-		return nil, false
-	}
+	flush()
 
 	i.reconcileHistogramBases(histogramStates, unused, ctx)
 	i.reconcileSummaryBases(summaryStates, unused, ctx)
-	return unused, true
+	return unused
 }
 
 type summaryVariantState struct {
@@ -752,19 +743,25 @@ func (i *OtlpIngester) updateSummaryState(name string, summaryBases map[string]s
 }
 
 // processDBMisses queries the database for cache misses and updates states.
-func (i *OtlpIngester) processDBMisses(ctx context.Context, misses []string, histogramBases map[string]struct{}, histogramStates map[string]*histogramVariantState, summaryBases map[string]struct{}, summaryStates map[string]*summaryVariantState, unused map[string]struct{}) bool {
+//
+// A DB error here fails open for the names in this chunk: it does not mark them
+// as unused, does not mark them as resolved, and does not abort the surrounding
+// lookupUnused/Export call. The affected names simply stay out of the unused
+// set for this batch (equivalent to "not confirmed unused"), so the batch is
+// still forwarded downstream instead of being silently discarded.
+// See https://github.com/nicolastakashi/prom-analytics-proxy/issues/569.
+func (i *OtlpIngester) processDBMisses(ctx context.Context, misses []string, histogramBases map[string]struct{}, histogramStates map[string]*histogramVariantState, summaryBases map[string]struct{}, summaryStates map[string]*summaryVariantState, unused map[string]struct{}) {
 	t0 := time.Now()
 	metas, err := i.db.GetSeriesMetadataByNames(ctx, misses, "")
 	if err != nil {
-		slog.ErrorContext(ctx, "ingester.lookup.failed_skipping_drops", "err", err)
+		slog.ErrorContext(ctx, "ingester.lookup.failed_treating_as_used", "err", err, "names_count", len(misses))
 		processorLookupErrorsTotal.Inc()
-		return false
+		return
 	}
 	processorLookupDurationSeconds.Observe(time.Since(t0).Seconds())
 
 	cacheWriteBack := i.processMetadata(metas, histogramBases, histogramStates, summaryBases, summaryStates, unused, ctx)
 	i.writeBackToCache(ctx, cacheWriteBack)
-	return true
 }
 
 // processMetadata processes database metadata and updates histogram states and unused map.

--- a/internal/ingester/otlp_ingester_test.go
+++ b/internal/ingester/otlp_ingester_test.go
@@ -242,6 +242,9 @@ func TestExport_DBError_FailOpen(t *testing.T) {
 	ing, err := NewOtlpIngester(cfg, mp)
 	assert.NoError(t, err)
 
+	exp := &captureExporter{}
+	ing.SetExporter(exp)
+
 	req := buildExportRequest(
 		buildGaugeMetric("unused_metric", 1),
 	)
@@ -256,7 +259,64 @@ func TestExport_DBError_FailOpen(t *testing.T) {
 	assert.Len(t, rms, 1)
 	assert.Len(t, rms[0].ScopeMetrics[0].Metrics, 1)
 
+	// Regression guard for https://github.com/nicolastakashi/prom-analytics-proxy/issues/569:
+	// a DB lookup error must not make Export() bail out before ever reaching the
+	// downstream exporter. "Fail open" has to mean the batch is actually forwarded,
+	// not just that the (never-reached) filtering step didn't mutate it in place.
+	assert.NotNil(t, exp.captured, "batch should have been forwarded to the downstream exporter despite the DB lookup error")
+	if exp.captured != nil {
+		assert.Len(t, exp.captured.ResourceMetrics, 1)
+		assert.Len(t, exp.captured.ResourceMetrics[0].ScopeMetrics[0].Metrics, 1)
+	}
+
 	mp.AssertExpectations(t)
+}
+
+// TestExport_DBError_PartialChunkFailure_StillDropsResolvedUnused verifies that when
+// usage lookups are split across multiple DB-lookup chunks, a DB error on one chunk
+// only fails open for that chunk's names -- metrics whose usage was already resolved
+// by a different, successful chunk must still be dropped normally.
+func TestExport_DBError_PartialChunkFailure_StillDropsResolvedUnused(t *testing.T) {
+	mp := &mockUsageProvider{}
+	cfg := &config.Config{
+		Ingester: config.IngesterConfig{
+			OTLP: config.OtlpIngesterConfig{
+				LookupChunkSize: 1, // force one name per DB lookup chunk
+			},
+		},
+	}
+	ing, err := NewOtlpIngester(cfg, mp)
+	assert.NoError(t, err)
+
+	exp := &captureExporter{}
+	ing.SetExporter(exp)
+
+	req := buildExportRequest(
+		buildGaugeMetric("resolved_unused_metric", 1),
+		buildGaugeMetric("unresolved_metric", 1),
+	)
+
+	// One chunk resolves cleanly and confirms the metric is unused.
+	mp.On("GetSeriesMetadataByNames", mock.Anything, []string{"resolved_unused_metric"}, "").Return([]models.MetricMetadata{
+		{Name: "resolved_unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+	}, nil).Maybe()
+	// The other chunk's DB lookup fails.
+	mp.On("GetSeriesMetadataByNames", mock.Anything, []string{"unresolved_metric"}, "").Return(nil, assert.AnError).Maybe()
+
+	_, err = ing.Export(context.Background(), req)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, exp.captured, "batch should still reach the downstream exporter")
+	if exp.captured != nil {
+		got := exp.captured.ResourceMetrics[0].ScopeMetrics[0].Metrics
+		names := make([]string, 0, len(got))
+		for _, m := range got {
+			names = append(names, m.GetName())
+		}
+		// resolved_unused_metric was confirmed unused by a successful chunk and must be
+		// dropped; unresolved_metric's chunk failed and must fail open (kept).
+		assert.ElementsMatch(t, []string{"unresolved_metric"}, names)
+	}
 }
 
 func TestExport_DryRunMode_RecordsMetricsButDoesNotDrop(t *testing.T) {


### PR DESCRIPTION
A DB error while resolving usage-unused metadata for part of a batch used to make Export() return an empty success response before ever calling the downstream exporter, discarding the entire OTLP batch without any way for the sender to know or retry.

processDBMisses now fails open per lookup chunk: on error it logs (renamed to ingester.lookup.failed_treating_as_used, since nothing is actually skipped except the export step) and increments the existing ingester_processor_lookup_errors_total counter, but leaves that chunk's names out of the unused set instead of aborting. lookupUnused and Export() no longer have a path that returns early without attempting the real export.

RPC status codes now come entirely from the actual downstream export outcome instead of being forced to OK on lookup failure -- OK is only returned when the batch genuinely reached the exporter and was accepted.

Adds regression coverage for both the whole-chunk failure case and a multi-chunk case where one chunk's DB error must not affect another chunk's already-resolved unused verdict.

Fixes #569

Change-Id: I9818ab485f7a3c0891497e9713a82d259179b59a