### PR TITLE
fix(db,ingester): don't treat unevaluated metrics as confirmed unused

### DIFF
--- a/api/models/series.go
+++ b/api/models/series.go
@@ -15,4 +15,11 @@ type MetricMetadata struct {
 	DashboardCount int    `json:"dashboardCount,omitempty"`
 	QueryCount     int    `json:"queryCount,omitempty"`
 	LastQueriedAt  string `json:"lastQueriedAt,omitempty"`
+	// IsUnused reflects metrics_usage_summary.is_unused as evaluated by
+	// RefreshMetricsUsageSummary. It is the single source of truth for
+	// whether a metric is confirmed unused - callers must not infer
+	// "unused" from AlertCount/RecordCount/DashboardCount/QueryCount being
+	// zero, since zero counts are also what an unevaluated metric looks
+	// like before its first RefreshMetricsUsageSummary run.
+	IsUnused bool `json:"isUnused,omitempty"`
 }

--- a/api/routes/bench_test.go
+++ b/api/routes/bench_test.go
@@ -704,9 +704,19 @@ func BenchmarkSeriesMetadataUnused_SQLite_JobScopedScaleUp(b *testing.B) {
 			defer func() { _ = provider.Close() }()
 
 			seedCatalogAndSparseJobIndex(b, provider, totalN, scaleUpUnusedN, targetJob, noiseJob)
-			// No seedSummaryUsedRows call: every catalog row stays unused.
-			// UpsertMetricsCatalog already creates default-unused summary
-			// rows, so the unused predicate matches every metric.
+			// Evaluate the whole catalog via a real RefreshMetricsUsageSummary
+			// (no RulesUsage/DashboardUsage/queries seeded, so every row
+			// genuinely computes is_unused=TRUE) rather than relying on
+			// UpsertMetricsCatalog's placeholder default, which now defaults
+			// to is_unused=FALSE (unevaluated) precisely so it can't be
+			// mistaken for a confirmed-unused row. See
+			// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
+			if err := provider.RefreshMetricsUsageSummary(context.Background(), db.TimeRange{
+				From: time.Now().Add(-time.Hour),
+				To:   time.Now().Add(time.Hour),
+			}); err != nil {
+				b.Fatalf("RefreshMetricsUsageSummary: %v", err)
+			}
 
 			var rawDB *sql.DB
 			provider.WithDB(func(d *sql.DB) { rawDB = d })
@@ -760,6 +770,15 @@ func BenchmarkSeriesMetadataUnused_PostgreSQL_JobScopedScaleUp(b *testing.B) {
 			defer cleanup()
 
 			seedCatalogAndSparseJobIndex(b, provider, totalN, scaleUpUnusedN, targetJob, noiseJob)
+			// See the SQLite JobScopedScaleUp benchmark's comment: this
+			// evaluates the whole catalog for real instead of relying on the
+			// (now unevaluated-by-default) placeholder rows.
+			if err := provider.RefreshMetricsUsageSummary(context.Background(), db.TimeRange{
+				From: time.Now().Add(-time.Hour),
+				To:   time.Now().Add(time.Hour),
+			}); err != nil {
+				b.Fatalf("RefreshMetricsUsageSummary: %v", err)
+			}
 
 			var rawDB *sql.DB
 			provider.WithDB(func(d *sql.DB) { rawDB = d })

--- a/api/routes/routes_test.go
+++ b/api/routes/routes_test.go
@@ -68,7 +68,10 @@ func TestSeriesMetadata_UsageFilter_Route(t *testing.T) {
 		Type:          db.QueryTypeInstant,
 	}})
 	_ = provider.RefreshMetricsUsageSummary(context.Background(), db.TimeRange{From: now.Add(-1 * time.Hour), To: now})
-	_ = provider.UpsertMetricsCatalog(context.Background(), []db.MetricCatalogItem{{Name: "no_summary_metric", Type: "gauge"}})
+	// Catalogued after the only RefreshMetricsUsageSummary run: this metric has
+	// never actually been evaluated, so it must not show up as "unused". See
+	// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
+	_ = provider.UpsertMetricsCatalog(context.Background(), []db.MetricCatalogItem{{Name: "never_evaluated_metric", Type: "gauge"}})
 
 	upstream, _ := url.Parse("http://127.0.0.1")
 	reg := prometheus.NewRegistry()
