### PR TITLE
perf(inventory): add covering index for RulesUsage summary refresh scan

### DIFF
--- a/internal/db/migrations/postgresql/0016_rulesusage_summary_presence.sql
+++ b/internal/db/migrations/postgresql/0016_rulesusage_summary_presence.sql
@@ -1,0 +1,20 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Covering index for RefreshMetricsUsageSummary's RulesUsage subquery: it
+-- aggregates GROUP BY serie with no serie/kind predicate, so
+-- idx_rulesusage_presence (serie, kind, first_seen_at, last_seen_at) can't
+-- support it and the planner falls back to a full sequential scan.
+-- idx_rulesusage_presence stays untouched - splitting it would regress
+-- GetRulesUsage's equality-prefix lookup. Leading on last_seen_at makes the
+-- range condition indexable; serie/kind ride along via INCLUDE for an
+-- index-only scan. See
+-- https://github.com/nicolastakashi/prom-analytics-proxy/issues/589.
+--
+-- CREATE INDEX CONCURRENTLY (hence NO TRANSACTION, and no in-line ANALYZE -
+-- see migration 0013's deadlock note) so the build doesn't block writes
+-- from the inventory syncer.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_rulesusage_summary_presence
+    ON RulesUsage (last_seen_at, first_seen_at) INCLUDE (serie, kind);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_rulesusage_summary_presence;

--- a/internal/db/migrations/sqlite/0010_rulesusage_summary_presence.sql
+++ b/internal/db/migrations/sqlite/0010_rulesusage_summary_presence.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- Covering index for RefreshMetricsUsageSummary's RulesUsage subquery: it
+-- aggregates GROUP BY serie with no serie/kind predicate, so
+-- idx_rulesusage_presence (serie, kind, first_seen_at, last_seen_at) can't
+-- support it and the planner falls back to a full table scan.
+-- idx_rulesusage_presence stays untouched - splitting it would regress
+-- GetRulesUsage's equality-prefix lookup. Leading on last_seen_at makes the
+-- range condition indexable; serie/kind ride along as trailing key columns
+-- (no INCLUDE clause in SQLite) so the aggregate is still satisfiable from
+-- the index alone. See
+-- https://github.com/nicolastakashi/prom-analytics-proxy/issues/589.
+CREATE INDEX IF NOT EXISTS idx_rulesusage_summary_presence
+    ON RulesUsage(last_seen_at, first_seen_at, serie, kind);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_rulesusage_summary_presence;

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -502,6 +502,19 @@ func TestPostgreSQL_RefreshMetricsUsageSummary_And_GetSeriesMetadata(t *testing.
 	assert.Greater(t, res.Total, 0)
 }
 
+// mustSummaryRowPostgreSQL reads back one metrics_usage_summary row's four
+// usage counts plus is_unused. Callers assert on the whole row rather than a
+// single count: is_unused is derived from all four, so seeing the whole row
+// is what tells you which one is off if this ever fails again.
+func mustSummaryRowPostgreSQL(t *testing.T, rawDB *sql.DB, name string) summaryRow {
+	t.Helper()
+	var r summaryRow
+	row := rawDB.QueryRowContext(context.Background(),
+		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = $1`, name)
+	require.NoError(t, row.Scan(&r.Alert, &r.Record, &r.Dashboard, &r.Query, &r.Unused))
+	return r
+}
+
 // TestPostgreSQL_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows is the
 // PostgreSQL counterpart of TestSQLite_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows:
 // see there for the full rationale.
@@ -538,23 +551,60 @@ func TestPostgreSQL_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows(t *testi
 	err = p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-time.Hour), To: now})
 	assert.NoError(t, err, "RefreshMetricsUsageSummary")
 
-	// Select all four counts, not just query_count: is_unused is derived
-	// from all of them, so asserting on the whole row is what actually
-	// tells us WHICH count is off if this ever fails again, instead of
-	// leaving is_unused's false/true a mystery relative to a single count.
-	var fresh summaryRow
-	row := rawDB.QueryRowContext(context.Background(),
-		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = $1`, "fresh_metric")
-	require.NoError(t, row.Scan(&fresh.Alert, &fresh.Record, &fresh.Dashboard, &fresh.Query, &fresh.Unused))
+	fresh := mustSummaryRowPostgreSQL(t, rawDB, "fresh_metric")
 	assert.Greater(t, fresh.Query, 0, "fresh_metric should have been recomputed with real usage")
 	assert.False(t, fresh.Unused, "fresh_metric should be marked used")
 
-	var stale summaryRow
-	row = rawDB.QueryRowContext(context.Background(),
-		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = $1`, "stale_metric")
-	require.NoError(t, row.Scan(&stale.Alert, &stale.Record, &stale.Dashboard, &stale.Query, &stale.Unused))
+	stale := mustSummaryRowPostgreSQL(t, rawDB, "stale_metric")
 	assert.Equal(t, summaryRow{Alert: 0, Record: 0, Dashboard: 0, Query: 0, Unused: false}, stale,
 		"stale_metric's summary should remain untouched at its placeholder values - got %+v", stale)
+}
+
+// TestPostgreSQL_RefreshMetricsUsageSummary_ExcludesOutOfWindowRulesUsage guards
+// RulesUsage's own presence-window filter in RefreshMetricsUsageSummary: a rule
+// whose first_seen_at/last_seen_at fall outside the refresh's TimeRange must not
+// count toward alert_count/record_count. See
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/589.
+func TestPostgreSQL_RefreshMetricsUsageSummary_ExcludesOutOfWindowRulesUsage(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "in_window_metric", Type: "gauge", Help: "actively alerting"},
+		{Name: "out_of_window_metric", Type: "gauge", Help: "alert retired long ago"},
+	})
+	mustInsertRules(t, p, []RulesUsage{
+		{Serie: "in_window_metric", GroupName: "g", Name: "a1", Expression: "e", Kind: string(RuleUsageKindAlert), Labels: []string{"l"}},
+		{Serie: "out_of_window_metric", GroupName: "g", Name: "a2", Expression: "e", Kind: string(RuleUsageKindAlert), Labels: []string{"l"}},
+	})
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	// InsertRulesUsage always stamps first_seen_at/last_seen_at at call time,
+	// so there's no public way to seed a rule outside the presence window -
+	// push it out directly, simulating a rule retired long ago.
+	_, err := rawDB.ExecContext(context.Background(),
+		`UPDATE RulesUsage SET first_seen_at = NOW() - INTERVAL '100 days', last_seen_at = NOW() - INTERVAL '99 days' WHERE serie = $1`,
+		"out_of_window_metric")
+	assert.NoError(t, err, "backdate out_of_window_metric's rule presence")
+
+	// To is a minute past "now": time-range formatting truncates to whole
+	// seconds, and the rule just inserted carries sub-second precision - an
+	// unpadded "now" bound can land before the rule's own timestamp and
+	// spuriously exclude it.
+	now := time.Now().UTC()
+	err = p.RefreshMetricsUsageSummary(context.Background(),
+		TimeRange{From: now.Add(-30 * 24 * time.Hour), To: now.Add(time.Minute)})
+	assert.NoError(t, err, "RefreshMetricsUsageSummary")
+
+	inWindow := mustSummaryRowPostgreSQL(t, rawDB, "in_window_metric")
+	assert.Equal(t, summaryRow{Alert: 1, Record: 0, Dashboard: 0, Query: 0, Unused: false}, inWindow,
+		"in_window_metric's alert rule falls inside the refresh window and must be counted - got %+v", inWindow)
+
+	outOfWindow := mustSummaryRowPostgreSQL(t, rawDB, "out_of_window_metric")
+	assert.Equal(t, summaryRow{Alert: 0, Record: 0, Dashboard: 0, Query: 0, Unused: true}, outOfWindow,
+		"out_of_window_metric's rule presence ended before the refresh window started, so it must not be counted as used - got %+v", outOfWindow)
 }
 
 // TestPostgreSQL_UpsertMetricsCatalog_LastSyncedAtIsUTC guards last_synced_at

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -453,6 +453,19 @@ func TestSQLite_RefreshMetricsUsageSummary_And_GetSeriesMetadata(t *testing.T) {
 	}
 }
 
+// mustSummaryRowSQLite reads back one metrics_usage_summary row's four usage
+// counts plus is_unused. Callers assert on the whole row rather than a
+// single count: is_unused is derived from all four, so seeing the whole row
+// is what tells you which one is off if this ever fails again.
+func mustSummaryRowSQLite(t *testing.T, rawDB *sql.DB, name string) summaryRow {
+	t.Helper()
+	var r summaryRow
+	row := rawDB.QueryRowContext(context.Background(),
+		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = ?`, name)
+	require.NoError(t, row.Scan(&r.Alert, &r.Record, &r.Dashboard, &r.Query, &r.Unused))
+	return r
+}
+
 // TestSQLite_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows is the
 // regression test for
 // https://github.com/nicolastakashi/prom-analytics-proxy/issues/579: a
@@ -500,23 +513,60 @@ func TestSQLite_RefreshMetricsUsageSummary_ExcludesStaleCatalogRows(t *testing.T
 	err = p.RefreshMetricsUsageSummary(context.Background(), TimeRange{From: now.Add(-time.Hour), To: now})
 	assert.NoError(t, err, "RefreshMetricsUsageSummary")
 
-	// Select all four counts, not just query_count: is_unused is derived
-	// from all of them, so asserting on the whole row is what actually
-	// tells us WHICH count is off if this ever fails again, instead of
-	// leaving is_unused's false/true a mystery relative to a single count.
-	var fresh summaryRow
-	row := rawDB.QueryRowContext(context.Background(),
-		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = ?`, "fresh_metric")
-	require.NoError(t, row.Scan(&fresh.Alert, &fresh.Record, &fresh.Dashboard, &fresh.Query, &fresh.Unused))
+	fresh := mustSummaryRowSQLite(t, rawDB, "fresh_metric")
 	assert.Greater(t, fresh.Query, 0, "fresh_metric should have been recomputed with real usage")
 	assert.False(t, fresh.Unused, "fresh_metric should be marked used")
 
-	var stale summaryRow
-	row = rawDB.QueryRowContext(context.Background(),
-		`SELECT alert_count, record_count, dashboard_count, query_count, is_unused FROM metrics_usage_summary WHERE name = ?`, "stale_metric")
-	require.NoError(t, row.Scan(&stale.Alert, &stale.Record, &stale.Dashboard, &stale.Query, &stale.Unused))
+	stale := mustSummaryRowSQLite(t, rawDB, "stale_metric")
 	assert.Equal(t, summaryRow{Alert: 0, Record: 0, Dashboard: 0, Query: 0, Unused: false}, stale,
 		"stale_metric's summary should remain untouched at its placeholder values - got %+v", stale)
+}
+
+// TestSQLite_RefreshMetricsUsageSummary_ExcludesOutOfWindowRulesUsage guards
+// RulesUsage's own presence-window filter in RefreshMetricsUsageSummary: a rule
+// whose first_seen_at/last_seen_at fall outside the refresh's TimeRange must not
+// count toward alert_count/record_count. See
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/589.
+func TestSQLite_RefreshMetricsUsageSummary_ExcludesOutOfWindowRulesUsage(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	mustUpsertCatalog(t, p, []MetricCatalogItem{
+		{Name: "in_window_metric", Type: "gauge", Help: "actively alerting"},
+		{Name: "out_of_window_metric", Type: "gauge", Help: "alert retired long ago"},
+	})
+	mustInsertRules(t, p, []RulesUsage{
+		{Serie: "in_window_metric", GroupName: "g", Name: "a1", Expression: "e", Kind: string(RuleUsageKindAlert), Labels: []string{"l"}},
+		{Serie: "out_of_window_metric", GroupName: "g", Name: "a2", Expression: "e", Kind: string(RuleUsageKindAlert), Labels: []string{"l"}},
+	})
+
+	var rawDB *sql.DB
+	p.WithDB(func(d *sql.DB) { rawDB = d })
+
+	// InsertRulesUsage always stamps first_seen_at/last_seen_at at call time,
+	// so there's no public way to seed a rule outside the presence window -
+	// push it out directly, simulating a rule retired long ago.
+	_, err := rawDB.ExecContext(context.Background(),
+		`UPDATE RulesUsage SET first_seen_at = datetime('now', '-100 days'), last_seen_at = datetime('now', '-99 days') WHERE serie = ?`,
+		"out_of_window_metric")
+	assert.NoError(t, err, "backdate out_of_window_metric's rule presence")
+
+	// To is a minute past "now": time-range formatting truncates to whole
+	// seconds, and the rule just inserted carries sub-second precision - an
+	// unpadded "now" bound can land before the rule's own timestamp and
+	// spuriously exclude it.
+	now := time.Now().UTC()
+	err = p.RefreshMetricsUsageSummary(context.Background(),
+		TimeRange{From: now.Add(-30 * 24 * time.Hour), To: now.Add(time.Minute)})
+	assert.NoError(t, err, "RefreshMetricsUsageSummary")
+
+	inWindow := mustSummaryRowSQLite(t, rawDB, "in_window_metric")
+	assert.Equal(t, summaryRow{Alert: 1, Record: 0, Dashboard: 0, Query: 0, Unused: false}, inWindow,
+		"in_window_metric's alert rule falls inside the refresh window and must be counted - got %+v", inWindow)
+
+	outOfWindow := mustSummaryRowSQLite(t, rawDB, "out_of_window_metric")
+	assert.Equal(t, summaryRow{Alert: 0, Record: 0, Dashboard: 0, Query: 0, Unused: true}, outOfWindow,
+		"out_of_window_metric's rule presence ended before the refresh window started, so it must not be counted as used - got %+v", outOfWindow)
 }
 
 // TestSQLite_RefreshMetricsUsageSummary_WarnsWhenAllRowsAreStale guards a


### PR DESCRIPTION
RefreshMetricsUsageSummary's RulesUsage subquery aggregates GROUP BY serie over the whole table, filtered only by the presence window - it has no serie/kind predicate. idx_rulesusage_presence (serie, kind, first_seen_at, last_seen_at) is the right shape for GetRulesUsage's per-metric lookup, but a btree index can't use first_seen_at/ last_seen_at for a range scan when they sit behind two unconstrained leading columns, so this subquery falls back to a full sequential scan that grows with the whole table rather than the presence window. Once #579 bounds metrics_catalog's own scan, this becomes the largest remaining cost in the refresh, and it compounds #572 the same way: RulesUsage growing large enough on its own can push the refresh past its timeout regardless of how well-behaved metrics_catalog is.

Added idx_rulesusage_summary_presence, leading on last_seen_at so first_seen_at <= $2 AND last_seen_at >= $1 becomes an index range condition, with serie/kind riding along (INCLUDE on PostgreSQL, trailing key columns on SQLite, which has no INCLUDE clause) so the aggregate is satisfiable from the index alone. idx_rulesusage_presence is left untouched: splitting it into two narrower indexes instead would regress GetRulesUsage's equality-prefix lookup to a less selective bitmap scan, trading one query's cost for another's.

PostgreSQL builds it CONCURRENTLY under NO TRANSACTION, with no in-line ANALYZE, matching migration 0013's pattern for the same RowExclusiveLock/ShareUpdateExclusiveLock deadlock risk against concurrent writes from the inventory syncer.

Tests: RulesUsage's own presence-window exclusion had no coverage - existing tests only guarded metrics_catalog's freshness filter one join away. Added ExcludesOutOfWindowRulesUsage for both backends, backdating a rule's first_seen_at/last_seen_at directly since InsertRulesUsage always stamps them at call time. Extracted the four-count-plus-is_unused row read, now repeated across both this and the existing stale-catalog test, into a mustSummaryRow helper per backend so the two tests can't drift apart on how they read back the same shape of assertion.

Addresses #589

Change-Id: I5182c9b3b7d69bcb344e0aac14bb11f90dee0b05