### PR TITLE
perf(inventory): bound RefreshMetricsUsageSummary to actively-synced metrics

### DIFF
--- a/internal/db/common.go
+++ b/internal/db/common.go
@@ -150,6 +150,29 @@ func PrepareTimeRange(tr TimeRange, dialect string) (string, string) {
 	return tr.Format(SQLiteTimeFormat)
 }
 
+// warnIfSummaryRefreshWasNoOp logs when RefreshMetricsUsageSummary's INSERT
+// touched zero rows while metrics_catalog is non-empty. That combination
+// means every catalog row failed the last_synced_at freshness filter (see
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/579) - most
+// likely metadata sync has stopped advancing last_synced_at (disabled, or a
+// seen_ttl raised above inventory.time_window) - which otherwise surfaces as
+// a silently frozen summary with no error, the same failure class that issue
+// was about.
+func warnIfSummaryRefreshWasNoOp(ctx context.Context, db *sql.DB, rowsAffected int64, dialect string) {
+	if rowsAffected > 0 {
+		return
+	}
+	var catalogNonEmpty bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM metrics_catalog)`).Scan(&catalogNonEmpty); err != nil {
+		return // best-effort diagnostic; don't fail the refresh over it
+	}
+	if catalogNonEmpty {
+		slog.Warn("inventory: refresh summary touched no rows despite a non-empty catalog; "+
+			"every row failed the last_synced_at freshness filter - check that metadata sync is advancing last_synced_at",
+			"dialect", dialect)
+	}
+}
+
 // GetInterval returns the appropriate interval string for time-based queries
 func GetInterval(from, to time.Time, dialect string) string {
 	duration := to.Sub(from)

--- a/internal/db/migrations/postgresql/0014_metrics_catalog_last_synced_at_index.sql
+++ b/internal/db/migrations/postgresql/0014_metrics_catalog_last_synced_at_index.sql
@@ -1,0 +1,20 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Covering index backing RefreshMetricsUsageSummary's "only recompute
+-- actively-synced metrics" filter. The query filters metrics_catalog on
+-- last_synced_at and only ever needs name from that table (for the join to
+-- RulesUsage/DashboardUsage/queries), so name rides along via INCLUDE
+-- rather than as a full key column - it doesn't need to participate in
+-- ordering or uniqueness, just be present at the leaf level so the planner
+-- can satisfy the scan as an index-only scan. See
+-- https://github.com/nicolastakashi/prom-analytics-proxy/issues/579.
+--
+-- CREATE INDEX CONCURRENTLY (hence the disabled goose transaction, and no
+-- in-line ANALYZE - see migration 0013's note on the RowExclusiveLock vs
+-- ShareUpdateExclusiveLock deadlock this avoids) so the build does not
+-- block writes from the inventory syncer while it runs.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metrics_catalog_last_synced_at
+    ON metrics_catalog (last_synced_at) INCLUDE (name);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_metrics_catalog_last_synced_at;

--- a/internal/db/migrations/sqlite/0009_metrics_catalog_last_synced_at_index.sql
+++ b/internal/db/migrations/sqlite/0009_metrics_catalog_last_synced_at_index.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- Covering index backing RefreshMetricsUsageSummary's "only recompute
+-- actively-synced metrics" filter: the query filters on last_synced_at but
+-- only ever needs name from metrics_catalog, so name rides along as a
+-- second key column (SQLite has no INCLUDE clause) to let the planner
+-- satisfy the scan straight from the index. See
+-- https://github.com/nicolastakashi/prom-analytics-proxy/issues/579.
+CREATE INDEX IF NOT EXISTS idx_metrics_catalog_last_synced_at
+    ON metrics_catalog(last_synced_at, name);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_metrics_catalog_last_synced_at;

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -1078,9 +1078,14 @@ func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []M
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
+	// last_synced_at is stored as TIMESTAMP WITHOUT TIME ZONE, so a bare NOW()
+	// lands in the server session's time zone while RefreshMetricsUsageSummary
+	// compares it against tr.From.UTC() (see PrepareTimeRange). AT TIME ZONE
+	// 'UTC' pins the written value to UTC so the two stay in the same clock
+	// domain regardless of session TimeZone.
 	stmt, err := tx.PrepareContext(ctx, `
         INSERT INTO metrics_catalog(name, type, help, unit, last_synced_at)