@@ -93,7 +96,7 @@ func TestSeriesMetadata_UsageFilter_Route(t *testing.T) {
 		{
 			name:      "unused usage filter",
 			query:     "/api/v1/seriesMetadata?page=1&pageSize=10&type=all&usage=unused",
-			wantNames: []string{"no_summary_metric", "unused_metric"},
+			wantNames: []string{"unused_metric"},
 		},
 	}
 

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -1010,10 +1010,18 @@ func (p *PostGreSQLProvider) GetSeriesMetadataByNames(ctx context.Context, names
 		args  []any
 	)
 
+	// COALESCE(s.is_unused, FALSE) is the single source of truth for
+	// "confirmed unused" - it must not be recomputed from the four counts
+	// below, since a metric that was never evaluated by
+	// RefreshMetricsUsageSummary also has all-zero counts (see the
+	// placeholder insert in UpsertMetricsCatalog) and a missing summary row
+	// (FALSE from COALESCE) must fail toward "keep" the same way. See
+	// https://github.com/nicolastakashi/prom-analytics-proxy/issues/571.
 	if job != "" {
 		query = `
             SELECT c.name, c.type, c.help, c.unit,
-                   COALESCE(s.alert_count,0), COALESCE(s.record_count,0), COALESCE(s.dashboard_count,0), COALESCE(s.query_count,0), s.last_queried_at
+                   COALESCE(s.alert_count,0), COALESCE(s.record_count,0), COALESCE(s.dashboard_count,0), COALESCE(s.query_count,0), s.last_queried_at,
+                   COALESCE(s.is_unused, FALSE)
             FROM metrics_catalog c
             LEFT JOIN metrics_usage_summary s ON s.name = c.name
             WHERE c.name = ANY($1)
@@ -1023,7 +1031,8 @@ func (p *PostGreSQLProvider) GetSeriesMetadataByNames(ctx context.Context, names
 	} else {
 		query = `
             SELECT c.name, c.type, c.help, c.unit,
-                   COALESCE(s.alert_count,0), COALESCE(s.record_count,0), COALESCE(s.dashboard_count,0), COALESCE(s.query_count,0), s.last_queried_at
+                   COALESCE(s.alert_count,0), COALESCE(s.record_count,0), COALESCE(s.dashboard_count,0), COALESCE(s.query_count,0), s.last_queried_at,
+                   COALESCE(s.is_unused, FALSE)
             FROM metrics_catalog c
             LEFT JOIN metrics_usage_summary s ON s.name = c.name
             WHERE c.name = ANY($1)
@@ -1041,14 +1050,15 @@ func (p *PostGreSQLProvider) GetSeriesMetadataByNames(ctx context.Context, names
 		name, mtype, help, unit     string
 		alert, record, dash, qcount int
 		last                        sql.NullTime
+		isUnused                    bool
 	}
 	out := make([]models.MetricMetadata, 0, len(names))
 	for rows.Next() {
 		var r row
-		if err := rows.Scan(&r.name, &r.mtype, &r.help, &r.unit, &r.alert, &r.record, &r.dash, &r.qcount, &r.last); err != nil {
+		if err := rows.Scan(&r.name, &r.mtype, &r.help, &r.unit, &r.alert, &r.record, &r.dash, &r.qcount, &r.last, &r.isUnused); err != nil {
 			return nil, fmt.Errorf("scan: %w", err)
 		}
-		mm := models.MetricMetadata{Name: r.name, Type: r.mtype, Help: r.help, Unit: r.unit, AlertCount: r.alert, RecordCount: r.record, DashboardCount: r.dash, QueryCount: r.qcount}
+		mm := models.MetricMetadata{Name: r.name, Type: r.mtype, Help: r.help, Unit: r.unit, AlertCount: r.alert, RecordCount: r.record, DashboardCount: r.dash, QueryCount: r.qcount, IsUnused: r.isUnused}
 		if r.last.Valid {
 			mm.LastQueriedAt = r.last.Time.UTC().Format(time.RFC3339)
 		}
@@ -1092,11 +1102,18 @@ func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []M
 		names[i] = it.Name
 	}
 
-	// Co-write a default-unused summary row per catalog item so the
+	// Co-write a placeholder summary row per catalog item so the
 	// metrics_catalog <-> metrics_usage_summary invariant holds before
 	// the next RefreshMetricsUsageSummary. ON CONFLICT DO NOTHING means
-	// existing rows with real counts are not clobbered. The new
-	// ?usage=unused query depends on this invariant to use an INNER JOIN.
+	// existing rows with real counts are not clobbered.
+	//
+	// is_unused=FALSE here, not TRUE: a metric that has never been
+	// evaluated is not the same thing as one confirmed to have zero usage,
+	// and defaulting to TRUE previously caused every newly-catalogued
+	// metric to be treated as unused (and dropped/hidden) until the next
+	// successful RefreshMetricsUsageSummary run - which, if that job is
+	// failing, could be never. See
+	// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
 	//
 	// One bulk INSERT via unnest() instead of one statement per item -
 	// the syncer calls this with the full catalog inventory (~tens of
@@ -1104,7 +1121,7 @@ func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []M
 	// add up fast.
 	if _, err := tx.ExecContext(ctx, `
         INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused)
-        SELECT n, 0, 0, 0, 0, NOW(), TRUE FROM unnest($1::text[]) AS n
+        SELECT n, 0, 0, 0, 0, NOW(), FALSE FROM unnest($1::text[]) AS n
         ON CONFLICT (name) DO NOTHING
     `, pq.Array(names)); err != nil {
 		_ = tx.Rollback()

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -634,16 +634,20 @@ func TestPostgreSQL_GetSeriesMetadata_UsageFilters(t *testing.T) {
 	}})
 
 	assert.NoError(t, p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-1 * time.Hour), To: now}))
