### PR TITLE
docs: regenerate README flags and swagger spec (fix stale generated docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Flags (api):
     	Port of the postgresql server. (default 5432)
   -postgresql-sslmode string
     	SSL mode for the postgresql server. (default "disable")
+  -postgresql-statement-timeout duration
+    	Server-side per-statement timeout enforced by PostgreSQL on every pooled connection. When a single query exceeds this, PostgreSQL aborts it (SQLSTATE 57014) and frees the connection slot before the HTTP client can cancel it - useful as a load-shedder under saturation. Set just under the expected client per-call deadline (e.g. 4500ms when clients use 5s). 0 disables.
   -postgresql-user string
     	Username for the postgresql server, can also be set via POSTGRESQL_USER env var.
   -push-metrics-usage-timeout duration
@@ -453,6 +455,8 @@ Flags (metrics ingester):
     	Port of the postgresql server. (default 5432)
   -postgresql-sslmode string
     	SSL mode for the postgresql server. (default "disable")
+  -postgresql-statement-timeout duration
+    	Server-side per-statement timeout enforced by PostgreSQL on every pooled connection. When a single query exceeds this, PostgreSQL aborts it (SQLSTATE 57014) and frees the connection slot before the HTTP client can cancel it - useful as a load-shedder under saturation. Set just under the expected client per-call deadline (e.g. 4500ms when clients use 5s). 0 disables.
   -postgresql-user string
     	Username for the postgresql server, can also be set via POSTGRESQL_USER env var.
   -sqlite-database-path string

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1647,6 +1647,10 @@ const docTemplate = `{
                 "help": {
                     "type": "string"
                 },
+                "isUnused": {
+                    "description": "IsUnused reflects metrics_usage_summary.is_unused as evaluated by\nRefreshMetricsUsageSummary. It is the single source of truth for\nwhether a metric is confirmed unused - callers must not infer\n\"unused\" from AlertCount/RecordCount/DashboardCount/QueryCount being\nzero, since zero counts are also what an unevaluated metric looks\nlike before its first RefreshMetricsUsageSummary run.",
+                    "type": "boolean"
+                },
                 "lastQueriedAt": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1640,6 +1640,10 @@
                 "help": {
                     "type": "string"
                 },
+                "isUnused": {
+                    "description": "IsUnused reflects metrics_usage_summary.is_unused as evaluated by\nRefreshMetricsUsageSummary. It is the single source of truth for\nwhether a metric is confirmed unused - callers must not infer\n\"unused\" from AlertCount/RecordCount/DashboardCount/QueryCount being\nzero, since zero counts are also what an unevaluated metric looks\nlike before its first RefreshMetricsUsageSummary run.",
+                    "type": "boolean"
+                },
                 "lastQueriedAt": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -238,6 +238,15 @@ definitions:
         type: integer
       help:
         type: string
+      isUnused:
+        description: |-
+          IsUnused reflects metrics_usage_summary.is_unused as evaluated by
+          RefreshMetricsUsageSummary. It is the single source of truth for
+          whether a metric is confirmed unused - callers must not infer
+          "unused" from AlertCount/RecordCount/DashboardCount/QueryCount being
+          zero, since zero counts are also what an unevaluated metric looks
+          like before its first RefreshMetricsUsageSummary run.
+        type: boolean
       lastQueriedAt:
         type: string
       name:


### PR DESCRIPTION
## Summary

Two independently-generated docs had drifted from the code they document — both `check-docs` and `check-swagger` were failing on `main` as a result, unrelated to any specific feature PR.

## What changed

- `README.md`'s embedded `--help` output (`mdox-exec`) was missing `-postgresql-statement-timeout`, added to `internal/db/postgresql.go` without a docs regen. Fixed via `make docs`.
- `docs/{docs.go,swagger.json,swagger.yaml}` were missing `models.UnusedMetric.IsUnused`, added to the Go struct without a swagger regen. Fixed via `make generate-swagger`.

Both are mechanical regenerations — no manual edits to either output.

## Testing

`make check-docs` and `make check-swagger` both pass locally against this branch; `go build ./...` and `go vet ./...` clean.
