### PR TITLE
refactor(leaderelection): describe a won term as an acquisition

### DIFF
--- a/internal/leaderelection/advisory.go
+++ b/internal/leaderelection/advisory.go
@@ -89,26 +89,26 @@ func newAdvisoryLockStrategy(db connGetter) *advisoryLockStrategy {
 	return &advisoryLockStrategy{db: db, livenessInterval: defaultLivenessInterval}
 }
 
-func (s *advisoryLockStrategy) acquireOrHold(ctx context.Context, name string) (context.Context, func(), bool, error) {
+func (s *advisoryLockStrategy) acquireOrHold(ctx context.Context, name string) (acquisition, bool, error) {
 	key := lockKeyFor(name)
 
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return nil, nil, false, err
+		return acquisition{}, false, err
 	}
 
 	var got bool
 	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", key).Scan(&got); err != nil {
 		_ = conn.Close()
-		return nil, nil, false, err
+		return acquisition{}, false, err
 	}
 	if !got {
 		_ = conn.Close()
-		return nil, nil, false, nil
+		return acquisition{}, false, nil
 	}
 
 	leaderCtx, release := newHeldLease(ctx, &pqAdvisoryConn{c: conn}, key, name, s.livenessInterval)
-	return leaderCtx, release, true, nil
+	return acquisition{leaderCtx: leaderCtx, release: release}, true, nil
 }
 
 // newHeldLease builds the leaderCtx/release pair for a lock already held on

--- a/internal/leaderelection/advisory_leak_test.go
+++ b/internal/leaderelection/advisory_leak_test.go
@@ -28,14 +28,15 @@ func TestAdvisoryStrategy_RepeatedOperations_DoNotLeakConnections(t *testing.T) 
 		loser := newAdvisoryLockStrategy(db)
 
 		ctx := context.Background()
-		_, release, ok, err := winner.acquireOrHold(ctx, "leak-contention-test")
+		acq, ok, err := winner.acquireOrHold(ctx, "leak-contention-test")
+		release := acq.release
 		require.NoError(t, err) // release() below would nil-panic on failure to acquire
 		require.True(t, ok)
 		defer release()
 
 		const attempts = 50
 		for i := 0; i < attempts; i++ {
-			_, _, ok, err := loser.acquireOrHold(ctx, "leak-contention-test")
+			_, ok, err := loser.acquireOrHold(ctx, "leak-contention-test")
 			assert.NoError(t, err)
 			assert.False(t, ok, "still held by winner")
 		}