-	mustUpsertCatalog(t, p, []MetricCatalogItem{{Name: "no_summary_metric", Type: "gauge", Help: "no summary metric"}})
+	// Catalogued after the only RefreshMetricsUsageSummary run: this metric has
+	// never actually been evaluated, so it must not show up as "unused" - it
+	// should behave as "unknown" until a future refresh evaluates it. See
+	// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
+	mustUpsertCatalog(t, p, []MetricCatalogItem{{Name: "never_evaluated_metric", Type: "gauge", Help: "never evaluated metric"}})
 
 	tests := []struct {
 		name      string
 		usage     string
 		wantNames []string
 	}{
-		{name: "all metrics", usage: SeriesMetadataUsageAll, wantNames: []string{"no_summary_metric", "unused_metric", "used_metric"}},
+		{name: "all metrics", usage: SeriesMetadataUsageAll, wantNames: []string{"never_evaluated_metric", "unused_metric", "used_metric"}},
 		{name: "used metrics", usage: SeriesMetadataUsageUsed, wantNames: []string{"used_metric"}},
-		{name: "unused metrics", usage: SeriesMetadataUsageUnused, wantNames: []string{"no_summary_metric", "unused_metric"}},
+		{name: "unused metrics", usage: SeriesMetadataUsageUnused, wantNames: []string{"unused_metric"}},
 	}
 
 	for _, tt := range tests {
@@ -667,12 +671,14 @@ func TestPostgreSQL_GetSeriesMetadata_UsageFilters(t *testing.T) {
 	}
 }
 
