### PR TITLE
feat(config): range-validate job config before startup acts on it

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -376,6 +377,87 @@ func LoadConfig(path string) error {
 	}
 
 	return nil
+}
+
+// Validate reports config values no consumer could act on. Range checks
+// only: whether each value is one its field can mean anything as. How
+// values relate to one another - a job's cycle budget covering the steps it
+// runs, say - depends on what that job does with them, so it belongs to the
+// package that owns the job, not here.
+//
+// Called at startup before anything acts on the config, so a value that
+// would only surface as odd runtime behaviour surfaces as a startup error
+// instead - and only for the sections this process will run, since a
+// disabled job never reads its own values and no command reads both.
+func (c *Config) Validate() error {
+	if c == nil {
+		return fmt.Errorf("config is required")
+	}
+
+	// Only what this process will actually run: a job that is switched off
+	// never reads its own section, and the ingester command reads neither.
+	// Reporting all of it at once means an operator with two typos fixes
+	// both before restarting, rather than discovering the second one then.
+	var errs []error
+	if c.Inventory.Enabled {
+		errs = append(errs, c.Inventory.Validate())
+	}
+	if c.Retention.Enabled {
+		errs = append(errs, c.Retention.Validate())
+	}
+	return errors.Join(errs...)
+}
+
+// Validate range-checks the inventory syncer's own values. A step's values
+// are checked only when that step is enabled: a disabled step never reads
+// them, so a leftover value there can't affect anything.
+func (c InventoryConfig) Validate() error {
+	type field struct {
+		name  string
+		value time.Duration
+	}
+	positive := []field{
+		{"sync_interval", c.SyncInterval},
+		{"time_window", c.TimeWindow},
+		{"run_timeout", c.RunTimeout},
+		// Never gated by a flag, so it always has to be usable.
+		{"summary_step_timeout", c.SummaryStepTimeout},
+	}
+	if c.MetadataSyncEnabled {
+		positive = append(positive, field{"metadata_step_timeout", c.MetadataStepTimeout})
+	}
+	if c.JobSyncEnabled {
+		positive = append(positive,
+			field{"job_index_label_timeout", c.JobIndexLabelTimeout},
+			field{"job_index_per_job_timeout", c.JobIndexPerJobTimeout})
+	}
+	var errs []error
+	for _, f := range positive {
+		if f.value <= 0 {
+			errs = append(errs, fmt.Errorf("inventory.%s must be positive (got: %s)", f.name, f.value))
+		}
+	}
+	// Without a worker there's nothing to pull jobs off the fan-out channel,
+	// and the step reports success having indexed nothing.
+	if c.JobSyncEnabled && c.JobIndexWorkers <= 0 {
+		errs = append(errs, fmt.Errorf("inventory.job_index_workers must be positive (got: %d)", c.JobIndexWorkers))
+	}
+	return errors.Join(errs...)
+}
+
+// Validate range-checks the retention worker's own values.
+func (c RetentionConfig) Validate() error {
+	var errs []error
+	if c.Interval <= 0 {
+		errs = append(errs, fmt.Errorf("retention.interval must be positive (got: %v)", c.Interval))
+	}
+	if c.RunTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("retention.run_timeout must be positive (got: %v)", c.RunTimeout))
+	}
+	if c.QueriesMaxAge <= 0 {
+		errs = append(errs, fmt.Errorf("retention.queries_max_age must be positive (got: %v)", c.QueriesMaxAge))
+	}
+	return errors.Join(errs...)
 }
 
 func (c *Config) IsTracingEnabled() bool {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,234 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validInventory and validRetention are the shipped defaults, which every
+// case below starts from so it only has to state the one field it's about.
+func validInventory() InventoryConfig {
+	c := DefaultConfig.Inventory
+	c.JobSyncEnabled = true // so the job-index step's own values are in play
+	return c
+}
+
+func validRetention() RetentionConfig {
+	c := DefaultConfig.Retention
+	c.Enabled = true
+	return c
+}
+
+func TestInventoryConfig_Validate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		tweak    func(*InventoryConfig)
+		wantErr  string   // empty means the config must be accepted
+		wantErrs []string // every message the one error must carry
+	}{
+		{name: "shipped defaults", tweak: func(*InventoryConfig) {}},
+		{
+			name:    "sync_interval zero",
+			tweak:   func(c *InventoryConfig) { c.SyncInterval = 0 },
+			wantErr: "inventory.sync_interval must be positive",
+		},
+		{
+			name:    "sync_interval negative",
+			tweak:   func(c *InventoryConfig) { c.SyncInterval = -time.Minute },
+			wantErr: "inventory.sync_interval must be positive",
+		},
+		{
+			// A window ending before it starts silently finds no usage at
+			// all, which reads as "every metric is unused".
+			name:    "time_window zero",
+			tweak:   func(c *InventoryConfig) { c.TimeWindow = 0 },
+			wantErr: "inventory.time_window must be positive",
+		},
+		{
+			name:    "run_timeout zero",
+			tweak:   func(c *InventoryConfig) { c.RunTimeout = 0 },
+			wantErr: "inventory.run_timeout must be positive",
+		},
+		{
+			name:    "run_timeout negative",
+			tweak:   func(c *InventoryConfig) { c.RunTimeout = -time.Second },
+			wantErr: "inventory.run_timeout must be positive",
+		},
+		{
+			// Never gated, so it's checked whatever else is switched off.
+			name: "summary_step_timeout zero with every other step disabled",
+			tweak: func(c *InventoryConfig) {
+				c.SummaryStepTimeout = 0
+				c.MetadataSyncEnabled, c.JobSyncEnabled = false, false
+			},
+			wantErr: "inventory.summary_step_timeout must be positive",
+		},
+		{
+			name:    "metadata_step_timeout negative while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.MetadataStepTimeout = -5 * time.Second },
+			wantErr: "inventory.metadata_step_timeout must be positive",
+		},
+		{
+			name: "metadata_step_timeout negative while its step is disabled",
+			tweak: func(c *InventoryConfig) {
+				c.MetadataSyncEnabled = false
+				c.MetadataStepTimeout = -5 * time.Second
+			},
+		},
+		{
+			// The one that would otherwise index nothing in silence: a
+			// label fetch on an already-expired context fails, and that
+			// error is treated as "no series carry a job label".
+			name:    "job_index_label_timeout zero while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.JobIndexLabelTimeout = 0 },
+			wantErr: "inventory.job_index_label_timeout must be positive",
+		},
+		{
+			name:    "job_index_per_job_timeout negative while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.JobIndexPerJobTimeout = -time.Second },
+			wantErr: "inventory.job_index_per_job_timeout must be positive",
+		},
+		{
+			name:    "job_index_workers zero while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.JobIndexWorkers = 0 },
+			wantErr: "inventory.job_index_workers must be positive",
+		},
+		{
+			name: "every job-index value unusable while its step is disabled",
+			tweak: func(c *InventoryConfig) {
+				c.JobSyncEnabled = false
+				c.JobIndexLabelTimeout, c.JobIndexPerJobTimeout = 0, -time.Second
+				c.JobIndexWorkers = 0
+			},
+		},
+		{
+			// Every bad value at once: an operator with several typos should
+			// see all of them, not one per restart.
+			name: "several unusable values",
+			tweak: func(c *InventoryConfig) {
+				c.SyncInterval, c.RunTimeout, c.SummaryStepTimeout = 0, 0, 0
+			},
+			wantErrs: []string{
+				"inventory.sync_interval must be positive",
+				"inventory.run_timeout must be positive",
+				"inventory.summary_step_timeout must be positive",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validInventory()
+			tc.tweak(&cfg)
+
+			err := cfg.Validate()
+
+			if tc.wantErr == "" && tc.wantErrs == nil {
+				assert.NoError(t, err, "a disabled step's own values can't affect anything, so they don't have to be usable")
+				return
+			}
+			require.Error(t, err)
+			if tc.wantErr != "" {
+				assert.Contains(t, err.Error(), tc.wantErr)
+			}
+			for _, want := range tc.wantErrs {
+				assert.Contains(t, err.Error(), want, "every unusable value has to be reported, not just the first")
+			}
+		})
+	}
+}
+
+func TestRetentionConfig_Validate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		tweak   func(*RetentionConfig)
+		wantErr string
+	}{
+		{name: "shipped defaults", tweak: func(*RetentionConfig) {}},
+		{
+			name:    "interval zero",
+			tweak:   func(c *RetentionConfig) { c.Interval = 0 },
+			wantErr: "retention.interval must be positive",
+		},
+		{
+			name:    "run_timeout negative",
+			tweak:   func(c *RetentionConfig) { c.RunTimeout = -time.Minute },
+			wantErr: "retention.run_timeout must be positive",
+		},
+		{
+			name:    "queries_max_age zero",
+			tweak:   func(c *RetentionConfig) { c.QueriesMaxAge = 0 },
+			wantErr: "retention.queries_max_age must be positive",
+		},
+		{
+			// Checked whether or not the worker runs: an unusable value is
+			// an operator's typo either way, and enabling the job later
+			// shouldn't be what surfaces it.
+			name: "queries_max_age zero while the job is disabled",
+			tweak: func(c *RetentionConfig) {
+				c.Enabled = false
+				c.QueriesMaxAge = 0
+			},
+			wantErr: "retention.queries_max_age must be positive",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validRetention()
+			tc.tweak(&cfg)
+
+			err := cfg.Validate()
+
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestConfig_Validate_ReportsEverySectionItRuns proves the aggregate reaches
+// both jobs' sections and reports them together, so startup can't pass on a
+// config either of them would reject, and an operator sees every problem in
+// one go.
+func TestConfig_Validate_ReportsEverySectionItRuns(t *testing.T) {
+	cfg := *DefaultConfig
+	cfg.Inventory.Enabled, cfg.Retention.Enabled = true, true
+	cfg.Inventory.SyncInterval = 0
+	cfg.Retention.QueriesMaxAge = 0
+
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inventory.sync_interval")
+	assert.Contains(t, err.Error(), "retention.queries_max_age", "both sections' problems must arrive together")
+
+	var nilCfg *Config
+	require.ErrorContains(t, nilCfg.Validate(), "config is required")
+}
+
+// TestConfig_Validate_SkipsSectionsThisProcessWontRun proves a job switched
+// off is not a reason to refuse startup: its values are never read, and the
+// ingester command reads neither section, so a config carrying a stale
+// disabled block still starts.
+func TestConfig_Validate_SkipsSectionsThisProcessWontRun(t *testing.T) {
+	cfg := *DefaultConfig
+	cfg.Inventory.Enabled, cfg.Retention.Enabled = false, false
+	cfg.Inventory.SyncInterval = 0
+	cfg.Retention.QueriesMaxAge = 0
+
+	assert.NoError(t, cfg.Validate())
+}
+
+// TestConfig_Validate_AcceptsTheShippedDefaults guards the defaults against
+// their own range rules: every default a job reads has to be usable as
+// shipped, with or without the steps that are gated off by default.
+func TestConfig_Validate_AcceptsTheShippedDefaults(t *testing.T) {
+	require.NoError(t, DefaultConfig.Validate())
+
+	withJobSync := *DefaultConfig
+	withJobSync.Inventory.JobSyncEnabled = true
+	require.NoError(t, withJobSync.Validate())
+}

--- a/main.go
+++ b/main.go
@@ -114,6 +114,14 @@ func main() {
 		}
 	}
 	config.LogConfig(cmd)
+	// Before anything acts on the config: a value no consumer could use is
+	// an operator's typo, and this is the last point at which saying so
+	// costs nothing - past here, startup opens the database and runs
+	// migrations.
+	if err := config.DefaultConfig.Validate(); err != nil {
+		slog.Error("invalid configuration", "err", err)
+		os.Exit(1)
+	}
 	configureGoMemLimit(logger, config.DefaultConfig.MemoryLimit)
 	var shutdown func()
 	if config.DefaultConfig.IsTracingEnabled() {


### PR DESCRIPTION
Both the flags and the YAML currently accept a timeout that isn't a positive duration. `-inventory-job-index-label-timeout=-5s` parses fine, and the job-index step then runs on a context whose deadline has already passed.

How that surfaces varies only in visibility. A non-positive `metadata_step_timeout` fails the catalog step on every cycle, which at least lands in `inventory_sync_failure_total`. A non-positive `job_index_label_timeout` is worse: the label fetch's deadline error is deliberately treated as "no series carry a job label", so the step indexes nothing, permanently, while the cycle keeps reporting success. The same shape applies to `time_window` — a window ending before it starts finds no usage at all, which reads as "every metric is unused".

This adds `Validate` to `InventoryConfig` and `RetentionConfig`, aggregated by `Config.Validate`, and calls it from `main` before either command acts on the config. Range checks only: whether each value is one its field can mean anything as.

Two boundaries are deliberate.

**Where the rules live.** Range checks belong to the schema rather than to the jobs reading it — this package declares the fields, registers their flags and owns their YAML tags, and "a duration used as a timeout must be positive" needs no knowledge of what a job does with it. How values relate to each other — a cycle budget covering the steps it runs — does need that knowledge, and stays with the job that owns those steps. Each job's constructor still calls its own section's `Validate`, so the guarantee holds for callers that never went through startup.

**Nothing is corrected.** Substituting a default for an explicitly invalid value runs the process with a timing profile nobody asked for, leaving a warning line as the only trace. A value out of range is a typo, and failing at startup puts it in front of whoever just wrote it — before the process has opened the database and run every pending migration, which is where the existing constructor-time checks sit today.

A step's own values are checked only when that step is enabled, so a leftover value under a disabled feature doesn't make this a breaking change for configs that never used it. Tests cover each field and each gating case, plus that the shipped defaults pass with and without the job-index step.
