### PR TITLE
db: prevent deadlock in concurrent InsertRulesUsage upserts

### DIFF
--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -1242,6 +1242,22 @@ func (p *PostGreSQLProvider) UpsertMetricsJobIndex(ctx context.Context, items []
 	if len(items) == 0 {
 		return nil
 	}
+	// Sort by (name, job) before upserting, so this function stays safe
+	// under concurrent calls with overlapping rows in any order - the same
+	// deadlock precondition as #592. Unlike UpsertMetricsCatalog, no
+	// de-duplication is needed: the per-row loop stays as-is, so a
+	// repeated (name, job) pair within one call is just two separate
+	// statements, not the single-statement "ON CONFLICT DO UPDATE command
+	// cannot affect row a second time" case that requires it there.
+	sorted := make([]MetricJobIndexItem, len(items))
+	copy(sorted, items)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Name != sorted[j].Name {
+			return sorted[i].Name < sorted[j].Name
+		}
+		return sorted[i].Job < sorted[j].Job
+	})
+
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -1257,7 +1273,7 @@ func (p *PostGreSQLProvider) UpsertMetricsJobIndex(ctx context.Context, items []
 		return fmt.Errorf("prepare: %w", err)
 	}
 	defer CloseResource(stmt)
-	for _, it := range items {
+	for _, it := range sorted {
 		if _, err := stmt.ExecContext(ctx, it.Name, it.Job); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("exec: %w", err)

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -1070,41 +1070,75 @@ func (p *PostGreSQLProvider) GetSeriesMetadataByNames(ctx context.Context, names
 	return out, nil
 }
 
+// upsertMetricsCatalogItems de-duplicates items by name (last occurrence
+// wins) and sorts the result by name. Both are required for
+// UpsertMetricsCatalog to stay safe under concurrent calls with
+// overlapping items, in any relative order or interleaving:
+//
+//   - Sorting guarantees every call, however many run concurrently,
+//     always acquires metrics_catalog row locks in the same order. Two
+//     concurrent calls upserting overlapping rows in different orders is
+//     Postgres's own documented deadlock precondition (#592).
+//   - De-duplication is required independently: a single bulk
+//     INSERT ... ON CONFLICT DO UPDATE statement errors ("ON CONFLICT DO
+//     UPDATE command cannot affect row a second time") if its own input
+//     contains the same conflict target twice.
+func upsertMetricsCatalogItems(items []MetricCatalogItem) []MetricCatalogItem {
+	deduped := make(map[string]MetricCatalogItem, len(items))
+	for _, it := range items {
+		deduped[it.Name] = it
+	}
+	sorted := make([]MetricCatalogItem, 0, len(deduped))
+	for _, it := range deduped {
+		sorted = append(sorted, it)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	return sorted
+}
+
 func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []MetricCatalogItem) error {
 	if len(items) == 0 {
 		return nil
 	}
+	items = upsertMetricsCatalogItems(items)
+
+	names := make([]string, len(items))
+	types := make([]string, len(items))
+	helps := make([]string, len(items))
+	units := make([]string, len(items))
+	for i, it := range items {
+		names[i] = it.Name
+		types[i] = it.Type
+		helps[i] = it.Help
+		units[i] = it.Unit
+	}
+
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
+
+	// Both statements below run as one bulk INSERT via unnest() rather than
+	// one round-trip per item - the syncer calls this with the full catalog
+	// inventory (~tens of thousands of rows on a real Prometheus).
+	//
 	// last_synced_at is stored as TIMESTAMP WITHOUT TIME ZONE, so a bare NOW()
 	// lands in the server session's time zone while RefreshMetricsUsageSummary
 	// compares it against tr.From.UTC() (see PrepareTimeRange). AT TIME ZONE
 	// 'UTC' pins the written value to UTC so the two stay in the same clock
 	// domain regardless of session TimeZone.
-	stmt, err := tx.PrepareContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
         INSERT INTO metrics_catalog(name, type, help, unit, last_synced_at)
-        VALUES ($1, $2, $3, $4, NOW() AT TIME ZONE 'UTC')
+        SELECT n, t, h, u, NOW() AT TIME ZONE 'UTC'
+        FROM unnest($1::text[], $2::text[], $3::text[], $4::text[]) AS x(n, t, h, u)
         ON CONFLICT(name) DO UPDATE SET
           type=EXCLUDED.type,
           help=EXCLUDED.help,
           unit=EXCLUDED.unit,
           last_synced_at=EXCLUDED.last_synced_at
-    `)
-	if err != nil {
+    `, pq.Array(names), pq.Array(types), pq.Array(helps), pq.Array(units)); err != nil {
 		_ = tx.Rollback()
-		return fmt.Errorf("prepare: %w", err)
-	}
-	defer CloseResource(stmt)
-
-	names := make([]string, len(items))
-	for i, it := range items {
-		if _, err := stmt.ExecContext(ctx, it.Name, it.Type, it.Help, it.Unit); err != nil {
-			_ = tx.Rollback()
-			return fmt.Errorf("exec: %w", err)
-		}
-		names[i] = it.Name
+		return fmt.Errorf("exec: %w", err)
 	}
 
 	// Co-write a placeholder summary row per catalog item so the
@@ -1119,11 +1153,6 @@ func (p *PostGreSQLProvider) UpsertMetricsCatalog(ctx context.Context, items []M
 	// successful RefreshMetricsUsageSummary run - which, if that job is
 	// failing, could be never. See
 	// https://github.com/nicolastakashi/prom-analytics-proxy/issues/570.
-	//
-	// One bulk INSERT via unnest() instead of one statement per item -
-	// the syncer calls this with the full catalog inventory (~tens of
-	// thousands of rows on a real Prometheus), and per-item round-trips
-	// add up fast.
 	if _, err := tx.ExecContext(ctx, `
         INSERT INTO metrics_usage_summary(name, alert_count, record_count, dashboard_count, query_count, updated_at, is_unused)
         SELECT n, 0, 0, 0, 0, NOW(), FALSE FROM unnest($1::text[]) AS n

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -467,6 +467,34 @@ func (p *PostGreSQLProvider) InsertRulesUsage(ctx context.Context, rulesUsage []
 		return nil
 	}
 
+	// Sort by the same composite key as the ON CONFLICT target below before
+	// upserting, so this function stays safe under concurrent calls with
+	// overlapping rows in any order - the same deadlock precondition as
+	// #592.
+	sort.Slice(normalized, func(i, j int) bool {
+		a, b := normalized[i], normalized[j]
+		if a.Serie != b.Serie {
+			return a.Serie < b.Serie
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.GroupName != b.GroupName {
+			return a.GroupName < b.GroupName
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		if a.Expression != b.Expression {
+			return a.Expression < b.Expression
+		}
+		// labels is part of the ON CONFLICT target too - two rows can
+		// share every other field and still be distinct conflict targets
+		// differing only in labels. Each item's Labels is already sorted
+		// (a few lines above), so joining is a stable, comparable form.
+		return strings.Join(a.Labels, ",") < strings.Join(b.Labels, ",")
+	})
+
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -712,6 +712,24 @@ func TestPostgreSQL_InsertDashboardUsage_UpsertBehavior(t *testing.T) {
 	}
 }
 
+// TestPostgreSQL_InsertRulesUsage_ConcurrentOverlappingUpsertsDoNotDeadlock
+// verifies InsertRulesUsage tolerates concurrent calls upserting
+// overlapping rows in different orders without deadlocking (#594).
+func TestPostgreSQL_InsertRulesUsage_ConcurrentOverlappingUpsertsDoNotDeadlock(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	assertConcurrentOverlappingUpsertsDoNotDeadlock(t, 40, 25,
+		func(i int) RulesUsage {
+			return RulesUsage{
+				Serie:     fmt.Sprintf("deadlock_serie_%02d", i),
+				GroupName: "g", Name: "r", Expression: "e", Kind: string(RuleUsageKindAlert),
+			}
+		},
+		p.InsertRulesUsage,
+	)
+}
+
 // -------------------- Additional Tests parity with SQLite --------------------
 
 func TestPostgreSQL_HistogramSummaryMetricsCatalog(t *testing.T) {

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -971,6 +971,21 @@ func TestPostgreSQL_UpsertMetricsCatalog_ManyRows_EachRowGetsItsOwnValues(t *tes
 	}
 }
 
+// TestPostgreSQL_UpsertMetricsJobIndex_ConcurrentOverlappingUpsertsDoNotDeadlock
+// verifies UpsertMetricsJobIndex tolerates concurrent calls upserting
+// overlapping rows in different orders without deadlocking (#593).
+func TestPostgreSQL_UpsertMetricsJobIndex_ConcurrentOverlappingUpsertsDoNotDeadlock(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	assertConcurrentOverlappingUpsertsDoNotDeadlock(t, 40, 25,
+		func(i int) MetricJobIndexItem {
+			return MetricJobIndexItem{Name: fmt.Sprintf("deadlock_metric_%02d", i), Job: "shared_job"}
+		},
+		p.UpsertMetricsJobIndex,
+	)
+}
+
 // TestPostgreSQL_GetSeriesMetadataByNames_PopulatesIsUnused guards the
 // write-path half of https://github.com/nicolastakashi/prom-analytics-proxy/issues/571:
 // GetSeriesMetadataByNames (used by the OTLP ingester's usage-unused lookup)

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -67,6 +68,61 @@ func newTestPostgreSQLProvider(t *testing.T) (Provider, func()) {
 		_ = pgContainer.Terminate(ctx)
 	}
 	return p, cleanup
+}
+
+// assertConcurrentOverlappingUpsertsDoNotDeadlock races two concurrent
+// calls to upsert - each given the same itemsPerCall items, built by
+// buildItem, but in exactly reversed relative order - and asserts neither
+// ever fails. Two callers upserting overlapping rows via ON CONFLICT DO
+// UPDATE in opposite orders is Postgres's own documented deadlock
+// precondition (see
+// https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS):
+// "the best defense against deadlocks is generally to avoid them by being
+// certain that all applications ... acquire locks ... in a consistent
+// order."
+//
+// This repeats the attempt many times: a deadlock only happens if the two
+// calls' row-lock acquisition genuinely overlaps in time, which goroutine
+// scheduling doesn't guarantee on any single attempt - one try could pass
+// by luck even against code that doesn't sort before upserting.
+func assertConcurrentOverlappingUpsertsDoNotDeadlock[T any](
+	t *testing.T,
+	itemsPerCall, attempts int,
+	buildItem func(i int) T,
+	upsert func(context.Context, []T) error,
+) {
+	t.Helper()
+
+	ascending := make([]T, itemsPerCall)
+	descending := make([]T, itemsPerCall)
+	for i := 0; i < itemsPerCall; i++ {
+		item := buildItem(i)
+		ascending[i] = item
+		descending[itemsPerCall-1-i] = item
+	}
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		var wg sync.WaitGroup
+		errs := make(chan error, 2)
+		ready := make(chan struct{})
+
+		for _, items := range [][]T{ascending, descending} {
+			items := items
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-ready
+				errs <- upsert(context.Background(), items)
+			}()
+		}
+		close(ready)
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			assert.NoError(t, err, "attempt %d: concurrent overlapping upserts must not fail", attempt)
+		}
+	}
 }
 
 // TestNewPostgreSQLProvider_DoesNotMutateGlobalConfig verifies that
@@ -837,6 +893,82 @@ func TestPostgreSQL_UpsertMetricsCatalog_CreatesDefaultUnusedSummaryRow(t *testi
 		{name: "metric_a", isUnused: false},
 		{name: "metric_b", isUnused: false},
 	}, got)
+}
+
+// TestPostgreSQL_UpsertMetricsCatalog_ConcurrentOverlappingUpsertsDoNotDeadlock
+// verifies UpsertMetricsCatalog tolerates concurrent calls upserting
+// overlapping rows in different orders without deadlocking (#592).
+func TestPostgreSQL_UpsertMetricsCatalog_ConcurrentOverlappingUpsertsDoNotDeadlock(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	assertConcurrentOverlappingUpsertsDoNotDeadlock(t, 40, 25,
+		func(i int) MetricCatalogItem {
+			return MetricCatalogItem{Name: fmt.Sprintf("deadlock_metric_%02d", i), Type: "gauge", Help: "h"}
+		},
+		p.UpsertMetricsCatalog,
+	)
+}
+
+// TestPostgreSQL_UpsertMetricsCatalog_DuplicateNameInSameCall_LastOccurrenceWins
+// verifies a repeated name within one call resolves to its last
+// occurrence's values. This must keep holding with a bulk
+// INSERT ... ON CONFLICT DO UPDATE statement, which errors outright if
+// its own input contains the same conflict target twice ("ON CONFLICT DO
+// UPDATE command cannot affect row a second time"), so de-duplicating
+// before upserting is required independently of the deadlock fix itself.
+func TestPostgreSQL_UpsertMetricsCatalog_DuplicateNameInSameCall_LastOccurrenceWins(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "dup_metric", Type: "gauge", Help: "first"},
+		{Name: "other_metric", Type: "counter", Help: "unrelated"},
+		{Name: "dup_metric", Type: "counter", Help: "second"},
+	})
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	var gotType, gotHelp string
+	err := rawDB.QueryRowContext(context.Background(),
+		`SELECT type, help FROM metrics_catalog WHERE name = $1`, "dup_metric").Scan(&gotType, &gotHelp)
+	assert.NoError(t, err)
+	assert.Equal(t, "counter", gotType, "the later occurrence in the same call must win")
+	assert.Equal(t, "second", gotHelp)
+}
+
+// TestPostgreSQL_UpsertMetricsCatalog_ManyRows_EachRowGetsItsOwnValues
+// verifies each row in a multi-row call gets its own field values, not
+// another row's. This guards against a risk specific to a bulk-unnest
+// statement: four parallel arrays (name/type/help/unit) are passed
+// positionally into unnest($1, $2, $3, $4), and a swap (e.g. passing
+// helps where types belongs) would compile fine and silently misfile
+// every row's fields.
+func TestPostgreSQL_UpsertMetricsCatalog_ManyRows_EachRowGetsItsOwnValues(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	items := []MetricCatalogItem{
+		{Name: "metric_alpha", Type: "gauge", Help: "help alpha", Unit: "bytes"},
+		{Name: "metric_beta", Type: "counter", Help: "help beta", Unit: "seconds"},
+		{Name: "metric_gamma", Type: "histogram", Help: "help gamma", Unit: "requests"},
+	}
+	mustUpsertCatalog(t, p, items)
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	for _, want := range items {
+		var gotType, gotHelp, gotUnit string
+		err := rawDB.QueryRowContext(context.Background(),
+			`SELECT type, help, unit FROM metrics_catalog WHERE name = $1`, want.Name).
+			Scan(&gotType, &gotHelp, &gotUnit)
+		assert.NoError(t, err, "row for %s", want.Name)
+		assert.Equal(t, want.Type, gotType, "%s: type", want.Name)
+		assert.Equal(t, want.Help, gotHelp, "%s: help", want.Name)
+		assert.Equal(t, want.Unit, gotUnit, "%s: unit", want.Name)
+	}
 }
 
 // TestPostgreSQL_GetSeriesMetadataByNames_PopulatesIsUnused guards the


### PR DESCRIPTION
## Summary

Stacked on #597 (which is stacked on #596) - this branch includes both PRs' commits, so the diff currently shows all three. It will shrink as each earlier PR merges.

`InsertRulesUsage` has the same deadlock precondition as #592/#593: a per-row loop upserting via `ON CONFLICT DO UPDATE`, fed whatever order its input happens to be in. Its own in-function de-duplication preserves the caller's original order for the rows it keeps, and its only caller - a plain HTTP handler with no coordination between requests - builds that order from unstructured request data with no guaranteed ordering. Unlike `UpsertMetricsJobIndex`'s worker pool, there's no partitioning here to keep concurrent requests' target rows disjoint: any number of requests can land concurrently with overlapping rules.

Confirmed directly against a real PostgreSQL instance: two concurrent, overlapping, oppositely-ordered calls reliably reproduce `pq: deadlock detected (40P01)`.

## Fix

Sort the de-duplicated rows by the full `(serie, kind, group_name, name, expression, labels)` key - the same key the `ON CONFLICT` target uses - before upserting. All six columns are needed: two rows can share every field except `labels` and still be distinct conflict targets, so a tiebreak stopping short of the full key would leave those pairs' relative order undetermined. No de-duplication or bulk-statement changes needed beyond what already exists.

## Testing

A regression test with two concurrent, overlapping, oppositely-ordered calls against a real PostgreSQL instance - confirmed it reliably reproduces `deadlock detected` against the unfixed code, and passes cleanly with the fix.

Fixes #594
