### PR TITLE
fix(inventory): decouple summary-refresh timeout from catalog-sync bu…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect

--- a/internal/inventory/syncer.go
+++ b/internal/inventory/syncer.go
@@ -36,9 +36,10 @@ type Syncer struct {
 
 	jobIndexWorkers int
 
-	syncDuration prometheus.Histogram
-	syncSuccess  prometheus.Counter
-	syncFailure  prometheus.Counter
+	syncDuration           prometheus.Histogram
+	syncSuccess            prometheus.Counter
+	syncFailure            prometheus.Counter
+	catalogSummaryMismatch prometheus.Counter
 }
 
 func NewSyncer(dbp db.Provider, upstream string, cfg *config.Config, reg prometheus.Registerer) (*Syncer, error) {
@@ -82,6 +83,10 @@ func NewSyncer(dbp db.Provider, upstream string, cfg *config.Config, reg prometh
 	s.syncFailure = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "inventory_sync_failure_total",
 		Help: "Total number of failed inventory sync runs",
+	})
+	s.catalogSummaryMismatch = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "inventory_catalog_summary_mismatch_total",
+		Help: "Total number of runs where the metadata catalog was committed but the usage-summary refresh failed, stranding the affected metrics at placeholder values",
 	})
 
 	return s, nil