-        VALUES ($1, $2, $3, $4, NOW())
+        VALUES ($1, $2, $3, $4, NOW() AT TIME ZONE 'UTC')
         ON CONFLICT(name) DO UPDATE SET
           type=EXCLUDED.type,
           help=EXCLUDED.help,
@@ -1134,9 +1139,10 @@ func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []M
 	return nil
 }
 
-func (p *PostGreSQLProvider) RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error {
-	from, to := PrepareTimeRange(tr, "postgresql")
-	query := `
+// refreshMetricsUsageSummaryQueryPostgreSQL is kept as a package-level const
+// so a test can assert on the exact statement RefreshMetricsUsageSummary
+// runs without risking drift between a duplicated copy and the real query.
+const refreshMetricsUsageSummaryQueryPostgreSQL = `
     INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, last_queried_at, updated_at, is_unused)
     SELECT c.name,
            COALESCE(ra.alert_count, 0),
@@ -1173,6 +1179,14 @@ func (p *PostGreSQLProvider) RefreshMetricsUsageSummary(ctx context.Context, tr 
         WHERE ts BETWEEN $1 AND $2
         GROUP BY 1
     ) qa USING(name)
+    -- Only recompute catalog rows Prometheus has actually reconfirmed
+    -- within the window: this bounds the scan to actively-synced metrics
+    -- instead of every name ever seen, however long ago. See
+    -- https://github.com/nicolastakashi/prom-analytics-proxy/issues/579.
+    -- Rows that age out simply keep whatever summary they last had. Reuses
+    -- $1 rather than adding a new bind param, since it's the same lower
+    -- bound already used above.
+    WHERE c.last_synced_at >= $1
     ON CONFLICT(name) DO UPDATE SET
         alert_count=EXCLUDED.alert_count,
         record_count=EXCLUDED.record_count,
