### PR TITLE
fix(db): compute paginated Total independently of the LIMIT/OFFSET window

### DIFF
--- a/internal/db/common.go
+++ b/internal/db/common.go
@@ -142,6 +142,19 @@ func ScanSingleRow(rows *sql.Rows, dest ...interface{}) error {
 	return nil
 }
 
+// countMatching runs a standalone COUNT query and returns the scalar result.
+// A paginated method must run this independently of its paged query - a
+// count read off a paged row is wrong once LIMIT/OFFSET selects zero rows
+// (a page past the last one), since there is then no row left to read it
+// from.
+func countMatching(ctx context.Context, db *sql.DB, countQuery string, args ...interface{}) (int, error) {
+	var n int
+	if err := db.QueryRowContext(ctx, countQuery, args...).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
 // PrepareTimeRange formats time range parameters based on the database dialect
 func PrepareTimeRange(tr TimeRange, dialect string) (string, string) {
 	if dialect == "postgresql" {

--- a/internal/db/postgresql.go
+++ b/internal/db/postgresql.go
@@ -339,7 +339,6 @@ func (p *PostGreSQLProvider) GetQueriesBySerieName(
 	ctx context.Context,
 	params QueriesBySerieNameParams) (PagedResult, error) {
 
-	// Set default values using common helpers
 	ValidatePagination(&params.Page, &params.PageSize, 10)
 
 	validSortFields := map[string]bool{
@@ -351,50 +350,51 @@ func (p *PostGreSQLProvider) GetQueriesBySerieName(
 	ValidateSortField(&params.SortBy, &params.SortOrder, validSortFields, "avgDuration")
 	SetDefaultTimeRange(&params.TimeRange)
 
+	// filterClause is shared with the count query below (see countMatching)
+	// so both see the identical row set.
+	filterClause := `
+		labelMatchers @> $1::jsonb
+		AND ts BETWEEN $2 AND $3
+		AND CASE
+			WHEN $4 != '' THEN
+				queryParam ILIKE '%' || $4 || '%'
+			ELSE
+				TRUE
+			END
+	`
+	filterArgs := []interface{}{
+		metricMatcherJSON(params.SerieName),
+		params.TimeRange.From,
+		params.TimeRange.To,
+		params.Filter,
+	}
+
+	countQuery := `SELECT COUNT(DISTINCT queryParam) FROM queries WHERE ` + filterClause
+	totalCount, err := countMatching(ctx, p.db, countQuery, filterArgs...)
+	if err != nil {
+		return PagedResult{}, fmt.Errorf("count: %w", err)
+	}
+	if totalCount == 0 {
+		return PagedResult{Total: 0, TotalPages: 0, Data: []QueriesBySerieNameResult{}}, nil
+	}
+
 	baseQuery := `
-	WITH filtered_queries AS (
-		SELECT
-			queryParam,
-			AVG(duration) AS avgDuration,
-			AVG(peakSamples) AS avgPeakySamples,
-			MAX(peakSamples) AS maxPeakSamples
-		FROM
-			queries
-		WHERE
-			labelMatchers @> $1::jsonb
-			AND ts BETWEEN $2 AND $3
-			AND CASE
-				WHEN $4 != '' THEN
-					queryParam ILIKE '%' || $4 || '%'
-				ELSE
-					TRUE
-				END
-		GROUP BY
-			queryParam
-	),
-	counted_queries AS (
-		SELECT COUNT(*) as total_count
-		FROM filtered_queries
-	)
 	SELECT
-		q.*,
-		cq.total_count
+		queryParam,
+		AVG(duration) AS avgDuration,
+		AVG(peakSamples) AS avgPeakySamples,
+		MAX(peakSamples) AS maxPeakSamples
 	FROM
-		filtered_queries q,
-		counted_queries cq
+		queries
+	WHERE ` + filterClause + `
+	GROUP BY
+		queryParam
 	`
 	// Build ORDER BY clause dynamically to avoid mixed-type CASE expressions
 	orderClause := fmt.Sprintf(" ORDER BY %s %s NULLS LAST", params.SortBy, strings.ToUpper(params.SortOrder))
 	query := baseQuery + orderClause + " LIMIT $5 OFFSET $6;"
 
-	args := []interface{}{
-		metricMatcherJSON(params.SerieName),
-		params.TimeRange.From,
-		params.TimeRange.To,
-		params.Filter,
-		params.PageSize,
-		(params.Page - 1) * params.PageSize,
-	}
+	args := append(append([]interface{}{}, filterArgs...), params.PageSize, (params.Page-1)*params.PageSize)
 
 	rows, err := ExecuteQuery(ctx, p.db, query, args...)
 	if err != nil {
@@ -403,7 +403,6 @@ func (p *PostGreSQLProvider) GetQueriesBySerieName(
 	defer CloseResource(rows)
 
 	var results []QueriesBySerieNameResult
-	var totalCount int
 
 	for rows.Next() {
 		var result QueriesBySerieNameResult
@@ -412,7 +411,6 @@ func (p *PostGreSQLProvider) GetQueriesBySerieName(
 			&result.AvgDuration,
 			&result.AvgPeakySamples,
 			&result.MaxPeakSamples,
-			&totalCount,
 		); err != nil {
 			return PagedResult{}, ErrorWithOperation(err, "scanning row")
 		}
@@ -580,9 +578,7 @@ func (p *PostGreSQLProvider) GetRulesUsage(ctx context.Context, params RulesUsag
                 TRUE
             END;
     `
-	var totalCount int
-	err := p.db.QueryRowContext(ctx, countQuery, params.Serie, params.Kind, startTime, endTime,
-		params.Filter).Scan(&totalCount)
+	totalCount, err := countMatching(ctx, p.db, countQuery, params.Serie, params.Kind, startTime, endTime, params.Filter)
 	if err != nil {
 		return PagedResult{}, fmt.Errorf("failed to query total count: %w", err)
 	}
@@ -791,9 +787,7 @@ func (p *PostGreSQLProvider) GetDashboardUsage(ctx context.Context, params Dashb
                 TRUE
             END;
     `
-	var totalCount int
-	err := p.db.QueryRowContext(ctx, countQuery,
-		params.Serie, from, to, params.Filter).Scan(&totalCount)
+	totalCount, err := countMatching(ctx, p.db, countQuery, params.Serie, from, to, params.Filter)
 	if err != nil {
 		return PagedResult{}, fmt.Errorf("failed to query total count: %w", err)
 	}
@@ -1786,12 +1780,25 @@ func (p *PostGreSQLProvider) GetQueryExpressions(ctx context.Context, params Que
 
 	from, to := params.TimeRange.Format(ISOTimeFormat)
 
+	// filterClause is shared with the count query below (see countMatching)
+	// so both see the identical row set.
+	filterClause := `ts BETWEEN $1 AND $2 AND CASE WHEN $3 <> '' THEN queryParam ILIKE '%%' || $3 || '%%' ELSE TRUE END`
+	filterArgs := []interface{}{from, to, params.Filter}
+
+	countQuery := `SELECT COUNT(DISTINCT fingerprint) FROM queries WHERE ` + filterClause
+	totalCount, err := countMatching(ctx, p.db, countQuery, filterArgs...)
+	if err != nil {
+		return PagedResult{}, fmt.Errorf("count: %w", err)
+	}
+	if totalCount == 0 {
+		return PagedResult{Total: 0, TotalPages: 0, Data: []QueryExpression{}}, nil
+	}
+
 	baseQuery := `
         WITH filtered AS (
             SELECT *
             FROM queries
-            WHERE ts BETWEEN $1 AND $2
-              AND CASE WHEN $3 <> '' THEN queryParam ILIKE '%%' || $3 || '%%' ELSE TRUE END
+            WHERE ` + filterClause + `
         ), grouped AS (
             SELECT
                 fingerprint,
@@ -1802,30 +1809,26 @@ func (p *PostGreSQLProvider) GetQueryExpressions(ctx context.Context, params Que
                 (ARRAY_AGG(queryParam ORDER BY ts DESC))[1] AS query
             FROM filtered
             GROUP BY fingerprint
-        ), counted AS (
-            SELECT COUNT(*) AS total_count FROM grouped
         )
-        SELECT fingerprint, query, executions, avgDuration, errorRatePercent, peakSamples, total_count
-        FROM grouped, counted
+        SELECT fingerprint, query, executions, avgDuration, errorRatePercent, peakSamples
+        FROM grouped
     `
 
 	// Safe ORDER BY
 	orderClause := fmt.Sprintf(" ORDER BY %s %s NULLS LAST", params.SortBy, strings.ToUpper(params.SortOrder))
 	query := baseQuery + orderClause + " LIMIT $4 OFFSET $5;"
 
-	rows, err := ExecuteQuery(ctx, p.db, query, from, to, params.Filter, params.PageSize, (params.Page-1)*params.PageSize)
+	args := append(append([]interface{}{}, filterArgs...), params.PageSize, (params.Page-1)*params.PageSize)
+	rows, err := ExecuteQuery(ctx, p.db, query, args...)
 	if err != nil {
 		return PagedResult{}, err
 	}
 	defer CloseResource(rows)
 
-	var (
-		results    []QueryExpression
-		totalCount int
-	)
+	var results []QueryExpression
 	for rows.Next() {
 		var r QueryExpression
-		if err := rows.Scan(&r.Fingerprint, &r.Query, &r.Executions, &r.AvgDuration, &r.ErrorRatePercent, &r.PeakSamples, &totalCount); err != nil {
+		if err := rows.Scan(&r.Fingerprint, &r.Query, &r.Executions, &r.AvgDuration, &r.ErrorRatePercent, &r.PeakSamples); err != nil {
 			return PagedResult{}, fmt.Errorf("scan: %w", err)
 		}
 		results = append(results, r)
@@ -1853,27 +1856,34 @@ func (p *PostGreSQLProvider) GetQueryExecutions(ctx context.Context, params Quer
 
 	from, to := params.TimeRange.Format(ISOTimeFormat)
 
+	// filterClause is shared with the count query below (see countMatching)
+	// so both see the identical row set.
+	filterClause := `ts BETWEEN $1 AND $2 AND fingerprint = $3 AND ($4 = '' OR type = $4)`
+	filterArgs := []interface{}{from, to, params.Fingerprint, params.Type}
+
+	countQuery := `SELECT COUNT(*) FROM queries WHERE ` + filterClause
+	total, err := countMatching(ctx, p.db, countQuery, filterArgs...)
+	if err != nil {
+		return PagedResult{}, fmt.Errorf("count: %w", err)
+	}
+	if total == 0 {
+		return PagedResult{Total: 0, TotalPages: 0, Data: []QueryExecutionRow{}}, nil
+	}
+
 	base := `
-        WITH filtered AS (
-            SELECT ts, statusCode, duration, totalQueryableSamples AS samples, type, start, "end", step, httpHeaders
-            FROM queries
-            WHERE ts BETWEEN $1 AND $2
-              AND fingerprint = $3
-              AND ($4 = '' OR type = $4)
-        ), counted AS (
-            SELECT COUNT(*) AS total_count FROM filtered
-        )
-        SELECT ts, statusCode, duration, samples, type,
+        SELECT ts, statusCode, duration, totalQueryableSamples AS samples, type,
                COALESCE(step, 0) AS steps,
-               httpHeaders, start, "end", total_count
-        FROM filtered, counted
+               httpHeaders, start, "end"
+        FROM queries
+        WHERE ` + filterClause + `
     `
 
 	orderClause := fmt.Sprintf(" ORDER BY %s %s NULLS LAST", params.SortBy, strings.ToUpper(params.SortOrder))
 	query := base + orderClause + " LIMIT $5 OFFSET $6;"
 
 	offset := (params.Page - 1) * params.PageSize
-	rows, err := ExecuteQuery(ctx, p.db, query, from, to, params.Fingerprint, params.Type, params.PageSize, offset)
+	args := append(append([]interface{}{}, filterArgs...), params.PageSize, offset)
+	rows, err := ExecuteQuery(ctx, p.db, query, args...)
 	if err != nil {
 		return PagedResult{}, err
 	}
@@ -1889,15 +1899,11 @@ func (p *PostGreSQLProvider) GetQueryExecutions(ctx context.Context, params Quer
 		httpHeaders []byte
 		start       time.Time
 		end         time.Time
-		totalCount  int
 	}
-	var (
-		results []QueryExecutionRow
-		total   int
-	)
+	var results []QueryExecutionRow
 	for rows.Next() {
 		var r row
-		if err := rows.Scan(&r.ts, &r.status, &r.duration, &r.samples, &r.typ, &r.steps, &r.httpHeaders, &r.start, &r.end, &r.totalCount); err != nil {
+		if err := rows.Scan(&r.ts, &r.status, &r.duration, &r.samples, &r.typ, &r.steps, &r.httpHeaders, &r.start, &r.end); err != nil {
 			return PagedResult{}, ErrorWithOperation(err, "scanning row")
 		}
 		res := QueryExecutionRow{Timestamp: r.ts, Status: r.status, Duration: r.duration, Samples: r.samples, Type: r.typ, Steps: r.steps, Start: r.start, End: r.end}
@@ -1907,7 +1913,6 @@ func (p *PostGreSQLProvider) GetQueryExecutions(ctx context.Context, params Quer
 			}
 		}
 		results = append(results, res)
-		total = r.totalCount
 	}
 	if err := rows.Err(); err != nil {
 		return PagedResult{}, ErrorWithOperation(err, "row iteration")

--- a/internal/db/postgresql_test.go
+++ b/internal/db/postgresql_test.go
@@ -442,6 +442,74 @@ func TestPostgreSQL_GetQueryExpressions_And_Executions(t *testing.T) {
 	}
 }
 
+// TestPostgreSQL_TotalCountCorrectPastLastPage verifies GetQueriesBySerieName,
+// GetQueryExpressions, and GetQueryExecutions report the true total row
+// count even when the requested page is past the last page, not just
+// whatever fits inside the LIMIT/OFFSET window.
+func TestPostgreSQL_TotalCountCorrectPastLastPage(t *testing.T) {
+	p, cleanup := newTestPostgreSQLProvider(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Minute)
+	tr := TimeRange{From: now.Add(-1 * time.Hour), To: now.Add(1 * time.Hour)}
+
+	t.Run("GetQueriesBySerieName", func(t *testing.T) {
+		var qs []Query
+		for i := 1; i <= 3; i++ {
+			qs = append(qs, Query{
+				TS: now.Add(time.Duration(i) * time.Minute), QueryParam: fmt.Sprintf("qbsn_variant_%d", i),
+				TimeParam: now, Duration: time.Duration(i*10) * time.Millisecond, StatusCode: 200,
+				LabelMatchers: LabelMatchers{{"__name__": "up"}}, Type: QueryTypeInstant,
+			})
+		}
+		mustInsertQueries(t, p, qs)
+
+		out, err := p.GetQueriesBySerieName(context.Background(), QueriesBySerieNameParams{
+			SerieName: "up", Filter: "qbsn_variant", TimeRange: tr, Page: 10, PageSize: 1, SortBy: "avgDuration", SortOrder: "desc",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, out.Total, "Total must reflect all matching rows, not just what fits in this page's window")
+	})
+
+	t.Run("GetQueryExpressions", func(t *testing.T) {
+		var qs []Query
+		for i := 1; i <= 3; i++ {
+			qs = append(qs, Query{
+				TS: now.Add(time.Duration(i) * time.Minute), QueryParam: fmt.Sprintf("qe_expr_%d", i),
+				TimeParam: now, Duration: 10 * time.Millisecond, StatusCode: 200,
+				LabelMatchers: LabelMatchers{{"__name__": "up"}}, Type: QueryTypeInstant,
+				Fingerprint: fmt.Sprintf("qe_fp_%d", i),
+			})
+		}
+		mustInsertQueries(t, p, qs)
+
+		out, err := p.GetQueryExpressions(context.Background(), QueryExpressionsParams{
+			Filter: "qe_expr", TimeRange: tr, Page: 10, PageSize: 1, SortBy: "executions", SortOrder: "desc",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, out.Total, "Total must reflect all matching rows, not just what fits in this page's window")
+	})
+
+	t.Run("GetQueryExecutions", func(t *testing.T) {
+		var qs []Query
+		for i := 1; i <= 3; i++ {
+			qs = append(qs, Query{
+				TS: now.Add(time.Duration(i) * time.Minute), QueryParam: "up",
+				TimeParam: now, Duration: 10 * time.Millisecond, StatusCode: 200,
+				LabelMatchers: LabelMatchers{{"__name__": "up"}}, Type: QueryTypeInstant,
+				Fingerprint: "qexec_fp",
+			})
+		}
+		mustInsertQueries(t, p, qs)
+
+		out, err := p.GetQueryExecutions(context.Background(), QueryExecutionsParams{
+			Fingerprint: "qexec_fp", TimeRange: tr, Page: 10, PageSize: 1, SortBy: "ts", SortOrder: "desc",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, out.Total, "Total must reflect all matching rows, not just what fits in this page's window")
+	})
+}
+
 // -------------------- Metrics Inventory --------------------
 
 func TestPostgreSQL_MetricsJobIndex_And_ListJobs(t *testing.T) {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -265,37 +265,43 @@ func (p *SQLiteProvider) GetQueriesBySerieName(ctx context.Context, params Queri
 
 	startTime, endTime := PrepareTimeRange(params.TimeRange, "sqlite")
 
+	// filterClause is shared with the count query below (see countMatching)
+	// so both see the identical row set.
+	filterClause := `
+		json_extract(labelMatchers, '$[0].__name__') = ?
+		AND ts BETWEEN ? AND ?
+		AND CASE
+			WHEN ? != '' THEN
+				queryParam LIKE '%' || ? || '%'
+			ELSE
+				1=1
+			END
+	`
+	filterArgs := []interface{}{
+		params.SerieName, startTime, endTime,
+		params.Filter, params.Filter,
+	}
+
+	countQuery := `SELECT COUNT(DISTINCT queryParam) FROM queries WHERE ` + filterClause
+	totalCount, err := countMatching(ctx, p.db, countQuery, filterArgs...)
+	if err != nil {
+		return PagedResult{}, fmt.Errorf("count: %w", err)
+	}
+	if totalCount == 0 {
+		return PagedResult{Total: 0, TotalPages: 0, Data: []QueriesBySerieNameResult{}}, nil
+	}
+
 	query := `
-	WITH filtered_queries AS (
-		SELECT
-			queryParam,
-			AVG(duration) AS avgDuration,
-			AVG(peakSamples) AS avgPeakySamples,
-			MAX(peakSamples) AS maxPeakSamples
-		FROM
-			queries
-		WHERE
-			json_extract(labelMatchers, '$[0].__name__') = ?
-			AND ts BETWEEN ? AND ?
-			AND CASE
-				WHEN ? != '' THEN
-					queryParam LIKE '%' || ? || '%'
-				ELSE
-					1=1
-				END
-		GROUP BY
-			queryParam
-	),
-	counted_queries AS (
-		SELECT COUNT(*) as total_count
-		FROM filtered_queries
-	)
 	SELECT
-		q.*,
-		cq.total_count
+		queryParam,
+		AVG(duration) AS avgDuration,
+		AVG(peakSamples) AS avgPeakySamples,
+		MAX(peakSamples) AS maxPeakSamples
 	FROM
-		filtered_queries q,
-		counted_queries cq
+		queries
+	WHERE ` + filterClause + `
+	GROUP BY
+		queryParam
 	ORDER BY
 		CASE WHEN ? = 'asc' THEN
 			CASE ?
@@ -316,14 +322,12 @@ func (p *SQLiteProvider) GetQueriesBySerieName(ctx context.Context, params Queri
 	LIMIT ? OFFSET ?;
 	`
 
-	args := []interface{}{
-		params.SerieName, startTime, endTime,
-		params.Filter, params.Filter,
+	args := append(append([]interface{}{}, filterArgs...),
 		params.SortOrder, params.SortBy,
 		params.SortOrder, params.SortBy,
 		params.PageSize,
-		(params.Page - 1) * params.PageSize,
-	}
+		(params.Page-1)*params.PageSize,
+	)
 
 	stmt, err := p.db.PrepareContext(ctx, query)
 	if err != nil {
@@ -338,7 +342,6 @@ func (p *SQLiteProvider) GetQueriesBySerieName(ctx context.Context, params Queri
 	defer CloseResource(rows)
 
 	results := []QueriesBySerieNameResult{}
-	var totalCount int
 
 	for rows.Next() {
 		var result QueriesBySerieNameResult
@@ -347,7 +350,6 @@ func (p *SQLiteProvider) GetQueriesBySerieName(ctx context.Context, params Queri
 			&result.AvgDuration,
 			&result.AvgPeakySamples,
 			&result.MaxPeakSamples,
-			&totalCount,
 		); err != nil {
 			return PagedResult{}, ErrorWithOperation(err, "scanning row")
 		}
@@ -494,9 +496,8 @@ func (p *SQLiteProvider) GetRulesUsage(ctx context.Context, params RulesUsagePar
                 1=1
             END;
     `
-	var totalCount int
-	err := p.db.QueryRowContext(ctx, countQuery, params.Serie, params.Kind, endTime, startTime,
-		params.Filter, params.Filter, params.Filter).Scan(&totalCount)
+	totalCount, err := countMatching(ctx, p.db, countQuery, params.Serie, params.Kind, endTime, startTime,
+		params.Filter, params.Filter, params.Filter)
 	if err != nil {
 		return PagedResult{}, fmt.Errorf("failed to query total count: %w", err)
 	}
@@ -711,10 +712,9 @@ func (p *SQLiteProvider) GetDashboardUsage(ctx context.Context, params Dashboard
                 1=1
             END;
     `
-	var totalCount int
-	err := p.db.QueryRowContext(ctx, countQuery,
+	totalCount, err := countMatching(ctx, p.db, countQuery,
 		params.Serie, endTime, startTime,
-		params.Filter, params.Filter, params.Filter).Scan(&totalCount)
+		params.Filter, params.Filter, params.Filter)
 	if err != nil {
 		return PagedResult{}, fmt.Errorf("failed to query total count: %w", err)
 	}
@@ -1731,11 +1731,24 @@ func (p *SQLiteProvider) GetQueryExpressions(ctx context.Context, params QueryEx
 
 	from, to := PrepareTimeRange(params.TimeRange, "sqlite")
 
+	// filterClause is shared with the count query below (see countMatching)
+	// so both see the identical row set.
+	filterClause := `ts BETWEEN datetime(?) AND datetime(?) AND CASE WHEN ? != '' THEN queryParam LIKE '%' || ? || '%' ELSE 1=1 END`
+	filterArgs := []interface{}{from, to, params.Filter, params.Filter}
+
+	countQuery := `SELECT COUNT(DISTINCT fingerprint) FROM queries WHERE ` + filterClause
+	totalCount, err := countMatching(ctx, p.db, countQuery, filterArgs...)
+	if err != nil {
+		return PagedResult{}, fmt.Errorf("failed to count query expressions: %w", err)
+	}
+	if totalCount == 0 {
+		return PagedResult{Total: 0, TotalPages: 0, Data: []QueryExpression{}}, nil
+	}
+
 	query := `
         WITH filtered AS (
             SELECT * FROM queries
-            WHERE ts BETWEEN datetime(?) AND datetime(?)
-              AND CASE WHEN ? != '' THEN queryParam LIKE '%' || ? || '%' ELSE 1=1 END
+            WHERE ` + filterClause + `
         ), latest AS (
             SELECT fingerprint, queryParam, ts,
                    ROW_NUMBER() OVER (PARTITION BY fingerprint ORDER BY ts DESC) AS rn
@@ -1750,11 +1763,9 @@ func (p *SQLiteProvider) GetQueryExpressions(ctx context.Context, params QueryEx
                 (SELECT l.queryParam FROM latest l WHERE l.fingerprint = f.fingerprint AND l.rn = 1) AS query
             FROM filtered f
             GROUP BY f.fingerprint
-        ), counted AS (
-            SELECT COUNT(*) AS total_count FROM grouped
         )
-        SELECT fingerprint, query, executions, avgDuration, errorRatePercent, peakSamples, total_count
-        FROM grouped, counted
+        SELECT fingerprint, query, executions, avgDuration, errorRatePercent, peakSamples
+        FROM grouped
         ORDER BY
             CASE WHEN ? = 'asc' THEN
                 CASE ?
@@ -1777,7 +1788,10 @@ func (p *SQLiteProvider) GetQueryExpressions(ctx context.Context, params QueryEx
         LIMIT ? OFFSET ?;
     `
 
-	args := []interface{}{from, to, params.Filter, params.Filter, params.SortOrder, params.SortBy, params.SortOrder, params.SortBy, params.PageSize, (params.Page - 1) * params.PageSize}
+	args := append(append([]interface{}{}, filterArgs...),
+		params.SortOrder, params.SortBy, params.SortOrder, params.SortBy,
+		params.PageSize, (params.Page-1)*params.PageSize,
+	)
 
 	rows, err := p.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1785,13 +1799,10 @@ func (p *SQLiteProvider) GetQueryExpressions(ctx context.Context, params QueryEx
 	}
 	defer CloseResource(rows)
 
-	var (
-		results    []QueryExpression
-		totalCount int
-	)
+	var results []QueryExpression
 	for rows.Next() {
 		var r QueryExpression
-		if err := rows.Scan(&r.Fingerprint, &r.Query, &r.Executions, &r.AvgDuration, &r.ErrorRatePercent, &r.PeakSamples, &totalCount); err != nil {
+		if err := rows.Scan(&r.Fingerprint, &r.Query, &r.Executions, &r.AvgDuration, &r.ErrorRatePercent, &r.PeakSamples); err != nil {
 			return PagedResult{}, fmt.Errorf("failed to scan row: %w", err)
 		}
 		results = append(results, r)
@@ -1822,6 +1833,25 @@ func (p *SQLiteProvider) GetQueryExecutions(ctx context.Context, params QueryExe
 
 	from, to := PrepareTimeRange(params.TimeRange, "sqlite")
 
+	// filterClause is shared with the count query below (see countMatching)
+	// so both see the identical row set.
+	filterClause := `
+		julianday(substr(REPLACE(REPLACE(ts, 'T', ' '), 'Z', ''),1,19))
+			  BETWEEN julianday(?) AND julianday(?)
+		  AND fingerprint = ?
+		  AND CASE WHEN ? != '' THEN type = ? ELSE 1=1 END
+	`
+	filterArgs := []interface{}{from, to, params.Fingerprint, params.Type, params.Type}
+
+	countQuery := `SELECT COUNT(*) FROM queries WHERE ` + filterClause
+	totalCount, err := countMatching(ctx, p.db, countQuery, filterArgs...)
+	if err != nil {
+		return PagedResult{}, fmt.Errorf("failed to count executions: %w", err)
+	}
+	if totalCount == 0 {
+		return PagedResult{Total: 0, TotalPages: 0, Data: []QueryExecutionRow{}}, nil
+	}
+
 	query := `
         WITH filtered AS (
             SELECT
@@ -1836,12 +1866,7 @@ func (p *SQLiteProvider) GetQueryExecutions(ctx context.Context, params QueryExe
 				httpHeaders,
                 julianday(substr(REPLACE(REPLACE(ts, 'T', ' '), 'Z', ''),1,19)) AS nts
             FROM queries
-            WHERE julianday(substr(REPLACE(REPLACE(ts, 'T', ' '), 'Z', ''),1,19))
-                  BETWEEN julianday(?) AND julianday(?)
-              AND fingerprint = ?
-              AND CASE WHEN ? != '' THEN type = ? ELSE 1=1 END
-        ), counted AS (
-            SELECT COUNT(*) AS total_count FROM filtered
+            WHERE ` + filterClause + `
         )
         SELECT
             ts,
@@ -1852,9 +1877,8 @@ func (p *SQLiteProvider) GetQueryExecutions(ctx context.Context, params QueryExe
 			httpHeaders,
 			start,
 			"end",
-            COALESCE(step, 0) AS steps,
-            total_count
-        FROM filtered, counted
+            COALESCE(step, 0) AS steps
+        FROM filtered
         ORDER BY
             CASE WHEN ? = 'asc' THEN
                 CASE ?
@@ -1879,10 +1903,10 @@ func (p *SQLiteProvider) GetQueryExecutions(ctx context.Context, params QueryExe
         LIMIT ? OFFSET ?;
     `
 
-	args := []interface{}{from, to, params.Fingerprint, params.Type, params.Type,
+	args := append(append([]interface{}{}, filterArgs...),
 		params.SortOrder, params.SortBy, params.SortOrder, params.SortBy,
-		params.PageSize, (params.Page - 1) * params.PageSize,
-	}
+		params.PageSize, (params.Page-1)*params.PageSize,
+	)
 
 	rows, err := p.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1890,10 +1914,7 @@ func (p *SQLiteProvider) GetQueryExecutions(ctx context.Context, params QueryExe
 	}
 	defer CloseResource(rows)
 
-	var (
-		results    []QueryExecutionRow
-		totalCount int
-	)
+	var results []QueryExecutionRow
 	for rows.Next() {
 		var ts time.Time
 		var status int
@@ -1904,7 +1925,7 @@ func (p *SQLiteProvider) GetQueryExecutions(ctx context.Context, params QueryExe
 		var start time.Time
 		var end time.Time
 		var httpHeadersJSON string
-		if err := rows.Scan(&ts, &status, &duration, &samples, &typ, &httpHeadersJSON, &start, &end, &steps, &totalCount); err != nil {
+		if err := rows.Scan(&ts, &status, &duration, &samples, &typ, &httpHeadersJSON, &start, &end, &steps); err != nil {
 			return PagedResult{}, fmt.Errorf("failed to scan row: %w", err)
 		}
 		r := QueryExecutionRow{Timestamp: ts, Status: status, Duration: duration, Samples: samples, Type: typ, Steps: steps, Start: start, End: end}

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"log/slog"
 	"os"
 	"sort"
@@ -376,6 +377,74 @@ func TestSQLite_GetQueryExpressions_And_Executions(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestSQLite_TotalCountCorrectPastLastPage verifies GetQueriesBySerieName,
+// GetQueryExpressions, and GetQueryExecutions report the true total row
+// count even when the requested page is past the last page, not just
+// whatever fits inside the LIMIT/OFFSET window.
+func TestSQLite_TotalCountCorrectPastLastPage(t *testing.T) {
+	p, cleanup := newTestSQLiteProvider(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Minute)
+	tr := TimeRange{From: now.Add(-1 * time.Hour), To: now.Add(1 * time.Hour)}
+
+	t.Run("GetQueriesBySerieName", func(t *testing.T) {
+		var qs []Query
+		for i := 1; i <= 3; i++ {
+			qs = append(qs, Query{
+				TS: now.Add(time.Duration(i) * time.Minute), QueryParam: fmt.Sprintf("qbsn_variant_%d", i),
+				TimeParam: now, Duration: time.Duration(i*10) * time.Millisecond, StatusCode: 200,
+				LabelMatchers: LabelMatchers{{"__name__": "up"}}, Type: QueryTypeInstant,
+			})
+		}
+		mustInsertQueries(t, p, qs)
+
+		out, err := p.GetQueriesBySerieName(context.Background(), QueriesBySerieNameParams{
+			SerieName: "up", Filter: "qbsn_variant", TimeRange: tr, Page: 10, PageSize: 1, SortBy: "avgDuration", SortOrder: "desc",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, out.Total, "Total must reflect all matching rows, not just what fits in this page's window")
+	})
+
+	t.Run("GetQueryExpressions", func(t *testing.T) {
+		var qs []Query
+		for i := 1; i <= 3; i++ {
+			qs = append(qs, Query{
+				TS: now.Add(time.Duration(i) * time.Minute), QueryParam: fmt.Sprintf("qe_expr_%d", i),
+				TimeParam: now, Duration: 10 * time.Millisecond, StatusCode: 200,
+				LabelMatchers: LabelMatchers{{"__name__": "up"}}, Type: QueryTypeInstant,
+				Fingerprint: fmt.Sprintf("qe_fp_%d", i),
+			})
+		}
+		mustInsertQueries(t, p, qs)
+
+		out, err := p.GetQueryExpressions(context.Background(), QueryExpressionsParams{
+			Filter: "qe_expr", TimeRange: tr, Page: 10, PageSize: 1, SortBy: "executions", SortOrder: "desc",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, out.Total, "Total must reflect all matching rows, not just what fits in this page's window")
+	})
+
+	t.Run("GetQueryExecutions", func(t *testing.T) {
+		var qs []Query
+		for i := 1; i <= 3; i++ {
+			qs = append(qs, Query{
+				TS: now.Add(time.Duration(i) * time.Minute), QueryParam: "up",
+				TimeParam: now, Duration: 10 * time.Millisecond, StatusCode: 200,
+				LabelMatchers: LabelMatchers{{"__name__": "up"}}, Type: QueryTypeInstant,
+				Fingerprint: "qexec_fp",
+			})
+		}
+		mustInsertQueries(t, p, qs)
+
+		out, err := p.GetQueryExecutions(context.Background(), QueryExecutionsParams{
+			Fingerprint: "qexec_fp", TimeRange: tr, Page: 10, PageSize: 1, SortBy: "ts", SortOrder: "desc",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, out.Total, "Total must reflect all matching rows, not just what fits in this page's window")
+	})
 }
 
 // -------------------- Metrics Inventory --------------------


### PR DESCRIPTION
GetQueriesBySerieName, GetQueryExpressions, and GetQueryExecutions (both
backends) embedded their total row count as a column on each paged
result row via a CROSS JOIN with a `COUNT(*)` CTE, then applied
`LIMIT`/`OFFSET` to that joined set. Once the requested page fell past
the last page, the `LIMIT`/`OFFSET` window returned zero rows - leaving
no row to read the total from, so the methods silently reported
`Total: 0` instead of the true count. A caller paging past the end would
see "no results" instead of "you've gone past N total results".

Each method now runs a `COUNT` query independent of the paged query,
sharing a `WHERE`-clause fragment so both see the identical row set.
This matches the pattern `GetRulesUsage`/`GetDashboardUsage` already
use, so those two are switched to the same `countMatching` helper
(common.go) this fix introduces instead of leaving a fourth and fifth
copy of the same inline `QueryRowContext(...).Scan(&total)` block.

Covered by a new test on each backend
(`TestPostgreSQL/SQLite_TotalCountCorrectPastLastPage`) that pins the
correct `Total` on a page past the last one for all three methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)