@@ -134,8 +139,20 @@ func (s *Syncer) runOnce(ctx context.Context) {
 	runCtx, cancel := context.WithTimeout(ctx, s.runTimeout)
 	defer cancel()
 
-	if err := s.syncCatalogAndSummary(runCtx); err != nil {
+	catalogCommitted, err := s.syncCatalogAndSummary(ctx, runCtx)
+	if err != nil {
 		s.syncFailure.Inc()
+		if catalogCommitted {
+			// The metadata catalog step already committed (or was skipped)
+			// this run, so any newly-catalogued metrics now sit at their
+			// default placeholder summary values (is_unused=true, zero
+			// counts) until a future run successfully refreshes them.
+			// Surface this as its own signal so it isn't buried in the
+			// generic failure counter.
+			s.catalogSummaryMismatch.Inc()
+			slog.Warn("inventory: catalog committed but usage-summary refresh failed this run; affected metrics remain at placeholder values until the next scheduled sync",
+				"err", err)
+		}
 		s.syncDuration.Observe(time.Since(start).Seconds())
 		return
 	}
@@ -152,29 +169,45 @@ func (s *Syncer) runOnce(ctx context.Context) {
 	s.syncDuration.Observe(time.Since(start).Seconds())
 }
 
-func (s *Syncer) syncCatalogAndSummary(ctx context.Context) error {
+// syncCatalogAndSummary runs the metadata-catalog sync followed by the
+// usage-summary refresh. It reports whether the catalog step committed (or
+// was intentionally skipped) so the caller can tell an ordinary failure
+// apart from the partial-failure case where the catalog moved forward but
+// the summary refresh didn't.
+//
+// The two steps deliberately do NOT share a single deadline: the catalog
+// step is bounded by runCtx (itself bounded by runTimeout), while the
+// summary step gets its own context.WithTimeout(baseCtx, summaryStepTimeout)
+// built directly from baseCtx. Deriving the summary step's deadline from
+// runCtx instead would let a slow-but-successful catalog step eat into
+// runCtx's remaining budget and hand the refresh less than its configured
+// timeout - or none at all - on every single run, permanently starving it
+// (see #572). Giving the refresh its own independent budget guarantees it
+// always gets a full, fair shot regardless of how long the catalog step
+// took.
+func (s *Syncer) syncCatalogAndSummary(baseCtx, runCtx context.Context) (catalogCommitted bool, err error) {
 	if s.metadataSyncEnabled {
 		if s.metadataMetricsNameOnly {
-			if err := s.syncMetadataCatalogFromMetricNames(ctx); err != nil {
-				return err
+			if err := s.syncMetadataCatalogFromMetricNames(runCtx); err != nil {
+				return false, err
 			}
 		} else {
-			if err := s.syncMetadataCatalog(ctx); err != nil {
-				return err
+			if err := s.syncMetadataCatalog(runCtx); err != nil {
+				return false, err
 			}
 		}
 	} else {
 		slog.Info("inventory: metadata sync disabled, skipping catalog population")
 	}
 
-	sumCtx, cancelSum := context.WithTimeout(ctx, s.summaryStepTimeout)
+	sumCtx, cancelSum := context.WithTimeout(baseCtx, s.summaryStepTimeout)
 	defer cancelSum()
 	tr := db.TimeRange{From: time.Now().UTC().Add(-s.timeWindow), To: time.Now().UTC()}
 	if err := s.dbProvider.RefreshMetricsUsageSummary(sumCtx, tr); err != nil {
 		slog.Error("inventory: refresh summary", "err", err)
-		return err
+		return true, err
 	}
-	return nil
+	return true, nil
 }
 
 func (s *Syncer) syncMetadataCatalog(ctx context.Context) error {

--- a/internal/inventory/syncer_test.go
+++ b/internal/inventory/syncer_test.go
@@ -1,0 +1,205 @@
+package inventory
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeMetadataAPI is a minimal v1.API stand-in. Embedding the (nil) interface
+// means any method we don't override panics if called - fine, since these
+// tests only ever exercise Metadata.
+type fakeMetadataAPI struct {
+	v1.API
+	delay time.Duration
+	meta  map[string][]v1.Metadata
+	err   error
+}
+
+func (f *fakeMetadataAPI) Metadata(ctx context.Context, _ string, _ string) (map[string][]v1.Metadata, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	select {
+	case <-time.After(f.delay):
+		return f.meta, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// fakeInventoryProvider is a minimal db.Provider stand-in that only tracks
+// the two calls the syncer's catalog+summary path makes.
+type fakeInventoryProvider struct {
+	db.Provider
+
+	mu sync.Mutex
+
+	catalogCommits int
+
+	summaryCalls     int
+	summaryWork      time.Duration // how long a real refresh would take
+	summarySucceeded bool
+}
+
+func (f *fakeInventoryProvider) UpsertMetricsCatalog(_ context.Context, _ []db.MetricCatalogItem) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.catalogCommits++
+	return nil
+}
+
+func (f *fakeInventoryProvider) RefreshMetricsUsageSummary(ctx context.Context, _ db.TimeRange) error {
+	f.mu.Lock()
+	f.summaryCalls++
+	f.mu.Unlock()
+
+	select {
+	case <-time.After(f.summaryWork):
+		f.mu.Lock()
+		f.summarySucceeded = true
+		f.mu.Unlock()
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func newCounter() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{Name: "test_counter"})
+}
+
+func newHistogram() prometheus.Histogram {
+	return prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_histogram"})
+}
+
+// TestSyncer_SlowMetadataStepDoesNotPermanentlyStarveSummaryRefresh reproduces
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/572: the
+// metadata-catalog step and the usage-summary refresh share a single
+// run-timeout budget. A metadata step that (legitimately, within its own
+// per-step timeout) takes long enough leaves the summary step less time than
+// its own configured summaryStepTimeout - or none at all - every single run,
+// so the newly-catalogued metrics never get their placeholder summary rows
+// refreshed with real usage data. This is a deterministic race, not a flaky
+// one: the same shortfall recurs on every run, so nothing about "just retry
+// on the next scheduled sync" fixes it.
+func TestSyncer_SlowMetadataStepDoesNotPermanentlyStarveSummaryRefresh(t *testing.T) {
+	provider := &fakeInventoryProvider{
+		summaryWork: 40 * time.Millisecond,
+	}
+	api := &fakeMetadataAPI{
+		delay: 60 * time.Millisecond,
+		meta:  map[string][]v1.Metadata{"up": {{Type: "gauge", Help: "up metric"}}},
+	}
+
+	s := &Syncer{
+		dbProvider:              provider,
+		promAPI:                 api,
+		timeWindow:              time.Hour,
+		metadataSyncEnabled:     true,
+		metadataMetricsNameOnly: false,
+		runTimeout:              80 * time.Millisecond, // shared budget: barely more than the metadata step alone needs
+		metadataStepTimeout:     time.Second,           // generous on its own; runTimeout is the real limiter
+		summaryStepTimeout:      50 * time.Millisecond, // > summaryWork, so summary should always have enough time of its own
+		syncDuration:            newHistogram(),
+		syncSuccess:             newCounter(),
+		syncFailure:             newCounter(),
+		catalogSummaryMismatch:  newCounter(),
+	}
+
+	// Run twice: a fix must not merely get lucky once, it must hold up on
+	// every run since the metadata step's duration here is fixed and always
+	// eats the same share of any shared budget.
+	for i := 0; i < 2; i++ {
+		provider.mu.Lock()
+		provider.summarySucceeded = false
+		provider.mu.Unlock()
+
+		s.runOnce(context.Background())
+
+		provider.mu.Lock()
+		commits, calls, succeeded := provider.catalogCommits, provider.summaryCalls, provider.summarySucceeded
+		provider.mu.Unlock()
+
+		assert.Equalf(t, i+1, commits, "run %d: metadata catalog step should have committed", i+1)
+		assert.Equalf(t, i+1, calls, "run %d: summary refresh should have been attempted", i+1)
+		assert.Truef(t, succeeded,
+			"run %d: usage-summary refresh should complete within its own summaryStepTimeout "+
+				"(%s) even though the metadata step already used most of the shared run timeout "+
+				"(%s); otherwise newly-catalogued metrics are permanently stranded at placeholder "+
+				"values", i+1, s.summaryStepTimeout, s.runTimeout)
+	}
+}
+
+// TestSyncer_SummaryFailureAfterCatalogCommitEmitsMismatchMetric asserts the
+// partial-failure case from the acceptance criteria is distinguishable: when
+// the catalog step commits but the summary refresh still fails (e.g. the DB
+// itself is unavailable, independent of any timeout budget), that's reported
+// via the dedicated catalogSummaryMismatch counter and a distinct log line,
+// not folded into the generic failure counter alone.
+func TestSyncer_SummaryFailureAfterCatalogCommitEmitsMismatchMetric(t *testing.T) {
+	provider := &fakeInventoryProvider{
+		summaryWork: time.Hour, // never completes within the step timeout
+	}
+	api := &fakeMetadataAPI{meta: map[string][]v1.Metadata{"up": {{Type: "gauge", Help: "up metric"}}}}
+
+	s := &Syncer{
+		dbProvider:             provider,
+		promAPI:                api,
+		timeWindow:             time.Hour,
+		metadataSyncEnabled:    true,
+		runTimeout:             time.Second,
+		metadataStepTimeout:    time.Second,
+		summaryStepTimeout:     10 * time.Millisecond,
+		syncDuration:           newHistogram(),
+		syncSuccess:            newCounter(),
+		syncFailure:            newCounter(),
+		catalogSummaryMismatch: newCounter(),
+	}
+
+	s.runOnce(context.Background())
+
+	assert.Equal(t, 1, provider.catalogCommits, "catalog step should have committed")
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.syncFailure), "generic failure counter should still increment")
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.catalogSummaryMismatch),
+		"catalog-committed-but-summary-failed should be counted separately from the generic failure")
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.syncSuccess))
+}
+
+// TestSyncer_MetadataFailureDoesNotEmitMismatchMetric asserts an ordinary
+// metadata-step failure (nothing committed) is NOT misreported as the
+// catalog/summary partial-failure case.
+func TestSyncer_MetadataFailureDoesNotEmitMismatchMetric(t *testing.T) {
+	provider := &fakeInventoryProvider{}
+	api := &fakeMetadataAPI{err: errors.New("upstream unavailable")}
+
+	s := &Syncer{
+		dbProvider:             provider,
+		promAPI:                api,
+		timeWindow:             time.Hour,
+		metadataSyncEnabled:    true,
+		runTimeout:             time.Second,
+		metadataStepTimeout:    time.Second,
+		summaryStepTimeout:     time.Second,
+		syncDuration:           newHistogram(),
+		syncSuccess:            newCounter(),
+		syncFailure:            newCounter(),
+		catalogSummaryMismatch: newCounter(),
+	}
+
+	s.runOnce(context.Background())
+
+	assert.Equal(t, 0, provider.catalogCommits, "catalog step should not have committed")
+	assert.Equal(t, 0, provider.summaryCalls, "summary refresh should not even be attempted")
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.syncFailure))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.catalogSummaryMismatch),
+		"a plain metadata-step failure is not the catalog/summary partial-failure case")
+}


### PR DESCRIPTION
…dget

Syncer.runOnce() ran the metadata-catalog sync and the usage-summary refresh under a single shared run timeout. context.WithTimeout caps at the parent's deadline, so a metadata step that legitimately consumed most of runTimeout silently truncated the summary step's budget below its own configured summaryStepTimeout - deterministically, on every run, not just occasionally. Catalog rows committed that same run were then permanently stranded at their placeholder (is_unused=true, zero-count) values.

syncCatalogAndSummary now builds the summary step's context directly from the original run() context instead of the runTimeout-bound runCtx, guaranteeing it always gets its full configured timeout regardless of how long the catalog step took. It also now reports whether the catalog step committed, so a plain metadata failure can be told apart from the partial-failure case (catalog committed, summary refresh still failed) - the latter now increments a dedicated inventory_catalog_summary_mismatch_total counter and logs distinctly, instead of disappearing into the generic failure counter.

Fixes #572

Change-Id: I21a27d9f944a59dc571100d847b3de5e325628ab