@@ -56,7 +57,8 @@ func TestAdvisoryStrategy_RepeatedOperations_DoNotLeakConnections(t *testing.T) 
 
 		const cycles = 50
 		for i := 0; i < cycles; i++ {
-			_, release, ok, err := strat.acquireOrHold(ctx, "leak-cycle-test")
+			acq, ok, err := strat.acquireOrHold(ctx, "leak-cycle-test")
+			release := acq.release
 			require.NoError(t, err) // release() below would nil-panic on failure to acquire
 			require.True(t, ok)
 			release()

--- a/internal/leaderelection/advisory_release_test.go
+++ b/internal/leaderelection/advisory_release_test.go
@@ -23,7 +23,8 @@ func TestAdvisoryStrategy_ReleasesLockExplicitly_NotJustViaConnClose(t *testing.
 	strat := newAdvisoryLockStrategy(db)
 
 	ctx := context.Background()
-	_, release, ok, err := strat.acquireOrHold(ctx, "release-test")
+	acq, ok, err := strat.acquireOrHold(ctx, "release-test")
+	release := acq.release
 	require.NoError(t, err) // release() below would nil-panic on failure to acquire
 	require.True(t, ok)
 

--- a/internal/leaderelection/advisory_strategy_test.go
+++ b/internal/leaderelection/advisory_strategy_test.go
@@ -55,7 +55,8 @@ func TestAdvisoryStrategy_MutualExclusion_ConcurrentGoroutines(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for ctx.Err() == nil {
-				_, release, ok, err := strat.acquireOrHold(ctx, "mutex-test")
+				acq, ok, err := strat.acquireOrHold(ctx, "mutex-test")
+				release := acq.release
 				if err != nil {
 					// ctx expiring mid-attempt right at the test's own
 					// deadline is expected shutdown noise, not a failure of

--- a/internal/leaderelection/elector.go
+++ b/internal/leaderelection/elector.go
@@ -54,7 +54,7 @@ func (e *elector) Run(ctx context.Context, name string, fn func(context.Context)
 			return nil
 		}
 
-		leaderCtx, release, ok, err := e.strat.acquireOrHold(ctx, name)
+		acq, ok, err := e.strat.acquireOrHold(ctx, name)
 		if err != nil {
 			// Must never cause a silent, permanent return — the only event
 			// allowed to stop this loop is ctx being canceled — but must
@@ -86,7 +86,7 @@ func (e *elector) Run(ctx context.Context, name string, fn func(context.Context)
 		e.m.isLeader.WithLabelValues(name).Set(1)
 		e.m.transitions.WithLabelValues(name, "leader").Inc()
 
-		runAndRelease(leaderCtx, fn, release, name)
+		runAndRelease(acq, fn, name)
 
 		e.m.isLeader.WithLabelValues(name).Set(0)
 		e.m.transitions.WithLabelValues(name, "follower").Inc()
@@ -104,15 +104,15 @@ func (e *elector) Run(ctx context.Context, name string, fn func(context.Context)
 // panic is logged and re-raised, not swallowed — deferred calls still run
 // to completion during that re-panic's unwind, so release() executes
 // before it escapes this function.
-func runAndRelease(leaderCtx context.Context, fn func(context.Context), release func(), name string) {
-	defer release()
+func runAndRelease(acq acquisition, fn func(context.Context), name string) {
+	defer acq.release()
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("leader-elected fn panicked; releasing lock before repanicking", "lease", name, "panic", r)
 			panic(r)
 		}
 	}()
-	fn(leaderCtx)
+	fn(acq.leaderCtx)
 }
 
 // sleep waits for d or ctx cancellation, whichever comes first, reporting

--- a/internal/leaderelection/elector_backoff_test.go
+++ b/internal/leaderelection/elector_backoff_test.go
@@ -23,11 +23,11 @@ type recordingStrategy struct {
 	returnErr error
 }
 
-func (s *recordingStrategy) acquireOrHold(ctx context.Context, name string) (context.Context, func(), bool, error) {
+func (s *recordingStrategy) acquireOrHold(ctx context.Context, name string) (acquisition, bool, error) {
 	s.mu.Lock()
 	s.times = append(s.times, time.Now())
 	s.mu.Unlock()
-	return nil, nil, false, s.returnErr
+	return acquisition{}, false, s.returnErr
 }
 
 func (s *recordingStrategy) snapshot() []time.Time {
@@ -128,7 +128,7 @@ type failThenSucceedOnceStrategy struct {
 	succeeded          bool
 }
 
-func (s *failThenSucceedOnceStrategy) acquireOrHold(ctx context.Context, _ string) (context.Context, func(), bool, error) {
+func (s *failThenSucceedOnceStrategy) acquireOrHold(ctx context.Context, _ string) (acquisition, bool, error) {
 	s.mu.Lock()
 	s.times = append(s.times, time.Now())
 	s.attempts++
@@ -141,9 +141,9 @@ func (s *failThenSucceedOnceStrategy) acquireOrHold(ctx context.Context, _ strin
 		s.succeeded = true
 		s.mu.Unlock()
 		leaderCtx, cancel := context.WithCancel(ctx)
-		return leaderCtx, cancel, true, nil
+		return acquisition{leaderCtx: leaderCtx, release: cancel}, true, nil
 	}
-	return nil, nil, false, errors.New("simulated error")
+	return acquisition{}, false, errors.New("simulated error")
 }
 
 func (s *failThenSucceedOnceStrategy) snapshot() []time.Time {

--- a/internal/leaderelection/lease.go
+++ b/internal/leaderelection/lease.go
@@ -79,13 +79,13 @@ func newLeaseStrategy(db *sql.DB, ttl, renewInterval time.Duration) *leaseStrate
 	return &leaseStrategy{db: db, ttl: ttl, renewInterval: renewInterval, holderID: uuid.NewString()}
 }
 
-func (s *leaseStrategy) acquireOrHold(ctx context.Context, name string) (context.Context, func(), bool, error) {
+func (s *leaseStrategy) acquireOrHold(ctx context.Context, name string) (acquisition, bool, error) {
 	_, ok, err := s.tryAcquireOrRenew(ctx, name)
 	if err != nil {
-		return nil, nil, false, err
+		return acquisition{}, false, err
 	}
 	if !ok {
-		return nil, nil, false, nil
+		return acquisition{}, false, nil
 	}
 
 	// Leadership acquired. A background watchdog renews on renewInterval
@@ -108,7 +108,7 @@ func (s *leaseStrategy) acquireOrHold(ctx context.Context, name string) (context
 			slog.Warn("releasing lease failed; next holder will wait out the TTL", "lease", name, "err", err)
 		}
 	}
-	return leaderCtx, release, true, nil
+	return acquisition{leaderCtx: leaderCtx, release: release}, true, nil
 }
 
 // leaseRenewer is the seam watchdog needs to attempt a renewal — a

--- a/internal/leaderelection/lease_failover_test.go
+++ b/internal/leaderelection/lease_failover_test.go
@@ -32,17 +32,17 @@ func TestLeaseStrategy_FailoverAfterUngracefulDeath(t *testing.T) {
 	holderB := newLeaseStrategy(db, ttl, noRenewal)
 
 	ctx := context.Background()
-	_, _, ok, err := holderA.acquireOrHold(ctx, "failover-test")
+	_, ok, err := holderA.acquireOrHold(ctx, "failover-test")
 	assert.NoError(t, err)
 	assert.True(t, ok)
 	// holderA "dies" here: no further acquireOrHold or release calls.
 
-	_, _, ok, err = holderB.acquireOrHold(ctx, "failover-test")
+	_, ok, err = holderB.acquireOrHold(ctx, "failover-test")
 	assert.NoError(t, err)
 	assert.False(t, ok, "the lease must not transfer before the TTL elapses")
 
 	assert.Eventually(t, func() bool {
-		_, _, ok, err := holderB.acquireOrHold(ctx, "failover-test")
+		_, ok, err := holderB.acquireOrHold(ctx, "failover-test")
 		return err == nil && ok
 	}, ttl*4, 10*time.Millisecond, "holder B should acquire the lease shortly after holder A's TTL expires")
 }

--- a/internal/leaderelection/lease_renewal_test.go
+++ b/internal/leaderelection/lease_renewal_test.go
@@ -64,7 +64,7 @@ func TestElector_Run_HoldsLeadershipAcrossMultipleRenewalTicks(t *testing.T) {
 		default:
 		}
 
-		_, _, ok, err := rival.acquireOrHold(context.Background(), "sustained-renewal-test")
+		_, ok, err := rival.acquireOrHold(context.Background(), "sustained-renewal-test")
 		assert.NoError(t, err)
 		assert.False(t, ok, "the lease must still be held by the original holder throughout the hold window")
 

--- a/internal/leaderelection/lease_test.go
+++ b/internal/leaderelection/lease_test.go
@@ -22,7 +22,9 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 	t.Run("AcquireWhenFree_Succeeds", func(t *testing.T) {
 		strat := newLeaseStrategy(db, time.Second, noRenewal)
 
-		_, release, ok, err := strat.acquireOrHold(context.Background(), "lifecycle-test")
+		acq, ok, err := strat.acquireOrHold(context.Background(), "lifecycle-test")
+
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok)
 		defer release()
@@ -41,7 +43,9 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		leaderCtx, release, ok, err := strat.acquireOrHold(ctx, "canceled-ctx-test")
+		acq, ok, err := strat.acquireOrHold(ctx, "canceled-ctx-test")
+
+		leaderCtx, release := acq.leaderCtx, acq.release
 		assert.Error(t, err)
 		assert.False(t, ok)
 		assert.Nil(t, leaderCtx)
@@ -52,12 +56,14 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		holderA := newLeaseStrategy(db, time.Second, noRenewal)
 		holderB := newLeaseStrategy(db, time.Second, noRenewal)
 
-		_, release, ok, err := holderA.acquireOrHold(context.Background(), "contended-test")
+		acq, ok, err := holderA.acquireOrHold(context.Background(), "contended-test")
+
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok)
 		defer release()
 
-		_, _, ok, err = holderB.acquireOrHold(context.Background(), "contended-test")
+		_, ok, err = holderB.acquireOrHold(context.Background(), "contended-test")
 		assert.NoError(t, err)
 		assert.False(t, ok, "a second holder must not acquire a lease still held by someone else")
 	})
@@ -66,7 +72,7 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		holderA := newLeaseStrategy(db, 50*time.Millisecond, noRenewal)
 		holderB := newLeaseStrategy(db, time.Second, noRenewal)
 
-		_, _, ok, err := holderA.acquireOrHold(context.Background(), "expiry-test")
+		_, ok, err := holderA.acquireOrHold(context.Background(), "expiry-test")
 		assert.NoError(t, err)
 		assert.True(t, ok)
 		// holderA never renews again, and noRenewal keeps its watchdog
@@ -75,7 +81,9 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 
-		_, release, ok, err := holderB.acquireOrHold(context.Background(), "expiry-test")
+		acq, ok, err := holderB.acquireOrHold(context.Background(), "expiry-test")
+
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok, "a lease must become acquirable again once it has expired")
 		defer release()
@@ -85,7 +93,8 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		holderA := newLeaseStrategy(db, time.Second, noRenewal)
 
 		ctx := context.Background()
-		_, release, ok, err := holderA.acquireOrHold(ctx, "renew-test")
+		acq, ok, err := holderA.acquireOrHold(ctx, "renew-test")
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok)
 		defer release()
@@ -93,7 +102,8 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		tokenAfterAcquire, expiresAfterAcquire := queryLease(t, db, "renew-test")
 
 		time.Sleep(10 * time.Millisecond)
-		_, release2, ok, err := holderA.acquireOrHold(ctx, "renew-test")
+		acq2, ok, err := holderA.acquireOrHold(ctx, "renew-test")
+		release2 := acq2.release
 		require.NoError(t, err)
 		require.True(t, ok)
 		defer release2()
@@ -115,13 +125,15 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		holderA := newLeaseStrategy(db, time.Minute, noRenewal)
 		holderB := newLeaseStrategy(db, time.Minute, noRenewal)
 
-		_, release, ok, err := holderA.acquireOrHold(context.Background(), "handoff-test")
+		acq, ok, err := holderA.acquireOrHold(context.Background(), "handoff-test")
+
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok)
 
 		release()
 
-		_, _, ok, err = holderB.acquireOrHold(context.Background(), "handoff-test")
+		_, ok, err = holderB.acquireOrHold(context.Background(), "handoff-test")
 		assert.NoError(t, err)
 		assert.True(t, ok, "a graceful release must let another holder acquire immediately, without waiting out the TTL")
 	})
@@ -146,7 +158,9 @@ func TestLeaseStrategy_Release_LogsWarningWhenExpiryUpdateFails(t *testing.T) {
 	db := newTestPostgresDB(t)
 	strat := newLeaseStrategy(db, time.Second, noRenewal)
 
-	_, release, ok, err := strat.acquireOrHold(context.Background(), "release-error-test")
+	acq, ok, err := strat.acquireOrHold(context.Background(), "release-error-test")
+
+	release := acq.release
 	require.NoError(t, err)
 	require.True(t, ok)
 

--- a/internal/leaderelection/strategy.go
+++ b/internal/leaderelection/strategy.go
@@ -14,11 +14,21 @@ type strategy interface {
 	//     caller backs off and retries — err is logged, never returned up
 	//     through Elector.Run. No error from acquireOrHold may ever cause
 	//     a silent, permanent stop; only ctx cancellation may.
-	//   - ok=true: caller now holds leadership. leaderCtx is derived from
-	//     ctx and MUST be canceled — by release(), or internally by the
-	//     strategy the moment leadership is lost — the instant leadership
-	//     ends, even mid-fn. release() must be safe to call exactly once
-	//     and must physically release the underlying lock/lease itself,
-	//     never relying on connection-pool GC to do so eventually.
-	acquireOrHold(ctx context.Context, name string) (leaderCtx context.Context, release func(), ok bool, err error)
+	//   - ok=true: caller now holds leadership, described by the returned
+	//     acquisition.
+	acquireOrHold(ctx context.Context, name string) (acquisition, bool, error)
+}
+
+// acquisition is one term of leadership as the strategy that granted it
+// describes it. Its zero value is what a strategy returns when it didn't
+// win, alongside ok=false.
+type acquisition struct {
+	// leaderCtx is derived from the ctx passed to acquireOrHold and MUST be
+	// canceled — by release, or internally by the strategy the moment
+	// leadership is lost — the instant leadership ends, even mid-fn.
+	leaderCtx context.Context
+	// release must be safe to call exactly once and must physically release
+	// the underlying lock or lease itself, never relying on connection-pool
+	// GC to do so eventually.
+	release func()
 }

--- a/internal/leaderelection/testhelpers_test.go
+++ b/internal/leaderelection/testhelpers_test.go
@@ -106,13 +106,13 @@ type releaseTrackingStrategy struct {
 	released atomic.Bool
 }
 
-func (s *releaseTrackingStrategy) acquireOrHold(ctx context.Context, _ string) (context.Context, func(), bool, error) {
+func (s *releaseTrackingStrategy) acquireOrHold(ctx context.Context, _ string) (acquisition, bool, error) {
 	leaderCtx, cancel := context.WithCancel(ctx)
 	release := func() {
 		cancel()
 		s.released.Store(true)
 	}
-	return leaderCtx, release, true, nil
+	return acquisition{leaderCtx: leaderCtx, release: release}, true, nil
 }
 
 // recordingHandler is a hand-written slog.Handler fake that records every


### PR DESCRIPTION
`strategy.acquireOrHold` returns four values, three of which only mean anything together: the context leadership lives in, the release that ends it, and whether leadership was won at all. Every failure path spells that out as `nil, nil, false, err`, every caller unpacks it positionally, and the constraints that actually matter — `leaderCtx` must be canceled the instant leadership ends, `release` must be safe to call exactly once and must physically release the underlying lock rather than relying on connection-pool GC — live in a comment above the signature rather than anywhere near the values they constrain.

This replaces those three with an `acquisition` struct:

```go
acquireOrHold(ctx context.Context, name string) (acquisition, bool, error)
```

so each contract sits on the field it governs, a strategy that didn't win returns the zero value, and `runAndRelease` takes what it releases as a single argument instead of a context and a func that have to be passed in step.

No behaviour change: both strategies grant and release leadership exactly as before, and the existing tests — including the advisory-lock contention and lease failover suites against a real PostgreSQL — pass unchanged in intent.

The benefit is in the contract's placement. A side effect worth noting is that the shape absorbs change better than a positional return did: should a strategy ever need to hand back something more about the term it just granted, that would be a field rather than a fifth return value threaded through every strategy and every test double.