@@ -1182,9 +1196,15 @@ func (p *PostGreSQLProvider) RefreshMetricsUsageSummary(ctx context.Context, tr 
         updated_at=EXCLUDED.updated_at,
         is_unused=EXCLUDED.is_unused;
     `
-	_, err := p.db.ExecContext(ctx, query, from, to)
+
+func (p *PostGreSQLProvider) RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error {
+	from, to := PrepareTimeRange(tr, "postgresql")
+	res, err := p.db.ExecContext(ctx, refreshMetricsUsageSummaryQueryPostgreSQL, from, to)
 	if err != nil {
 		return fmt.Errorf("refresh summary: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		warnIfSummaryRefreshWasNoOp(ctx, p.db, n, "postgresql")
 	}
 	return nil
 }

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -442,6 +444,128 @@ func TestPostgreSQL_RefreshMetricsUsageSummary_And_GetSeriesMetadata(t *testing.
 	})
 	assert.NoError(t, err, "GetSeriesMetadata")
 	assert.Greater(t, res.Total, 0)
+}
+
+// TestPostgreSQL_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows is the
+// PostgreSQL counterpart of TestSQLite_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows:
+// see there for the full rationale.
+func TestPostgreSQL_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "fresh_metric", Type: "gauge", Help: "still scraped"},
+		{Name: "stale_metric", Type: "gauge", Help: "no longer scraped"},
+	})
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	_, err := rawDB.ExecContext(context.Background(),
+		`UPDATE metrics_catalog SET last_synced_at = NOW() - INTERVAL '90 days' WHERE name = $1`, "stale_metric")
+	assert.NoError(t, err, "backdate stale_metric")
+
+	now := time.Now().UTC()
+	mustInsertQueries(t, p, []Query{
+		{
+			TS: now.Add(-time.Minute), QueryParam: "fresh_metric", TimeParam: now,
+			Duration: time.Millisecond, StatusCode: 200,
+			LabelMatchers: LabelMatchers{{"__name__": "fresh_metric"}}, Type: QueryTypeInstant,
+		},
+		{
+			TS: now.Add(-time.Minute), QueryParam: "stale_metric", TimeParam: now,
+			Duration: time.Millisecond, StatusCode: 200,
+			LabelMatchers: LabelMatchers{{"__name__": "stale_metric"}}, Type: QueryTypeInstant,
+		},
+	})
+
+	err = p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-time.Hour), To: now})
+	assert.NoError(t, err, "RefreshMetricsUsageSummary")
+
+	// Select all four counts, not just query_count: is_unused is derived
+	// from all of them, so asserting on the whole row is what actually
+	// tells us WHICH count is off if this ever fails again, instead of
+	// leaving is_unused's false/true a mystery relative to a single count.
+	var fresh summaryRow
+	row := rawDB.QueryRowContext(context.Background(),
+		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = $1`, "fresh_metric")
+	require.NoError(t, row.Scan(&fresh.Alert, &fresh.Record, &fresh.Dashboard, &fresh.Query, &fresh.Unused))
+	assert.Greater(t, fresh.Query, 0, "fresh_metric should have been recomputed with real usage")
+	assert.False(t, fresh.Unused, "fresh_metric should be marked used")
+
+	var stale summaryRow
+	row = rawDB.QueryRowContext(context.Background(),
+		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = $1`, "stale_metric")
+	require.NoError(t, row.Scan(&stale.Alert, &stale.Record, &stale.Dashboard, &stale.Query, &stale.Unused))
+	assert.Equal(t, summaryRow{Alert: 0, Record: 0, Dashboard: 0, Query: 0, Unused: false}, stale,
+		"stale_metric's summary should remain untouched at its placeholder values - got %+v", stale)
+}
+
+// TestPostgreSQL_UpsertMetricsCatalog_LastSyncedAtIsUTC guards last_synced_at
+// staying in the same clock domain as the $1 bound RefreshMetricsUsageSummary
+// compares it against (tr.From.UTC(), via PrepareTimeRange): last_synced_at is
+// TIMESTAMP WITHOUT TIME ZONE, so a bare NOW() lands in the writing session's
+// TimeZone instead of UTC, silently turning the freshness filter into a
+// permanent no-op on any server whose TimeZone isn't UTC. This container's own
+// session already defaults to TimeZone=UTC - which would let the bug pass
+// vacuously - so the database default is pinned to a fixed, DST-free non-UTC
+// offset before the provider (and its connection pool) ever connects.
+func TestPostgreSQL_UpsertMetricsCatalog_LastSyncedAtIsUTC(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := postgres.Run(ctx, "postgres:16",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("Skipping PostgreSQL container tests (Docker not available): %v", err)
+	}
+	defer func() { _ = pgContainer.Terminate(ctx) }()
+
+	host, err := pgContainer.Host(ctx)
+	require.NoError(t, err, "container host")
+	port, err := pgContainer.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err, "container port")
+	portNum, err := strconv.Atoi(port.Port())
+	require.NoError(t, err, "container port number")
+
+	bootstrapDSN := fmt.Sprintf(
+		"host='%s' port=%d user='testuser' password='testpass' dbname='testdb' sslmode='disable'",
+		host, portNum,
+	)
+	bootstrap, err := sql.Open("postgres", bootstrapDSN)
+	require.NoError(t, err, "open bootstrap connection")
+	_, err = bootstrap.ExecContext(ctx, `ALTER DATABASE testdb SET TIME ZONE 'Etc/GMT+5'`)
+	require.NoError(t, err, "pin database default TimeZone to a fixed non-UTC offset")
+	require.NoError(t, bootstrap.Close())
+
+	p, err := NewPostgreSQLProvider(ctx, config.PostgreSQLConfig{
+		Addr:        host,
+		Port:        portNum,
+		User:        "testuser",
+		Password:    "testpass",
+		Database:    "testdb",
+		SSLMode:     "disable",
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err, "failed to init postgres provider")
+	defer func() { _ = p.Close() }()
+
+	require.NoError(t, p.UpsertMetricsCatalog(ctx, []MetricCatalogItem{{Name: "tz_metric", Type: "gauge", Help: "h"}}))
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	var lastSynced time.Time
+	row := rawDB.QueryRowContext(ctx, `SELECT last_synced_at FROM metrics_catalog WHERE name = $1`, "tz_metric")
+	require.NoError(t, row.Scan(&lastSynced), "scan last_synced_at")
+
+	assert.WithinDuration(t, time.Now().UTC(), lastSynced, 10*time.Second,
+		"last_synced_at must be written in UTC regardless of the writing session's TimeZone (pinned to Etc/GMT+5 here); "+
+			"a bare NOW() would drift by the session's offset instead")
 }
 
 func TestPostgreSQL_GetMetricStatistics_And_QueryPerformanceStats(t *testing.T) {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -1185,9 +1185,10 @@ func (p *SQLiteProvider) ListJobs(ctx context.Context) ([]string, error) {
 	return jobs, nil
 }
 
-func (p *SQLiteProvider) RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error {
-	from, to := PrepareTimeRange(tr, "sqlite")
-	query := `
+// refreshMetricsUsageSummaryQuerySQLite is kept as a package-level const so
+// a test can assert on the exact statement RefreshMetricsUsageSummary runs
+// without risking drift between a duplicated copy and the real query.
+const refreshMetricsUsageSummaryQuerySQLite = `
     INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, last_queried_at, updated_at, is_unused)
     SELECT c.name,
            COALESCE(ra.alert_count, 0),
@@ -1224,6 +1225,12 @@ func (p *SQLiteProvider) RefreshMetricsUsageSummary(ctx context.Context, tr Time
         WHERE ts BETWEEN ? AND ?
         GROUP BY name
     ) qa USING(name)
+    -- Only recompute catalog rows Prometheus has actually reconfirmed
+    -- within the window: this bounds the scan to actively-synced metrics
+    -- instead of every name ever seen, however long ago. See
+    -- https://github.com/nicolastakashi/prom-analytics-proxy/issues/579.
+    -- Rows that age out simply keep whatever summary they last had.
+    WHERE c.last_synced_at >= ?
     ON CONFLICT(name) DO UPDATE SET
         alert_count=excluded.alert_count,
         record_count=excluded.record_count,
@@ -1233,9 +1240,15 @@ func (p *SQLiteProvider) RefreshMetricsUsageSummary(ctx context.Context, tr Time
         updated_at=excluded.updated_at,
         is_unused=excluded.is_unused;
     `
-	_, err := p.db.ExecContext(ctx, query, to, from, to, from, from, to)
+
+func (p *SQLiteProvider) RefreshMetricsUsageSummary(ctx context.Context, tr TimeRange) error {
+	from, to := PrepareTimeRange(tr, "sqlite")
+	res, err := p.db.ExecContext(ctx, refreshMetricsUsageSummaryQuerySQLite, to, from, to, from, from, to, from)
 	if err != nil {
 		return fmt.Errorf("refresh summary: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		warnIfSummaryRefreshWasNoOp(ctx, p.db, n, "sqlite")
 	}
 	return nil
 }

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"log/slog"
 	"os"
 	"sort"
 	"testing"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestSQLiteProvider creates a temporary SQLite database and returns a provider and cleanup.
@@ -448,6 +451,136 @@ func TestSQLite_RefreshMetricsUsageSummary_And_GetSeriesMetadata(t *testing.T) {
 	if data, ok := res.Data.([]models.MetricMetadata); ok {
 		_ = data // basic smoke to ensure type is correct for future checks
 	}
+}
+
+// TestSQLite_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows is the
+// regression test for
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/579: a
+// catalog row Prometheus stopped reporting long ago (last_synced_at far in
+// the past) must not be recomputed on every refresh just because some usage
+// evidence happens to fall inside the window - it should be skipped
+// entirely, keeping whatever summary it last had (here, its placeholder
+// zero-count row from UpsertMetricsCatalog, is_unused=false per
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570:
+// "never evaluated" is distinct from "confirmed unused").
+func TestSQLite_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "fresh_metric", Type: "gauge", Help: "still scraped"},
+		{Name: "stale_metric", Type: "gauge", Help: "no longer scraped"},
+	})
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	// Backdate stale_metric well outside any window the refresh below uses,
+	// simulating a metric Prometheus stopped reporting long ago.
+	_, err := rawDB.ExecContext(context.Background(),
+		`UPDATE metrics_catalog SET last_synced_at = datetime('now', '-90 days') WHERE name = ?`, "stale_metric")
+	assert.NoError(t, err, "backdate stale_metric")
+
+	now := time.Now().UTC()
+	// Usage evidence for BOTH metrics, inside the refresh window below - if
+	// the catalog-freshness filter didn't exist, both would come out used.
+	mustInsertQueries(t, p, []Query{
+		{
+			TS: now.Add(-time.Minute), QueryParam: "fresh_metric", TimeParam: now,
+			Duration: time.Millisecond, StatusCode: 200,
+			LabelMatchers: LabelMatchers{{"__name__": "fresh_metric"}}, Type: QueryTypeInstant,
+		},
+		{
+			TS: now.Add(-time.Minute), QueryParam: "stale_metric", TimeParam: now,
+			Duration: time.Millisecond, StatusCode: 200,
+			LabelMatchers: LabelMatchers{{"__name__": "stale_metric"}}, Type: QueryTypeInstant,
+		},
+	})
+
+	err = p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-time.Hour), To: now})
+	assert.NoError(t, err, "RefreshMetricsUsageSummary")
+
+	// Select all four counts, not just query_count: is_unused is derived
+	// from all of them, so asserting on the whole row is what actually
+	// tells us WHICH count is off if this ever fails again, instead of
+	// leaving is_unused's false/true a mystery relative to a single count.
+	var fresh summaryRow
+	row := rawDB.QueryRowContext(context.Background(),
+		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = ?`, "fresh_metric")
+	require.NoError(t, row.Scan(&fresh.Alert, &fresh.Record, &fresh.Dashboard, &fresh.Query, &fresh.Unused))
+	assert.Greater(t, fresh.Query, 0, "fresh_metric should have been recomputed with real usage")
+	assert.False(t, fresh.Unused, "fresh_metric should be marked used")
+
+	var stale summaryRow
+	row = rawDB.QueryRowContext(context.Background(),
+		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = ?`, "stale_metric")
+	require.NoError(t, row.Scan(&stale.Alert, &stale.Record, &stale.Dashboard, &stale.Query, &stale.Unused))
+	assert.Equal(t, summaryRow{Alert: 0, Record: 0, Dashboard: 0, Query: 0, Unused: false}, stale,
+		"stale_metric's summary should remain untouched at its placeholder values - got %+v", stale)
+}
+
+// TestSQLite_RefreshMetricsUsageSummary_WarnsWhenAllRowsAreStale guards a
+// suggestion adjacent to
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/579: when
+// every metrics_catalog row fails the freshness filter, the refresh's
+// INSERT touches zero rows and returns no error - indistinguishable,
+// without a log line, from "ran fine, nothing needed recomputing".
+// warnIfSummaryRefreshWasNoOp surfaces that combination so metadata-sync
+// stalling doesn't freeze summaries silently.
+func TestSQLite_RefreshMetricsUsageSummary_WarnsWhenAllRowsAreStale(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{{Name: "stale_metric", Type: "gauge", Help: "gone"}})
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+	_, err := rawDB.ExecContext(context.Background(),
+		`UPDATE metrics_catalog SET last_synced_at = datetime('now', '-90 days') WHERE name = ?`, "stale_metric")
+	assert.NoError(t, err, "backdate stale_metric")
+
+	var logs bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	defer slog.SetDefault(prevLogger)
+
+	now := time.Now().UTC()
+	err = p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-time.Hour), To: now})
+	assert.NoError(t, err, "RefreshMetricsUsageSummary")
+
+	assert.Contains(t, logs.String(), "refresh summary touched no rows",
+		"expected a warning when the freshness filter matches zero rows against a non-empty catalog")
+}
+
+// TestSQLite_RefreshMetricsUsageSummary_NoWarnOnEmptyCatalog is the
+// zero-rows counterpart of TestSQLite_RefreshMetricsUsageSummary_WarnsWhenAllRowsAreStale:
+// an empty metrics_catalog also touches zero rows, but that's the ordinary
+// steady state of a fresh deployment, not a stalled sync - it must not log
+// the same warning.
+func TestSQLite_RefreshMetricsUsageSummary_NoWarnOnEmptyCatalog(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	var logs bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	defer slog.SetDefault(prevLogger)
+
+	now := time.Now().UTC()
+	err := p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-time.Hour), To: now})
+	assert.NoError(t, err, "RefreshMetricsUsageSummary")
+
+	assert.NotContains(t, logs.String(), "refresh summary touched no rows",
+		"an empty catalog is the normal steady state and must not be logged as a stalled sync")
+}
+
+// summaryRow mirrors the four counts + is_unused columns of
+// metrics_usage_summary, so a stale-vs-fresh diagnostic assertion can compare
+// (and print, on failure) the whole row at once instead of one column at a
+// time - useful since is_unused is derived from all four counts together.
+type summaryRow struct {
+	Alert, Record, Dashboard, Query int
+	Unused                          bool
 }
 
 func TestSQLite_GetMetricStatistics_And_QueryPerformanceStats(t *testing.T) {


### PR DESCRIPTION
RefreshMetricsUsageSummary recomputed usage counts and is_unused for every row in metrics_catalog on every run, unconditionally. Catalog rows are never deleted (UpsertMetricsCatalog only ever inserts/updates), so a metric Prometheus stopped reporting - service decommissioned, metric renamed, scrape target removed - just sits there getting a full LEFT JOIN lookup and recomputation forever. Cost was O(|metrics_catalog|) regardless of how many of those metrics were still alive upstream, with no ceiling as the catalog accumulates churn over the life of a deployment.

Both RefreshMetricsUsageSummary implementations now filter the outer FROM metrics_catalog on last_synced_at >= the same lower bound already used for the joined usage-evidence subqueries. Actively-synced metrics get last_synced_at bumped every sync run, so this is a no-op for anything still alive; it only skips rows that haven't been reconfirmed in a full TimeWindow, which already sit at their correct terminal state (nothing recent references them) and don't need recomputing.

Added a covering index in both backends so the new filter is a range scan rather than a full-table scan: last_synced_at itself was previously unindexed. Postgres gets last_synced_at with an INCLUDE(name) payload column via CREATE INDEX CONCURRENTLY (following the same NO TRANSACTION pattern and locking rationale as migration 0013); SQLite gets a plain composite (last_synced_at, name) index, since it has no CONCURRENTLY/INCLUDE equivalent.

The SQL is now a package-level const in each provider, so it can't drift out of sync with a duplicated test copy.

Fixed a clock-domain bug the new filter exposed: last_synced_at is TIMESTAMP WITHOUT TIME ZONE, and UpsertMetricsCatalog wrote it via a bare NOW(), which lands in the server session's time zone. RefreshMetricsUsageSummary compares it against tr.From.UTC(). On a server whose TimeZone isn't UTC, every catalog row would silently fail the new filter and the refresh would become a permanent no-op - no error, no log. UpsertMetricsCatalog now writes NOW() AT TIME ZONE 'UTC' so both sides of the comparison stay in the same clock domain regardless of session TimeZone.

Also added a log line for the case where the freshness filter matches zero rows against a non-empty catalog - e.g. metadata sync disabled or its seen_ttl raised above inventory.time_window - so that failure mode surfaces as a warning instead of a summary that's silently frozen forever with no error surface.

Tests:
- Both backends: seed a fresh and a stale catalog row, both with matching usage evidence inside the refresh window; assert only the fresh row gets recomputed, the stale row keeps its untouched placeholder summary.
- PostgreSQL: pin a session to a fixed, DST-free non-UTC offset before the provider ever connects (the container's own session already defaults to UTC, which would let the clock-domain bug pass vacuously) and assert UpsertMetricsCatalog's write lands within seconds of true UTC now. Verified this fails with the exact ~5h drift when the fix is reverted.
- SQLite: assert the zero-rows-affected warning fires when every catalog row is stale, and does not fire when the catalog is simply empty (the ordinary steady state of a fresh deployment) - the warning should flag a stalled sync, not every idle refresh.

Addresses #579

Change-Id: If0db837a391b404f01804b6080a9136043c0c399
