### PR TITLE
test(ingester): fix stale mock in partial-chunk-failure OTLP test

### DIFF
--- a/internal/ingester/otlp_ingester_test.go
+++ b/internal/ingester/otlp_ingester_test.go
@@ -296,9 +296,12 @@ func TestExport_DBError_PartialChunkFailure_StillDropsResolvedUnused(t *testing.
 		buildGaugeMetric("unresolved_metric", 1),
 	)
 
-	// One chunk resolves cleanly and confirms the metric is unused.
+	// One chunk resolves cleanly and confirms the metric is unused. IsUnused
+	// is the field metricMetadataUnused actually checks (see its doc comment
+	// on models.MetricMetadata) - zero counts alone no longer mean unused,
+	// since they're also what an unevaluated metric looks like.
 	mp.On("GetSeriesMetadataByNames", mock.Anything, []string{"resolved_unused_metric"}, "").Return([]models.MetricMetadata{
-		{Name: "resolved_unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0},
+		{Name: "resolved_unused_metric", AlertCount: 0, RecordCount: 0, DashboardCount: 0, QueryCount: 0, IsUnused: true},
 	}, nil).Maybe()
 	// The other chunk's DB lookup fails.
 	mp.On("GetSeriesMetadataByNames", mock.Anything, []string{"unresolved_metric"}, "").Return(nil, assert.AnError).Maybe()


### PR DESCRIPTION
TestExport_DBError_PartialChunkFailure_StillDropsResolvedUnused mocked its DB response the pre-#570/#571 way - zero AlertCount/RecordCount/ DashboardCount/QueryCount, no IsUnused - to represent a metric confirmed unused. But metricMetadataUnused() no longer infers "unused" from zero counts; it checks mm.IsUnused directly (models.MetricMetadata's doc comment: zero counts are also what an unevaluated metric looks like before its first RefreshMetricsUsageSummary run, so they can't be used as a proxy). The mock's IsUnused defaulted to false, so the "resolved_unused_metric" the test expected to be dropped was kept instead - not a bug in the ingester, just a fixture this test's own comments say should represent a confirmed-unused result but didn't.

Every other MetricMetadata{...} fixture in this file already sets IsUnused explicitly; this was the one spot #570/#571 missed updating. Confirmed no other fixture in the repo has the same gap.

Change-Id: I1ff354948a8f0ca84c46e4315a84ae59d8c878c1