-// TestPostgreSQL_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow pins the
-// invariant the new ?usage=unused query depends on: after UpsertMetricsCatalog,
-// every catalog row has a corresponding metrics_usage_summary row with
-// is_unused=TRUE and zero counts, even before any RefreshMetricsUsageSummary.
-// This invariant lets the unused query INNER JOIN safely instead of having to
-// fall back to a LEFT JOIN + IS NULL branch.
+// TestPostgreSQL_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow pins two
+// invariants: (1) after UpsertMetricsCatalog, every catalog row has a
+// corresponding metrics_usage_summary row with zero counts, even before any
+// RefreshMetricsUsageSummary - this lets the unused query INNER JOIN safely
+// instead of falling back to a LEFT JOIN + IS NULL branch; and (2) that
+// placeholder row must NOT be marked is_unused=TRUE, since a metric that has
+// never been evaluated is not the same thing as a metric confirmed to have
+// zero usage. See https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
 func TestPostgreSQL_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow(t *testing.T) {
 	p, cleanup := newTestPostgreSQLProvider(t)
 	defer cleanup()
@@ -704,9 +710,48 @@ func TestPostgreSQL_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow(t *testi
 	assert.NoError(t, rows.Err())
 
 	assert.Equal(t, []summaryRow{
-		{name: "metric_a", isUnused: true},
-		{name: "metric_b", isUnused: true},
+		{name: "metric_a", isUnused: false},
+		{name: "metric_b", isUnused: false},
 	}, got)
+}
+
+// TestPostgreSQL_GetSeriesMetadataByNames_PopulatesIsUnused guards the
+// write-path half of https://github.com/nicolastakashi/prom-analytics-proxy/issues/571:
+// GetSeriesMetadataByNames (used by the OTLP ingester's usage-unused lookup)
+// must source IsUnused from metrics_usage_summary.is_unused directly, not
+// recompute it from the four usage counts - counts alone cannot distinguish
+// "evaluated, confirmed zero usage" from "never evaluated yet".
+func TestPostgreSQL_GetSeriesMetadataByNames_PopulatesIsUnused(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "evaluated_unused_metric", Type: "gauge", Help: "evaluated, confirmed unused"},
+	})
+	// Evaluate: no usage anywhere for this metric, so RefreshMetricsUsageSummary
+	// confirms it as genuinely unused.
+	assert.NoError(t, p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-1 * time.Hour), To: now}))
+
+	// Catalogued after the only refresh run: never evaluated.
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "fresh_metric", Type: "gauge", Help: "never evaluated"},
+	})
+
+	results, err := p.GetSeriesMetadataByNames(context.Background(), []string{"evaluated_unused_metric", "fresh_metric"}, "")
+	assert.NoError(t, err, "GetSeriesMetadataByNames")
+
+	byName := make(map[string]models.MetricMetadata, len(results))
+	for _, mm := range results {
+		byName[mm.Name] = mm
+	}
+
+	if assert.Contains(t, byName, "evaluated_unused_metric") {
+		assert.True(t, byName["evaluated_unused_metric"].IsUnused, "a metric confirmed unused by RefreshMetricsUsageSummary must report IsUnused=true")
+	}
+	if assert.Contains(t, byName, "fresh_metric") {
+		assert.False(t, byName["fresh_metric"].IsUnused, "a never-evaluated metric must not report IsUnused=true merely because its counts are zero")
+	}
 }
 
 func TestPostgreSQL_DashboardUsage(t *testing.T) {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -996,10 +996,17 @@ func (p *SQLiteProvider) GetSeriesMetadataByNames(ctx context.Context, names []s
 		args = append(args, n)
 	}
 
-	// Static base with parameterized placeholders; append job filter as parameter, not as formatted value
+	// Static base with parameterized placeholders; append job filter as parameter, not as formatted value.
+	// COALESCE(s.is_unused, FALSE) is the single source of truth for "confirmed
+	// unused" - it must not be recomputed from the four counts below, since a
+	// metric that was never evaluated by RefreshMetricsUsageSummary also has
+	// all-zero counts (see the placeholder insert in UpsertMetricsCatalog) and
+	// a missing summary row (FALSE from COALESCE) must fail toward "keep" the
+	// same way. See https://github.com/nicolastakashi/prom-analytics-proxy/issues/571.
 	base := fmt.Sprintf(`
         SELECT c.name, c.type, c.help, c.unit,
-               COALESCE(s.alert_count, 0), COALESCE(s.record_count, 0), COALESCE(s.dashboard_count, 0), COALESCE(s.query_count, 0), s.last_queried_at
+               COALESCE(s.alert_count, 0), COALESCE(s.record_count, 0), COALESCE(s.dashboard_count, 0), COALESCE(s.query_count, 0), s.last_queried_at,
+               COALESCE(s.is_unused, FALSE)
         FROM metrics_catalog AS c
         LEFT JOIN metrics_usage_summary AS s ON s.name = c.name
         WHERE c.name IN (%s)
@@ -1023,12 +1030,13 @@ func (p *SQLiteProvider) GetSeriesMetadataByNames(ctx context.Context, names []s
 		name, mtype, help, unit     string
 		alert, record, dash, qcount int
 		last                        sql.NullTime
+		isUnused                    bool
 	}
 
 	results := make([]models.MetricMetadata, 0, len(names))
 	for rows.Next() {
 		var r row
-		if err := rows.Scan(&r.name, &r.mtype, &r.help, &r.unit, &r.alert, &r.record, &r.dash, &r.qcount, &r.last); err != nil {
+		if err := rows.Scan(&r.name, &r.mtype, &r.help, &r.unit, &r.alert, &r.record, &r.dash, &r.qcount, &r.last, &r.isUnused); err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 		mm := models.MetricMetadata{
@@ -1040,6 +1048,7 @@ func (p *SQLiteProvider) GetSeriesMetadataByNames(ctx context.Context, names []s
 			RecordCount:    r.record,
 			DashboardCount: r.dash,
 			QueryCount:     r.qcount,
+			IsUnused:       r.isUnused,
 		}
 		if r.last.Valid {
 			mm.LastQueriedAt = r.last.Time.UTC().Format(time.RFC3339)
@@ -1078,18 +1087,25 @@ func (p *SQLiteProvider) UpsertMetricsCatalog(ctx context.Context, items []Metri
 	}
 	defer CloseResource(stmt)
 
-	// Co-write a default-unused summary row per catalog item so the
+	// Co-write a placeholder summary row per catalog item so the
 	// metrics_catalog <-> metrics_usage_summary invariant holds before
 	// the next RefreshMetricsUsageSummary. ON CONFLICT DO NOTHING means
-	// existing rows with real counts are not clobbered. The new
-	// ?usage=unused query depends on this invariant to use an INNER JOIN.
+	// existing rows with real counts are not clobbered.
+	//
+	// is_unused=FALSE here, not TRUE: a metric that has never been
+	// evaluated is not the same thing as one confirmed to have zero usage,
+	// and defaulting to TRUE previously caused every newly-catalogued
+	// metric to be treated as unused (and dropped/hidden) until the next
+	// successful RefreshMetricsUsageSummary run - which, if that job is
+	// failing, could be never. See
+	// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
 	//
 	// Kept as a per-item prepared statement (vs. PG's bulk unnest) because
 	// SQLite is in-process: per-exec overhead is microseconds and there's
 	// no network round-trip to amortise.
 	summaryStmt, err := tx.PrepareContext(ctx, `
         INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused)
-        VALUES(?, 0, 0, 0, 0, datetime('now'), TRUE)
+        VALUES(?, 0, 0, 0, 0, datetime('now'), FALSE)
         ON CONFLICT(name) DO NOTHING
     `)
 	if err != nil {

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -713,16 +713,20 @@ func TestSQLite_GetSeriesMetadata_UsageFilters(t *testing.T) {
 	}})
 
 	assert.NoError(t, p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-1 * time.Hour), To: now}))
-	mustUpsertCatalog(t, p, []MetricCatalogItem{{Name: "no_summary_metric", Type: "gauge", Help: "no summary metric"}})
+	// Catalogued after the only RefreshMetricsUsageSummary run: this metric has
+	// never actually been evaluated, so it must not show up as "unused" - it
+	// should behave as "unknown" until a future refresh evaluates it. See
+	// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
+	mustUpsertCatalog(t, p, []MetricCatalogItem{{Name: "never_evaluated_metric", Type: "gauge", Help: "never evaluated metric"}})
 
 	tests := []struct {
 		name      string
 		usage     string
 		wantNames []string
 	}{
-		{name: "all metrics", usage: SeriesMetadataUsageAll, wantNames: []string{"no_summary_metric", "unused_metric", "used_metric"}},
+		{name: "all metrics", usage: SeriesMetadataUsageAll, wantNames: []string{"never_evaluated_metric", "unused_metric", "used_metric"}},
 		{name: "used metrics", usage: SeriesMetadataUsageUsed, wantNames: []string{"used_metric"}},
-		{name: "unused metrics", usage: SeriesMetadataUsageUnused, wantNames: []string{"no_summary_metric", "unused_metric"}},
+		{name: "unused metrics", usage: SeriesMetadataUsageUnused, wantNames: []string{"unused_metric"}},
 	}
 
 	for _, tt := range tests {
@@ -746,12 +750,14 @@ func TestSQLite_GetSeriesMetadata_UsageFilters(t *testing.T) {
 	}
 }
 
-// TestSQLite_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow pins the
-// invariant the new ?usage=unused query depends on: after UpsertMetricsCatalog,
-// every catalog row has a corresponding metrics_usage_summary row with
-// is_unused=TRUE and zero counts, even before any RefreshMetricsUsageSummary.
-// This invariant lets the unused query INNER JOIN safely instead of having to
-// fall back to a LEFT JOIN + IS NULL branch.
+// TestSQLite_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow pins two
+// invariants: (1) after UpsertMetricsCatalog, every catalog row has a
+// corresponding metrics_usage_summary row with zero counts, even before any
+// RefreshMetricsUsageSummary - this lets the unused query INNER JOIN safely
+// instead of falling back to a LEFT JOIN + IS NULL branch; and (2) that
+// placeholder row must NOT be marked is_unused=TRUE, since a metric that has
+// never been evaluated is not the same thing as a metric confirmed to have
+// zero usage. See https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
 func TestSQLite_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow(t *testing.T) {
 	p, cleanup := newTestSQLiteProvider(t)
 	defer cleanup()
@@ -783,9 +789,48 @@ func TestSQLite_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow(t *testing.T
 	assert.NoError(t, rows.Err())
 
 	assert.Equal(t, []summaryRow{
-		{name: "metric_a", isUnused: true},
-		{name: "metric_b", isUnused: true},
+		{name: "metric_a", isUnused: false},
+		{name: "metric_b", isUnused: false},
 	}, got)
+}
+
+// TestSQLite_GetSeriesMetadataByNames_PopulatesIsUnused guards the write-path
+// half of https://github.com/nicolastakashi/prom-analytics-proxy/issues/571:
+// GetSeriesMetadataByNames (used by the OTLP ingester's usage-unused lookup)
+// must source IsUnused from metrics_usage_summary.is_unused directly, not
+// recompute it from the four usage counts - counts alone cannot distinguish
+// "evaluated, confirmed zero usage" from "never evaluated yet".
+func TestSQLite_GetSeriesMetadataByNames_PopulatesIsUnused(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "evaluated_unused_metric", Type: "gauge", Help: "evaluated, confirmed unused"},
+	})
+	// Evaluate: no usage anywhere for this metric, so RefreshMetricsUsageSummary
+	// confirms it as genuinely unused.
+	assert.NoError(t, p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-1 * time.Hour), To: now}))
+
+	// Catalogued after the only refresh run: never evaluated.
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "fresh_metric", Type: "gauge", Help: "never evaluated"},
+	})
+
+	results, err := p.GetSeriesMetadataByNames(context.Background(), []string{"evaluated_unused_metric", "fresh_metric"}, "")
+	assert.NoError(t, err, "GetSeriesMetadataByNames")
+
+	byName := make(map[string]models.MetricMetadata, len(results))
+	for _, mm := range results {
+		byName[mm.Name] = mm
+	}
+
+	if assert.Contains(t, byName, "evaluated_unused_metric") {
+		assert.True(t, byName["evaluated_unused_metric"].IsUnused, "a metric confirmed unused by RefreshMetricsUsageSummary must report IsUnused=true")
+	}
+	if assert.Contains(t, byName, "fresh_metric") {
+		assert.False(t, byName["fresh_metric"].IsUnused, "a never-evaluated metric must not report IsUnused=true merely because its counts are zero")
+	}
 }
 
 // TestSQLite_DashboardUsage verifies dashboard usage time range filtering

--- a/internal/ingester/otlp/ingester.go
+++ b/internal/ingester/otlp/ingester.go
@@ -903,11 +903,15 @@ func (i *OtlpIngester) isSummaryVariant(name string, summaryBases map[string]str
 	return "", false
 }
 
+// metricMetadataUnused reports whether mm is confirmed unused. This must be
+// sourced from metrics_usage_summary.is_unused (via mm.IsUnused), not
+// recomputed from the four usage counts - a metric that has never been
+// evaluated by RefreshMetricsUsageSummary also has all-zero counts, and
+// counts alone cannot distinguish "confirmed unused" from "not evaluated
+// yet". See https://github.com/nicolastakashi/prom-analytics-proxy/issues/570
+// and https://github.com/nicolastakashi/prom-analytics-proxy/issues/571.
 func metricMetadataUnused(mm models.MetricMetadata) bool {
-	return mm.AlertCount == 0 &&
-		mm.RecordCount == 0 &&
-		mm.DashboardCount == 0 &&
-		mm.QueryCount == 0
+	return mm.IsUnused
 }
 
 func resolveJob(res *resourcepb.Resource) string {

--- a/internal/ingester/otlp_ingester_test.go
+++ b/internal/ingester/otlp_ingester_test.go
@@ -126,7 +126,7 @@ func TestExport_DropsUnusedMetrics_KeepsUsedAndUnknown(t *testing.T) {
 	// Expect a single call with any slice (we assert content via behavior)
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
 		{Name: "used_metric", QueryCount: 1},
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 		// unknown_metric intentionally not returned
 	}, nil).Once()
 
@@ -171,7 +171,7 @@ func TestExport_AllowedJobs_ScopesUnusedDrop(t *testing.T) {
 
 	// DB: mark "unused_metric" as unused globally
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 	}, nil).Once()
 
 	req := buildExportRequestForJobs(
@@ -204,7 +204,7 @@ func TestExport_DeniedJobs_DisablesUnusedDrop(t *testing.T) {
 
 	// DB: mark "unused_metric" as unused globally
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 	}, nil).Once()
 
 	req := buildExportRequestForJobs(
@@ -278,7 +278,7 @@ func TestExport_DryRunMode_RecordsMetricsButDoesNotDrop(t *testing.T) {
 	// Expect a single call with any slice (we assert content via behavior)
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
 		{Name: "used_metric", QueryCount: 1},
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 		// unknown_metric intentionally not returned
 	}, nil).Once()
 
@@ -310,9 +310,9 @@ func TestExport_DropsHistogramWhenAllVariantsUnused(t *testing.T) {
 
 	// All histogram variants are unused, but used_metric has queries
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
-		{Name: "access_evaluation_duration_bucket", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
-		{Name: "access_evaluation_duration_count", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
-		{Name: "access_evaluation_duration_sum", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "access_evaluation_duration_bucket", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
+		{Name: "access_evaluation_duration_count", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
+		{Name: "access_evaluation_duration_sum", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 		{Name: "used_metric", QueryCount: 1},
 	}, nil).Once()
 
@@ -344,9 +344,9 @@ func TestExport_KeepsHistogramWhenVariantUsed(t *testing.T) {
 	// Histogram _bucket variant is used (has queries), so entire histogram should be kept
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
 		{Name: "access_evaluation_duration_bucket", QueryCount: 5}, // Used!
-		{Name: "access_evaluation_duration_count", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
-		{Name: "access_evaluation_duration_sum", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "access_evaluation_duration_count", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
+		{Name: "access_evaluation_duration_sum", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 	}, nil).Once()
 
 	_, err = ing.Export(context.Background(), req)
@@ -376,8 +376,8 @@ func TestExport_KeepsHistogramWhenVariantMissing(t *testing.T) {
 	// Only bucket and count variants returned, sum is missing
 	// Should fail open (keep histogram) when any variant is missing
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
-		{Name: "access_evaluation_duration_bucket", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
-		{Name: "access_evaluation_duration_count", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "access_evaluation_duration_bucket", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
+		{Name: "access_evaluation_duration_count", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 		// sum variant intentionally missing
 	}, nil).Once()
 
@@ -391,6 +391,45 @@ func TestExport_KeepsHistogramWhenVariantMissing(t *testing.T) {
 	got := rms[0].ScopeMetrics[0].Metrics
 	assert.Len(t, got, 1)
 	assert.Equal(t, "access_evaluation_duration", got[0].GetName())
+
+	mp.AssertExpectations(t)
+}
+
+// TestExport_UnevaluatedMetric_NotConfirmedUnused_IsKept guards the fix for
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570 and
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/571: a metric
+// with all-zero usage counts is not necessarily unused - it may simply be a
+// freshly-catalogued metric that has not yet had a chance to be evaluated by
+// RefreshMetricsUsageSummary (see UpsertMetricsCatalog's placeholder insert,
+// which creates exactly this all-zero-counts shape for every newly-seen
+// metric). Only IsUnused=true, sourced from metrics_usage_summary.is_unused,
+// may be trusted as "confirmed unused" - zero counts alone must not cause a
+// drop.
+func TestExport_UnevaluatedMetric_NotConfirmedUnused_IsKept(t *testing.T) {
+	mp := &mockUsageProvider{}
+	cfg := &config.Config{}
+	ing, err := NewOtlpIngester(cfg, mp)
+	assert.NoError(t, err)
+
+	req := buildExportRequest(
+		buildGaugeMetric("brand_new_metric", 1),
+	)
+
+	// Zero counts, but IsUnused is explicitly false: this is what a
+	// freshly-catalogued, not-yet-evaluated metric looks like. It must not be
+	// treated as confirmed unused merely because its counts happen to be zero.
+	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
+		{Name: "brand_new_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: false},
+	}, nil).Once()
+
+	_, err = ing.Export(context.Background(), req)
+	assert.NoError(t, err)
+
+	// Must be kept, not dropped, despite all-zero counts.
+	rms := req.ResourceMetrics
+	if assert.Len(t, rms, 1) && assert.Len(t, rms[0].ScopeMetrics[0].Metrics, 1) {
+		assert.Equal(t, "brand_new_metric", rms[0].ScopeMetrics[0].Metrics[0].GetName())
+	}
 
 	mp.AssertExpectations(t)
 }
@@ -440,7 +479,7 @@ func BenchmarkExport_FilterSizes(b *testing.B) {
 				k := int(float64(len(names)) * c.unusedRatio)
 				for i, n := range names {
 					if i < k {
-						res = append(res, models.MetricMetadata{Name: n})
+						res = append(res, models.MetricMetadata{Name: n, IsUnused: true})
 					} else {
 						res = append(res, models.MetricMetadata{Name: n, QueryCount: 1})
 					}
@@ -631,7 +670,7 @@ func TestExport_WithCacheDisabled_BehavesAsBefore(t *testing.T) {
 
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
 		{Name: "used_metric", QueryCount: 1},
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 	}, nil).Once()
 
 	_, err = ing.Export(context.Background(), req)
@@ -671,7 +710,7 @@ func TestExport_WithCacheEnabled_AllMisses_HitsDB(t *testing.T) {
 	// First call should hit DB (cache miss)
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
 		{Name: "used_metric", QueryCount: 1},
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 	}, nil).Once()
 
 	_, err = ing.Export(context.Background(), req)
@@ -716,7 +755,7 @@ func TestExport_WithCacheEnabled_UsedHit_SkipsDB(t *testing.T) {
 		// Should only contain unused_metric
 		return len(names) == 1 && names[0] == "unused_metric"
 	}), "").Return([]models.MetricMetadata{
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 	}, nil).Once()
 
 	_, err = ing.Export(context.Background(), req)
@@ -803,7 +842,7 @@ func TestExport_WithCacheError_FallsBackToDB(t *testing.T) {
 	// Should fall back to DB when cache errors
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
 		{Name: "used_metric", QueryCount: 1},
-		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 	}, nil).Once()
 
 	_, err = ing.Export(context.Background(), req)
@@ -844,9 +883,9 @@ func TestExport_WithHistogramCache_HandlesVariantsCorrectly(t *testing.T) {
 
 	// DB should return metadata for all variants
 	mp.On("GetSeriesMetadataByNames", mock.Anything, mock.Anything, "").Return([]models.MetricMetadata{
-		{Name: "http_request_duration_seconds_bucket", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
-		{Name: "http_request_duration_seconds_count", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
-		{Name: "http_request_duration_seconds_sum", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "http_request_duration_seconds_bucket", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
+		{Name: "http_request_duration_seconds_count", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
+		{Name: "http_request_duration_seconds_sum", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 		{Name: "regular_metric", QueryCount: 1},
 	}, nil).Once()
 


### PR DESCRIPTION
metrics_usage_summary.is_unused defaulted to TRUE for the placeholder row UpsertMetricsCatalog writes when a metric is first catalogued - before RefreshMetricsUsageSummary has ever had a chance to evaluate it. A metric that has never been evaluated is not the same thing as one confirmed to have zero usage, but both looked identical: all-zero counts, is_unused=TRUE. If RefreshMetricsUsageSummary was slow to run or failing outright for a cluster, every newly-introduced metric stayed marked unused indefinitely and was dropped/hidden accordingly.

This also meant the write path (GetSeriesMetadataByNames, used by the OTLP ingester) and the read path (GetSeriesMetadata's ?usage=unused, which already correctly gated on is_unused=TRUE via an INNER JOIN) were two independently-computed verdicts of "unused" that only agreed by coincidence: the write path never read is_unused at all, instead recomputing it in Go from the same four counts via metricMetadataUnused().

Fix, both backends:
- UpsertMetricsCatalog's placeholder insert now writes is_unused=FALSE ("not yet evaluated", fail toward keep) instead of TRUE.
- GetSeriesMetadataByNames now selects COALESCE(s.is_unused, FALSE) and populates the new models.MetricMetadata.IsUnused field, instead of never reading the column at all.
- metricMetadataUnused() in the ingester now just reads mm.IsUnused instead of recomputing "unused" from the four counts, making is_unused the single source of truth for both paths.

GetSeriesMetadata's read path needs no changes - it already gates on is_unused=TRUE, so it benefits automatically from the corrected default.

Also fixes two collateral issues the behavior change surfaced:
- TestSeriesMetadata_UsageFilter_Route (api/routes) encoded the same bug at the HTTP route level.
- BenchmarkSeriesMetadataUnused_{SQLite,PostgreSQL}_JobScopedScaleUp relied on the placeholder default to seed their "large unused universe" benchmark data; they now run a real RefreshMetricsUsageSummary so the seeded rows are genuinely evaluated as unused instead of accidentally defaulting to it.

Fixes #570
Fixes #571

Change-Id: I4f118b4fe770f61159c6cf42d5a905dc6c9ba2b3