### PR TITLE
refactor(leaderelection): elect a sole instance where there is nothing to coordinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Flags (api):
     	Timeout for job label values collection (default 30s)
   -inventory-job-index-per-job-timeout duration
     	Timeout for processing each individual job (default 30s)
+  -inventory-job-index-timeout duration
+    	Timeout for the job index step as a whole (job label fetch plus every job processed) (default 4m0s)
   -inventory-job-index-workers int
     	Number of worker goroutines for job index processing (default 10)
   -inventory-metadata-sync-enabled
@@ -519,18 +521,25 @@ inventory:
                              # Set to false when using the OTLP ingester to populate the catalog instead.
   sync_interval: 10m         # How often to sync inventory (default: 10m)
   time_window: 720h          # Time window for usage analysis (default: 30 days)
-  run_timeout: 30s           # Timeout for entire sync run (default: 30s)
-  metadata_step_timeout: 15s # Timeout for metadata fetch (default: 15s)
-  summary_step_timeout: 10s  # Timeout for usage summary refresh (default: 10s)
-  job_index_label_timeout: 10s  # Timeout for job label fetch (default: 10s)
-  job_index_per_job_timeout: 5s # Timeout per job for series fetch (default: 5s)
+  run_timeout: 300s          # Timeout for an entire sync run (default: 300s)
+                             # Must be at least the sum of every enabled step timeout below;
+                             # a smaller value is raised to that sum at startup, with a warning.
+  metadata_step_timeout: 30s # Timeout for metadata fetch (default: 30s)
+  summary_step_timeout: 30s  # Timeout for usage summary refresh (default: 30s)
+  job_sync_enabled: false    # Build the per-job metric index (default: false)
+                             # When true, job_index_timeout counts toward run_timeout's minimum.
+  job_index_timeout: 240s    # Timeout for the job index step as a whole (default: 240s)
+  job_index_label_timeout: 30s   # Timeout for job label fetch (default: 30s)
+  job_index_per_job_timeout: 30s # Timeout per job for series fetch (default: 30s)
   job_index_workers: 10      # Number of concurrent workers for job processing (default: 10)
 ```
+
+**📖 See the [Background Jobs guide](docs/jobs.md) for what each step does, how the time budget fits together, and the same reference for the retention worker.**
 
 **Performance Notes:**
 
 - For environments with hundreds of jobs (500+), increase `job_index_workers` to 20-50 for faster processing
-- Increase `run_timeout` proportionally when processing many jobs (e.g., 300s for 1000+ jobs)
+- When processing many jobs, raise `job_index_timeout` — it, not `job_index_per_job_timeout`, is what bounds the step as a whole — and raise `run_timeout` by at least as much, since it has to stay above the sum of every enabled step
 - Each worker processes one job at a time, so more workers = faster job index building
 
 ### Ingester & Deployment Modes

--- a/cmd/api/periodic_job.go
+++ b/cmd/api/periodic_job.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/oklog/run"
 
-	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/leaderelection"
 )
 
@@ -18,22 +17,19 @@ type periodicJob interface {
 	RunOnce(ctx context.Context)
 }
 
-// addPeriodicJob wires job into g under leaseName: on PostgreSQL, through
-// pgElector so only the current leader runs its cycles; on any other
-// provider, scheduling them directly, since there's no leader to
-// coordinate. Both paths schedule the identical loop - leadership governs
-// who runs cycles, never how often they run.
-func addPeriodicJob(g *run.Group, provider db.DatabaseProvider, pgElector leaderelection.Elector, leaseName string, interval time.Duration, job periodicJob) {
+// addPeriodicJob wires job into g under leaseName, scheduling its cycles
+// for as long as elector says this replica holds that lease. Every provider
+// has an elector - a sole instance holds leadership unconditionally where
+// there's nothing to coordinate - so leadership governs who runs cycles and
+// never how often they run, and there is one path here rather than one per
+// provider.
+func addPeriodicJob(g *run.Group, elector leaderelection.Elector, leaseName string, interval time.Duration, job periodicJob) {
 	ctx, cancel := context.WithCancel(context.Background())
 	loop := func(loopCtx context.Context) { runPeriodically(loopCtx, interval, job.RunOnce) }
 
-	if provider == db.PostGreSQL {
-		g.Add(func() error {
-			return pgElector.Run(ctx, leaseName, loop)
-		}, func(err error) { cancel() })
-		return
-	}
-	g.Add(func() error { loop(ctx); return nil }, func(err error) { cancel() })
+	g.Add(func() error {
+		return elector.Run(ctx, leaseName, loop)
+	}, func(err error) { cancel() })
 }
 
 // runPeriodically calls runOnce once immediately, then once per interval

--- a/cmd/api/periodic_job.go
+++ b/cmd/api/periodic_job.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+
+	"github.com/oklog/run"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/leaderelection"
+)
+
+// periodicJob is the shape cmd/api needs from every job it schedules: one
+// cycle per call, bounded by the context it's given, neither looping nor
+// aware of who's calling it - see docs/jobs.md.
+type periodicJob interface {
+	RunOnce(ctx context.Context)
+}
+
+// addPeriodicJob wires job into g under leaseName: on PostgreSQL, through
+// pgElector so only the current leader runs its cycles; on any other
+// provider, scheduling them directly, since there's no leader to
+// coordinate. Both paths schedule the identical loop - leadership governs
+// who runs cycles, never how often they run.
+func addPeriodicJob(g *run.Group, provider db.DatabaseProvider, pgElector leaderelection.Elector, leaseName string, interval time.Duration, job periodicJob) {
+	ctx, cancel := context.WithCancel(context.Background())
+	loop := func(loopCtx context.Context) { runPeriodically(loopCtx, interval, job.RunOnce) }
+
+	if provider == db.PostGreSQL {
+		g.Add(func() error {
+			return pgElector.Run(ctx, leaseName, loop)
+		}, func(err error) { cancel() })
+		return
+	}
+	g.Add(func() error { loop(ctx); return nil }, func(err error) { cancel() })
+}
+
+// runPeriodically calls runOnce once immediately, then once per interval
+// until ctx ends. It's the only scheduler any periodic job gets, so no job
+// implements ticking of its own; interval is jittered up to 20% so
+// replicas started together don't run their cycles in lockstep.
+//
+// interval must be positive; the jitter floor below only covers an
+// interval too small for 20% of it to be a whole nanosecond, not a zero
+// one.
+func runPeriodically(ctx context.Context, interval time.Duration, runOnce func(context.Context)) {
+	jitterBase := interval / 5
+	if jitterBase <= 0 {
+		jitterBase = 1
+	}
+	ticker := time.NewTicker(interval + time.Duration(rand.Int64N(int64(jitterBase))))
+	defer ticker.Stop()
+
+	runOnce(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runOnce(ctx)
+		}
+	}
+}

--- a/cmd/api/periodic_job_test.go
+++ b/cmd/api/periodic_job_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -11,16 +12,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/leaderelection"
 )
 
 // fakePeriodicJob is periodicJob's test double: counts the cycles it was
-// asked to run.
+// asked to run, and closes ran on the first of them when a test needs to
+// wait for one rather than race it.
 type fakePeriodicJob struct {
 	runs int
+	once sync.Once
+	ran  chan struct{}
 }
 
-func (f *fakePeriodicJob) RunOnce(context.Context) { f.runs++ }
+func (f *fakePeriodicJob) RunOnce(context.Context) {
+	f.runs++
+	if f.ran != nil {
+		f.once.Do(func() { close(f.ran) })
+	}
+}
 
 // fakeElector is leaderelection.Elector's test double. It records the lease
 // name it was called with, then invokes fn itself so a test can observe
@@ -40,18 +51,12 @@ func (f *fakeElector) Run(ctx context.Context, name string, fn func(context.Cont
 	return f.err
 }
 
-// stopGroup returns an actor that ends g as soon as it runs, so every other
-// actor's interrupt fires and the scheduling loops under test return.
-func stopGroup() (func() error, func(error)) {
-	return func() error { return errors.New("stop") }, func(error) {}
-}
-
-func TestAddPeriodicJob_PostgreSQL_SchedulesCyclesThroughElectorUnderTheGivenLeaseName(t *testing.T) {
+func TestAddPeriodicJob_SchedulesCyclesThroughTheElectorUnderTheGivenLeaseName(t *testing.T) {
 	var g run.Group
 	job := &fakePeriodicJob{}
 	elector := &fakeElector{err: context.Canceled}
 
-	addPeriodicJob(&g, db.PostGreSQL, elector, "test-lease", time.Hour, job)
+	addPeriodicJob(&g, elector, "test-lease", time.Hour, job)
 
 	err := g.Run()
 	require.ErrorIs(t, err, context.Canceled)
@@ -59,17 +64,21 @@ func TestAddPeriodicJob_PostgreSQL_SchedulesCyclesThroughElectorUnderTheGivenLea
 	assert.GreaterOrEqual(t, job.runs, 1, "leadership must schedule the job's cycles, not merely be acquired")
 }
 
-func TestAddPeriodicJob_NonPostgreSQL_SchedulesCyclesWithoutTouchingTheElector(t *testing.T) {
+// TestAddPeriodicJob_SoleInstanceElectorSchedulesCyclesToo covers the
+// deployment that used to be wired a second way: a sole instance holds
+// leadership outright, so the same single path schedules its cycles.
+func TestAddPeriodicJob_SoleInstanceElectorSchedulesCyclesToo(t *testing.T) {
 	var g run.Group
-	job := &fakePeriodicJob{}
+	job := &fakePeriodicJob{ran: make(chan struct{})}
 
-	// A nil elector would panic if addPeriodicJob ever called a method on
-	// it on this path - proving the leaderless path never touches it.
-	addPeriodicJob(&g, db.SQLite, nil, "unused-lease", time.Hour, job)
-	g.Add(stopGroup())
+	addPeriodicJob(&g, leaderelection.NewSoleInstance(prometheus.NewRegistry()), "sole-lease", time.Hour, job)
+	// End the group only once a cycle has actually run: an elector hands
+	// leadership to nobody if its context is already canceled, so racing
+	// cancellation against the first cycle would prove nothing either way.
+	g.Add(func() error { <-job.ran; return errors.New("stop") }, func(error) {})
 
 	require.Error(t, g.Run())
-	assert.GreaterOrEqual(t, job.runs, 1, "a non-PostgreSQL provider must still get its cycles scheduled")
+	assert.GreaterOrEqual(t, job.runs, 1, "a sole instance must get its cycles scheduled like any other leader")
 }
 
 // blockingPeriodicJob's RunOnce blocks until its context ends, recording
@@ -77,10 +86,12 @@ func TestAddPeriodicJob_NonPostgreSQL_SchedulesCyclesWithoutTouchingTheElector(t
 // interrupt function reaches the context the job's cycle was handed, not
 // just that run.Group's execute eventually returns some way or other.
 type blockingPeriodicJob struct {
+	started  chan struct{}
 	canceled chan struct{}
 }
 
 func (b *blockingPeriodicJob) RunOnce(ctx context.Context) {
+	close(b.started)
 	<-ctx.Done()
 	close(b.canceled)
 }
@@ -94,11 +105,13 @@ func (b *blockingPeriodicJob) RunOnce(ctx context.Context) {
 func TestAddPeriodicJob_InterruptCancelsTheContextPassedToTheJob(t *testing.T) {
 	var g run.Group
 
-	failing := &fakePeriodicJob{}
-	addPeriodicJob(&g, db.PostGreSQL, &fakeElector{err: errors.New("boom")}, "failing-lease", time.Hour, failing)
+	blocking := &blockingPeriodicJob{started: make(chan struct{}), canceled: make(chan struct{})}
+	addPeriodicJob(&g, leaderelection.NewSoleInstance(prometheus.NewRegistry()), "blocking-lease", time.Hour, blocking)
 
-	blocking := &blockingPeriodicJob{canceled: make(chan struct{})}
-	addPeriodicJob(&g, db.SQLite, nil, "unused-lease", time.Hour, blocking)
+	// A sibling actor that fails once the job is genuinely mid-cycle: that
+	// failure is what makes g invoke every other actor's interrupt, and
+	// waiting for the cycle first keeps the two from racing.
+	g.Add(func() error { <-blocking.started; return errors.New("sibling actor failed") }, func(error) {})
 
 	// g.Run() itself blocks until every actor's execute function returns -
 	// if the interrupt below never reaches blocking, g.Run() never

--- a/cmd/api/periodic_job_test.go
+++ b/cmd/api/periodic_job_test.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/oklog/run"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+)
+
+// fakePeriodicJob is periodicJob's test double: counts the cycles it was
+// asked to run.
+type fakePeriodicJob struct {
+	runs int
+}
+
+func (f *fakePeriodicJob) RunOnce(context.Context) { f.runs++ }
+
+// fakeElector is leaderelection.Elector's test double. It records the lease
+// name it was called with, then invokes fn itself so a test can observe
+// what actually got scheduled through it. fn is a scheduling loop that
+// returns only once its context ends, so this hands it a context of its
+// own that expires rather than one that never does.
+type fakeElector struct {
+	name string
+	err  error
+}
+
+func (f *fakeElector) Run(ctx context.Context, name string, fn func(context.Context)) error {
+	f.name = name
+	fnCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	fn(fnCtx)
+	return f.err
+}
+
+// stopGroup returns an actor that ends g as soon as it runs, so every other
+// actor's interrupt fires and the scheduling loops under test return.
+func stopGroup() (func() error, func(error)) {
+	return func() error { return errors.New("stop") }, func(error) {}
+}
+
+func TestAddPeriodicJob_PostgreSQL_SchedulesCyclesThroughElectorUnderTheGivenLeaseName(t *testing.T) {
+	var g run.Group
+	job := &fakePeriodicJob{}
+	elector := &fakeElector{err: context.Canceled}
+
+	addPeriodicJob(&g, db.PostGreSQL, elector, "test-lease", time.Hour, job)
+
+	err := g.Run()
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, "test-lease", elector.name, "must elect under the lease name the caller gave it, not a hardcoded one")
+	assert.GreaterOrEqual(t, job.runs, 1, "leadership must schedule the job's cycles, not merely be acquired")
+}
+
+func TestAddPeriodicJob_NonPostgreSQL_SchedulesCyclesWithoutTouchingTheElector(t *testing.T) {
+	var g run.Group
+	job := &fakePeriodicJob{}
+
+	// A nil elector would panic if addPeriodicJob ever called a method on
+	// it on this path - proving the leaderless path never touches it.
+	addPeriodicJob(&g, db.SQLite, nil, "unused-lease", time.Hour, job)
+	g.Add(stopGroup())
+
+	require.Error(t, g.Run())
+	assert.GreaterOrEqual(t, job.runs, 1, "a non-PostgreSQL provider must still get its cycles scheduled")
+}
+
+// blockingPeriodicJob's RunOnce blocks until its context ends, recording
+// that it actually observed cancellation - proving addPeriodicJob's
+// interrupt function reaches the context the job's cycle was handed, not
+// just that run.Group's execute eventually returns some way or other.
+type blockingPeriodicJob struct {
+	canceled chan struct{}
+}
+
+func (b *blockingPeriodicJob) RunOnce(ctx context.Context) {
+	<-ctx.Done()
+	close(b.canceled)
+}
+
+// TestAddPeriodicJob_InterruptCancelsTheContextPassedToTheJob proves the
+// cancel func addPeriodicJob wires into g's interrupt actually reaches the
+// context the job's cycle was handed - the mechanism run.Group depends on
+// to stop every actor once any one of them fails. Hence the two jobs: a
+// sibling actor failing is what makes g invoke every other actor's
+// interrupt.
+func TestAddPeriodicJob_InterruptCancelsTheContextPassedToTheJob(t *testing.T) {
+	var g run.Group
+
+	failing := &fakePeriodicJob{}
+	addPeriodicJob(&g, db.PostGreSQL, &fakeElector{err: errors.New("boom")}, "failing-lease", time.Hour, failing)
+
+	blocking := &blockingPeriodicJob{canceled: make(chan struct{})}
+	addPeriodicJob(&g, db.SQLite, nil, "unused-lease", time.Hour, blocking)
+
+	// g.Run() itself blocks until every actor's execute function returns -
+	// if the interrupt below never reaches blocking, g.Run() never
+	// returns either, so both waits need their own bound rather than
+	// letting a broken interrupt hang the whole test binary.
+	runErr := make(chan error, 1)
+	go func() { runErr <- g.Run() }()
+
+	select {
+	case <-blocking.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("the blocking job's context was never canceled after a sibling actor failed - addPeriodicJob's interrupt isn't reaching the job")
+	}
+
+	select {
+	case err := <-runErr:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("g.Run() never returned after the blocking job's context was canceled")
+	}
+}
+
+// TestRunPeriodically_RunsOneCycleImmediatelyThenOnePerJitteredInterval
+// pins the whole schedule the one shared scheduler produces: a cycle at
+// once, then one per interval, spaced by no less than interval and no more
+// than 20% beyond it, until its context ends. The synctest bubble's clock
+// makes those spacings exact rather than approximate, so the jitter's upper
+// bound is checkable at a realistic interval instead of inferred from a
+// tiny one.
+func TestRunPeriodically_RunsOneCycleImmediatelyThenOnePerJitteredInterval(t *testing.T) {
+	const (
+		interval = 10 * time.Minute
+		cycles   = 3
+		// One schedule draws its jitter once, so it samples the range once;
+		// repeated schedules make a draw outside the bound very unlikely to
+		// go unnoticed. Fake time makes the repetition free.
+		schedules = 20
+	)
+
+	synctest.Test(t, func(t *testing.T) {
+		for s := range schedules {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			start := time.Now()
+			var ranAt []time.Duration
+			returned := make(chan struct{})
+			go func() {
+				defer close(returned)
+				runPeriodically(ctx, interval, func(context.Context) {
+					ranAt = append(ranAt, time.Since(start))
+					if len(ranAt) == cycles {
+						cancel()
+					}
+				})
+			}()
+			<-returned
+			cancel()
+
+			require.Len(t, ranAt, cycles, "the scheduler must keep running cycles until its context ends")
+			assert.Zero(t, ranAt[0], "the first cycle runs immediately, not after a full interval")
+			for i := 1; i < len(ranAt); i++ {
+				gap := ranAt[i] - ranAt[i-1]
+				assert.GreaterOrEqual(t, gap, interval, "schedule %d cycle %d ran early: jitter must only ever delay a tick", s, i)
+				assert.Less(t, gap, interval+interval/5, "schedule %d cycle %d ran late: jitter must stay within 20%% of the interval", s, i)
+			}
+		}
+	})
+}
+
+// TestRunPeriodically_IntervalTooSmallToJitter covers the jitter floor: an
+// interval below 5ns leaves 20% of it under a nanosecond, and the floor is
+// what keeps that from panicking.
+func TestRunPeriodically_IntervalTooSmallToJitter(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		runs := 0
+		returned := make(chan struct{})
+		go func() {
+			defer close(returned)
+			runPeriodically(ctx, 4*time.Nanosecond, func(context.Context) {
+				runs++
+				if runs == 2 {
+					cancel()
+				}
+			})
+		}()
+		<-returned
+
+		assert.Equal(t, 2, runs)
+	})
+}

--- a/cmd/api/run.go
+++ b/cmd/api/run.go
@@ -173,21 +173,26 @@ func Run(uiFS fs.FS) error {
 
 	provider := db.DatabaseProvider(config.DefaultConfig.Database.Provider)
 
-	// Both leader-elected jobs below share one Elector instance: constructing
-	// leaderelection.New twice against the same reg would panic on
-	// duplicate metric registration.
-	var pgElector leaderelection.Elector
-	if provider == db.PostGreSQL &&
-		(config.DefaultConfig.Inventory.Enabled || config.DefaultConfig.Retention.Enabled) {
-		var leErr error
-		dbProvider.WithDB(func(d *sql.DB) {
-			pgElector, leErr = leaderelection.New(config.DefaultConfig.LeaderElection, d, reg)
-		})
-		if leErr != nil {
-			// Fail fast: a misconfiguration here (bad strategy, TTL/renew
-			// interval) would otherwise leave the inventory syncer and
-			// retention worker silently never running on any replica.
-			return fmt.Errorf("construct leader elector: %w", leErr)
+	// Both jobs below share one Elector instance: constructing two against
+	// the same reg would panic on duplicate metric registration.
+	var elector leaderelection.Elector
+	if config.DefaultConfig.Inventory.Enabled || config.DefaultConfig.Retention.Enabled {
+		if provider == db.PostGreSQL {
+			var leErr error
+			dbProvider.WithDB(func(d *sql.DB) {
+				elector, leErr = leaderelection.New(config.DefaultConfig.LeaderElection, d, reg)
+			})
+			if leErr != nil {
+				// Fail fast: a misconfiguration here (bad strategy, TTL/renew
+				// interval) would otherwise leave the inventory syncer and
+				// retention worker silently never running on any replica.
+				return fmt.Errorf("construct leader elector: %w", leErr)
+			}
+		} else {
+			// SQLite is single-instance-per-file by deployment convention:
+			// no other replica can be running these jobs against this
+			// database, so this one holds leadership outright.
+			elector = leaderelection.NewSoleInstance(reg)
 		}
 	}
 
@@ -199,7 +204,7 @@ func Run(uiFS fs.FS) error {
 		if err != nil {
 			return fmt.Errorf("create inventory syncer: %w", err)
 		}
-		addPeriodicJob(&g, provider, pgElector, "metric-analytics-inventory", config.DefaultConfig.Inventory.SyncInterval, inv)
+		addPeriodicJob(&g, elector, "metric-analytics-inventory", config.DefaultConfig.Inventory.SyncInterval, inv)
 	}
 
 	if config.DefaultConfig.Retention.Enabled {
@@ -207,7 +212,7 @@ func Run(uiFS fs.FS) error {
 		if err != nil {
 			return fmt.Errorf("create retention worker: %w", err)
 		}
-		addPeriodicJob(&g, provider, pgElector, "metric-analytics-retention", config.DefaultConfig.Retention.Interval, retWorker)
+		addPeriodicJob(&g, elector, "metric-analytics-retention", config.DefaultConfig.Retention.Interval, retWorker)
 	}
 
 	{

--- a/cmd/api/run.go
+++ b/cmd/api/run.go
@@ -171,11 +171,13 @@ func Run(uiFS fs.FS) error {
 		})
 	}
 
+	provider := db.DatabaseProvider(config.DefaultConfig.Database.Provider)
+
 	// Both leader-elected jobs below share one Elector instance: constructing
 	// leaderelection.New twice against the same reg would panic on
 	// duplicate metric registration.
 	var pgElector leaderelection.Elector
-	if db.DatabaseProvider(config.DefaultConfig.Database.Provider) == db.PostGreSQL &&
+	if provider == db.PostGreSQL &&
 		(config.DefaultConfig.Inventory.Enabled || config.DefaultConfig.Retention.Enabled) {
 		var leErr error
 		dbProvider.WithDB(func(d *sql.DB) {
@@ -184,47 +186,28 @@ func Run(uiFS fs.FS) error {
 		if leErr != nil {
 			// Fail fast: a misconfiguration here (bad strategy, TTL/renew
 			// interval) would otherwise leave the inventory syncer and
-			// retention worker silently never running on any replica,
-			// with only this log line to explain it.
-			slog.Error("unable to construct leader elector", "err", leErr)
+			// retention worker silently never running on any replica.
 			return fmt.Errorf("construct leader elector: %w", leErr)
 		}
 	}
 
+	// Both jobs below fail fast, as the elector above does: a job an
+	// operator explicitly enabled that silently never runs is
+	// indistinguishable from one that runs and finds nothing to do.
 	if config.DefaultConfig.Inventory.Enabled {
 		inv, err := inventory.NewSyncer(dbProvider, config.DefaultConfig.Upstream.URL, config.DefaultConfig, reg)
 		if err != nil {
-			slog.Error("unable to create inventory syncer", "err", err)
-		} else {
-			switch db.DatabaseProvider(config.DefaultConfig.Database.Provider) {
-			case db.PostGreSQL:
-				ctx, cancel := context.WithCancel(context.Background())
-				g.Add(func() error {
-					return pgElector.Run(ctx, "metric-analytics-inventory", inv.RunLeaderless)
-				}, func(err error) { cancel() })
-			default:
-				ctx, cancel := context.WithCancel(context.Background())
-				g.Add(func() error { inv.RunLeaderless(ctx); return nil }, func(err error) { cancel() })
-			}
+			return fmt.Errorf("create inventory syncer: %w", err)
 		}
+		addPeriodicJob(&g, provider, pgElector, "metric-analytics-inventory", config.DefaultConfig.Inventory.SyncInterval, inv)
 	}
 
 	if config.DefaultConfig.Retention.Enabled {
 		retWorker, err := retention.NewWorker(dbProvider, config.DefaultConfig, reg)
 		if err != nil {
-			slog.Error("unable to create retention worker", "err", err)
-		} else {
-			switch db.DatabaseProvider(config.DefaultConfig.Database.Provider) {
-			case db.PostGreSQL:
-				ctx, cancel := context.WithCancel(context.Background())
-				g.Add(func() error {
-					return pgElector.Run(ctx, "metric-analytics-retention", retWorker.RunLeaderless)
-				}, func(err error) { cancel() })
-			default:
-				ctx, cancel := context.WithCancel(context.Background())
-				g.Add(func() error { retWorker.RunLeaderless(ctx); return nil }, func(err error) { cancel() })
-			}
+			return fmt.Errorf("create retention worker: %w", err)
 		}
+		addPeriodicJob(&g, provider, pgElector, "metric-analytics-retention", config.DefaultConfig.Retention.Interval, retWorker)
 	}
 
 	{

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,0 +1,71 @@
+# Background jobs
+
+`internal/inventory` and `internal/retention` are the two periodic jobs `prom-analytics-proxy` runs against its own database: the inventory syncer builds and refreshes the metrics catalog and usage data the rest of the application reads, and the retention worker deletes old query-log rows. This doc covers what each job does and the time budget one cycle runs under; *who* gets to run them, and how a stuck cycle gets recovered, is [docs/leader-election.md](leader-election.md)'s concern.
+
+## Inventory syncer
+
+`internal/inventory.Syncer` maintains two tables: the metrics catalog (name, type, help, unit — what metrics exist) and, optionally, a per-Prometheus-job index (which metrics each job produces), used to answer job-scoped "which of this job's metrics are unused" queries. One sync cycle runs up to three independent steps, strictly in this order:
+
+1. **Metadata catalog sync** — populates the catalog from Prometheus. Skipped entirely if `metadata_sync_enabled` is `false` (the OTLP ingester populates the catalog instead in that mode — see [docs/ingester.md](ingester.md)). Two mutually exclusive sources, selected by `metadata_metrics_name_only`: the `/api/v1/metadata` endpoint by default (full type/help/unit; expands histograms and summaries into their `_bucket`/`_count`/`_sum` series; capped by the top-level `metadata_limit`), or `/api/v1/label/__name__/values` when set (names only — lighter, and less prone to hitting Prometheus's own metadata limits, at the cost of a less complete catalog). Bounded by `metadata_step_timeout`.
+2. **Usage-summary refresh** — always runs, never gated by a flag. Bounded by its own `summary_step_timeout`.
+3. **Job index sync** (`internal/inventory/job_index.go`) — only if `job_sync_enabled`, and only after steps 1–2 both succeed. Fetches the set of Prometheus job label values, then fans out across `job_index_workers` concurrent goroutines, each pulling jobs off a shared channel and querying-then-upserting one job's metric names at a time. Bounded as a *whole* by `job_index_timeout`; the label fetch (`job_index_label_timeout`) and each per-job query (`job_index_per_job_timeout`) are sub-budgets nested inside it, not independent of it. An empty label result or a 404 is treated as "no job labels exist" and logged, not an error; the step overall fails only if more than half of the individual jobs failed.
+
+Steps 1 and 2 are one unit for error reporting: a cycle stops there and reports which of two failure shapes happened — an ordinary failure (nothing committed) versus catalog-committed-but-summary-failed, counted separately (`inventory_catalog_summary_mismatch_total`) because it strands newly-catalogued metrics at placeholder usage values until the next successful run. Step 3's failures are logged but don't affect steps 1–2's outcome or the run's own success/failure counters, and step 3 never runs at all if step 1 or 2 failed.
+
+### Time budget
+
+Every step gets its own window sized by its own timeout, rather than a share of whatever an earlier step left behind. All three derive from one shared context — a cycle opens a single `cycleCtx` bounded by `run_timeout`, and every step's own `context.WithTimeout` nests inside it — and `NewSyncer` is what makes that safe, settling at construction on a `run_timeout` at least as large as the sum of every *enabled* step's own timeout: a configured value smaller than that sum is raised to it, with a warning naming the value to fix, rather than refusing to start. Running the steps an operator asked for is closer to their intent than not running at all. A step that finishes early leaves unused slack behind; it never lends to, or borrows from, another step.
+
+One caveat worth knowing when tuning these values: that validation bounds the *configured* worst case, not the wall clock. A step whose work overruns its own context — a non-cancellable database round trip finishing after its deadline passed — spends budget a later step was counting on. `run_timeout` set exactly equal to the sum has no slack to absorb that, which is the case for the shipped defaults when `job_sync_enabled` is on (`30s + 30s + 240s = 300s`). Raising `run_timeout` above the sum buys that slack.
+
+This is why `job_index_timeout` exists as its own flag distinct from `job_index_label_timeout`/`job_index_per_job_timeout`: those two bound individual calls, not the step's total duration, which otherwise scales with however many Prometheus jobs are discovered at run time — something no per-call timeout alone can cap. Without a step-level cap of its own, job index would have no accurate contribution to declare toward the overall budget, the same problem already fixed for the summary step (see `TestSyncer_SlowMetadataStepDoesNotPermanentlyStarveSummaryRefresh`).
+
+Settled this way, `run_timeout` is a true bound on one whole cycle rather than on part of one — which is what makes it usable as this job's declared cycle budget, with no separate computation needed anywhere else. The syncer settles those values at construction, so its cycles run under the settled ones.
+
+### Config
+
+| Field (`inventory.*`) | Flag | Default | Governs |
+|---|---|---|---|
+| `enabled` | `-inventory-enabled` | `true` | Whether this job runs at all |
+| `metadata_sync_enabled` | `-inventory-metadata-sync-enabled` | `true` | Whether step 1 runs (and counts toward `run_timeout`'s required minimum) |
+| `metadata_metrics_name_only` | — (YAML only) | `false` | Which source step 1 uses |
+| `sync_interval` | `-inventory-sync-interval` | `10m` | Time between cycles (jittered up to 20%, so replicas restarting together don't all sync in lockstep) |
+| `time_window` | `-inventory-time-window` | `720h` (30d) | Lookback window for the usage-summary refresh and job-index queries |
+| `run_timeout` | `-inventory-run-timeout` | `300s` | The whole cycle's real deadline — must be at least the sum of every enabled step's own timeout below; a smaller value is raised to that sum at startup, with a warning naming it |
+| `metadata_step_timeout` | `-inventory-metadata-timeout` | `30s` | Bounds step 1 alone |
+| `summary_step_timeout` | `-inventory-summary-timeout` | `30s` | Bounds step 2 alone |
+| `job_sync_enabled` | — (YAML only) | `false` | Whether step 3 runs (and counts toward `run_timeout`'s required minimum) |
+| `job_index_timeout` | `-inventory-job-index-timeout` | `240s` | Bounds step 3 as a whole — must be at least `job_index_label_timeout + job_index_per_job_timeout`, or the step could never index a single job; a smaller value is raised to that sum at startup, with a warning |
+| `job_index_label_timeout` | `-inventory-job-index-label-timeout` | `30s` | Bounds the job-label fetch, nested inside `job_index_timeout` |
+| `job_index_per_job_timeout` | `-inventory-job-index-per-job-timeout` | `30s` | Bounds each per-job query, nested inside `job_index_timeout` |
+| `job_index_workers` | `-inventory-job-index-workers` | `10` | Concurrency of step 3's per-job fan-out |
+
+### Metrics
+
+- `inventory_sync_duration_seconds` (histogram) — wall time of one cycle, observed once regardless of outcome.
+- `inventory_sync_success_total` / `inventory_sync_failure_total` (counters) — steps 1–2's outcome only; step 3 isn't reflected here.
+- `inventory_catalog_summary_mismatch_total` (counter) — the catalog-committed-but-summary-failed partial-failure case specifically.
+
+## Retention worker
+
+`internal/retention.Worker` deletes query-log rows older than `queries_max_age`. One retention cycle is a single step: compute the cutoff (`now - queries_max_age`), call `dbProvider.DeleteQueriesBefore`, bounded by `run_timeout`. No further steps, so unlike the inventory syncer there's nothing to validate or sum — `run_timeout` is already, directly, the whole cycle's true bound. If `queries_max_age` is zero or negative the run is a no-op (defensive; `NewWorker` already rejects a non-positive value at construction, so this only guards against a value changed after startup).
+
+### Config
+
+| Field (`retention.*`) | Flag | Default | Governs |
+|---|---|---|---|
+| `enabled` | `-retention-enabled` | `false` | Whether this job runs at all |
+| `interval` | `-retention-interval` | `1h` | Time between cycles (jittered up to 20%) |
+| `run_timeout` | `-retention-run-timeout` | `5m` | Bounds the single delete step — the whole cycle's true bound |
+| `queries_max_age` | `-retention-queries-max-age` | `720h` (30d) | Cutoff age — rows older than this are deleted |
+
+### Metrics
+
+- `retention_run_duration_seconds` (histogram, label `status` ∈ `{success, failure}`) — wall time of one cycle.
+
+## Constraints and invariants
+
+- Only one of the inventory syncer's step orderings is a data constraint: step 2's refresh reads `metrics_catalog` as the `FROM` table of its own `INSERT`, and `metrics_usage_summary.name` is a foreign key into it, so the summary can only ever see what the catalog step already committed. Step 3 writes `metrics_job_index`, which references neither, and reads nothing either of them writes - it runs last, and only when steps 1-2 succeed, as a deliberate choice not to spend a fan-out across every Prometheus job when the cheap steps already say something is wrong upstream. Anyone reordering these, or running them concurrently, needs that distinction: steps 1-2 are one unit, step 3 is separable.
+- Every step within one cycle ultimately derives its context from the same `ctx` that cycle was given — canceling that one context reaches every step still in flight, no matter how deep.
+- `run_timeout` must stay a true upper bound on a cycle's worst-case wall time, or the lease strategy's budget enforcement either kills healthy runs early or stops meaning anything. For the inventory syncer that's not just documentation — `NewSyncer` enforces it at construction, widening `run_timeout` to the sum of every enabled step's own timeout when the configured value falls short (see [Time budget](#time-budget)); adding a step, or a new independent sub-timeout, without adding it to that sum would reopen the exact gap https://github.com/nicolastakashi/prom-analytics-proxy/issues/572 fixed.
+- Work a step runs concurrently with itself (only the inventory syncer's per-job fan-out within step 3) is still bounded per unit — concurrency changes throughput, not the timeout each unit of work gets.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,26 +1,26 @@
 # Background jobs
 
-`internal/inventory` and `internal/retention` are the two periodic jobs `prom-analytics-proxy` runs against its own database: the inventory syncer builds and refreshes the metrics catalog and usage data the rest of the application reads, and the retention worker deletes old query-log rows. This doc covers what each job does and the time budget one cycle runs under; *who* gets to run them, and how a stuck cycle gets recovered, is [docs/leader-election.md](leader-election.md)'s concern.
+`internal/inventory` and `internal/retention` are the two periodic jobs `prom-analytics-proxy` runs against its own database: the inventory syncer builds and refreshes the metrics catalog and usage data the rest of the application reads, and the retention worker deletes old query-log rows. Both expose the same shape — a `RunOnce(ctx)` that runs exactly one cycle, bounded by whatever `ctx` it's given, and never loops or knows who's calling it — so `cmd/api` can drive them identically regardless of database provider. This doc covers what each job does and the constraints it operates under; *who* gets to run them, and how a stuck cycle gets recovered, is [docs/leader-election.md](leader-election.md)'s concern — see [Running these jobs](#running-these-jobs) for where the two connect.
 
 ## Inventory syncer
 
-`internal/inventory.Syncer` maintains two tables: the metrics catalog (name, type, help, unit — what metrics exist) and, optionally, a per-Prometheus-job index (which metrics each job produces), used to answer job-scoped "which of this job's metrics are unused" queries. One sync cycle runs up to three independent steps, strictly in this order:
+`internal/inventory.Syncer` maintains two tables: the metrics catalog (name, type, help, unit — what metrics exist) and, optionally, a per-Prometheus-job index (which metrics each job produces), used to answer job-scoped "which of this job's metrics are unused" queries. One call to `RunOnce` runs up to three independent steps, strictly in this order:
 
 1. **Metadata catalog sync** — populates the catalog from Prometheus. Skipped entirely if `metadata_sync_enabled` is `false` (the OTLP ingester populates the catalog instead in that mode — see [docs/ingester.md](ingester.md)). Two mutually exclusive sources, selected by `metadata_metrics_name_only`: the `/api/v1/metadata` endpoint by default (full type/help/unit; expands histograms and summaries into their `_bucket`/`_count`/`_sum` series; capped by the top-level `metadata_limit`), or `/api/v1/label/__name__/values` when set (names only — lighter, and less prone to hitting Prometheus's own metadata limits, at the cost of a less complete catalog). Bounded by `metadata_step_timeout`.
 2. **Usage-summary refresh** — always runs, never gated by a flag. Bounded by its own `summary_step_timeout`.
 3. **Job index sync** (`internal/inventory/job_index.go`) — only if `job_sync_enabled`, and only after steps 1–2 both succeed. Fetches the set of Prometheus job label values, then fans out across `job_index_workers` concurrent goroutines, each pulling jobs off a shared channel and querying-then-upserting one job's metric names at a time. Bounded as a *whole* by `job_index_timeout`; the label fetch (`job_index_label_timeout`) and each per-job query (`job_index_per_job_timeout`) are sub-budgets nested inside it, not independent of it. An empty label result or a 404 is treated as "no job labels exist" and logged, not an error; the step overall fails only if more than half of the individual jobs failed.
 
-Steps 1 and 2 are one unit for error reporting: a cycle stops there and reports which of two failure shapes happened — an ordinary failure (nothing committed) versus catalog-committed-but-summary-failed, counted separately (`inventory_catalog_summary_mismatch_total`) because it strands newly-catalogued metrics at placeholder usage values until the next successful run. Step 3's failures are logged but don't affect steps 1–2's outcome or the run's own success/failure counters, and step 3 never runs at all if step 1 or 2 failed.
+Steps 1 and 2 are one unit for error reporting: `RunOnce` stops there and reports which of two failure shapes happened — an ordinary failure (nothing committed) versus catalog-committed-but-summary-failed, counted separately (`inventory_catalog_summary_mismatch_total`) because it strands newly-catalogued metrics at placeholder usage values until the next successful run. Step 3's failures are logged but don't affect steps 1–2's outcome or the run's own success/failure counters, and step 3 never runs at all if step 1 or 2 failed.
 
 ### Time budget
 
-Every step gets its own window sized by its own timeout, rather than a share of whatever an earlier step left behind. All three derive from one shared context — a cycle opens a single `cycleCtx` bounded by `run_timeout`, and every step's own `context.WithTimeout` nests inside it — and `NewSyncer` is what makes that safe, settling at construction on a `run_timeout` at least as large as the sum of every *enabled* step's own timeout: a configured value smaller than that sum is raised to it, with a warning naming the value to fix, rather than refusing to start. Running the steps an operator asked for is closer to their intent than not running at all. A step that finishes early leaves unused slack behind; it never lends to, or borrows from, another step.
+Every step gets its own window sized by its own timeout, rather than a share of whatever an earlier step left behind. All three derive from one shared context — `RunOnce` opens a single `cycleCtx` bounded by `run_timeout`, and every step's own `context.WithTimeout` nests inside it — and `NewSyncer` is what makes that safe, settling at construction on a `run_timeout` at least as large as the sum of every *enabled* step's own timeout: a configured value smaller than that sum is raised to it, with a warning naming the value to fix, rather than refusing to start. Running the steps an operator asked for is closer to their intent than not running at all. A step that finishes early leaves unused slack behind; it never lends to, or borrows from, another step.
 
 One caveat worth knowing when tuning these values: that validation bounds the *configured* worst case, not the wall clock. A step whose work overruns its own context — a non-cancellable database round trip finishing after its deadline passed — spends budget a later step was counting on. `run_timeout` set exactly equal to the sum has no slack to absorb that, which is the case for the shipped defaults when `job_sync_enabled` is on (`30s + 30s + 240s = 300s`). Raising `run_timeout` above the sum buys that slack.
 
 This is why `job_index_timeout` exists as its own flag distinct from `job_index_label_timeout`/`job_index_per_job_timeout`: those two bound individual calls, not the step's total duration, which otherwise scales with however many Prometheus jobs are discovered at run time — something no per-call timeout alone can cap. Without a step-level cap of its own, job index would have no accurate contribution to declare toward the overall budget, the same problem already fixed for the summary step (see `TestSyncer_SlowMetadataStepDoesNotPermanentlyStarveSummaryRefresh`).
 
-Settled this way, `run_timeout` is a true bound on one whole cycle rather than on part of one — which is what makes it usable as this job's declared cycle budget, with no separate computation needed anywhere else. The syncer settles those values at construction, so its cycles run under the settled ones.
+Settled this way, `run_timeout` is a true bound on one whole cycle rather than on part of one — which is what makes it usable as this job's declared cycle budget, with no separate computation needed anywhere else. The syncer settles those values at construction, so its cycles run under the settled ones — see [Running these jobs](#running-these-jobs).
 
 ### Config
 
@@ -42,13 +42,13 @@ Settled this way, `run_timeout` is a true bound on one whole cycle rather than o
 
 ### Metrics
 
-- `inventory_sync_duration_seconds` (histogram) — wall time of one cycle, observed once regardless of outcome.
+- `inventory_sync_duration_seconds` (histogram) — wall time of one `RunOnce` call, observed once regardless of outcome.
 - `inventory_sync_success_total` / `inventory_sync_failure_total` (counters) — steps 1–2's outcome only; step 3 isn't reflected here.
 - `inventory_catalog_summary_mismatch_total` (counter) — the catalog-committed-but-summary-failed partial-failure case specifically.
 
 ## Retention worker
 
-`internal/retention.Worker` deletes query-log rows older than `queries_max_age`. One retention cycle is a single step: compute the cutoff (`now - queries_max_age`), call `dbProvider.DeleteQueriesBefore`, bounded by `run_timeout`. No further steps, so unlike the inventory syncer there's nothing to validate or sum — `run_timeout` is already, directly, the whole cycle's true bound. If `queries_max_age` is zero or negative the run is a no-op (defensive; `NewWorker` already rejects a non-positive value at construction, so this only guards against a value changed after startup).
+`internal/retention.Worker` deletes query-log rows older than `queries_max_age`. One call to `RunOnce` is a single step: compute the cutoff (`now - queries_max_age`), call `dbProvider.DeleteQueriesBefore`, bounded by `run_timeout`. No further steps, so unlike the inventory syncer there's nothing to validate or sum — `run_timeout` is already, directly, the whole cycle's true bound. If `queries_max_age` is zero or negative the run is a no-op (defensive; `NewWorker` already rejects a non-positive value at construction, so this only guards against a value changed after startup).
 
 ### Config
 
@@ -61,11 +61,21 @@ Settled this way, `run_timeout` is a true bound on one whole cycle rather than o
 
 ### Metrics
 
-- `retention_run_duration_seconds` (histogram, label `status` ∈ `{success, failure}`) — wall time of one cycle.
+- `retention_run_duration_seconds` (histogram, label `status` ∈ `{success, failure}`) — wall time of one `RunOnce` call.
+
+## Running these jobs
+
+`RunOnce(ctx)` is the one shape both packages expose to any caller — one cycle, no looping, no leadership awareness. Neither job schedules itself: `cmd/api` owns the single loop that turns `RunOnce` into a periodic job (`runPeriodically` — one cycle immediately, then one per `sync_interval`/`interval`, jittered up to 20% so replicas started together don't run their cycles in lockstep), and wires that same loop up two different ways depending on `-database-provider`:
+
+- **PostgreSQL**: the loop runs under `Elector.Run`, so only the current leader runs cycles — see [docs/leader-election.md](leader-election.md) for leadership hand-off. The interval comes from `config.DefaultConfig.<Inventory|Retention>.SyncInterval`/`Interval`, the same value each job's own `NewSyncer`/`NewWorker` already validated as positive at construction.
+- **Everything else (SQLite)**: the identical loop, run directly — there's no leader to coordinate since SQLite mode is single-instance-per-file by deployment convention.
+
+Leadership therefore governs *who* runs cycles, never how often they run: one scheduler, one jitter rule, one place to change either. Neither `internal/inventory` nor `internal/retention` imports `internal/leaderelection`, and neither owns a ticker; `cmd/api` is the only place leadership and scheduling meet, through the small `periodicJob` interface (`RunOnce` alone) declared in `cmd/api` itself, the consumer — see `cmd/api/periodic_job.go`.
 
 ## Constraints and invariants
 
+- `RunOnce` never loops and never learns who's calling it — scheduling and leadership are entirely the caller's concern. A job that grows a ticker of its own puts a second scheduling rule in the codebase; there is exactly one, and it lives in `cmd/api`.
 - Only one of the inventory syncer's step orderings is a data constraint: step 2's refresh reads `metrics_catalog` as the `FROM` table of its own `INSERT`, and `metrics_usage_summary.name` is a foreign key into it, so the summary can only ever see what the catalog step already committed. Step 3 writes `metrics_job_index`, which references neither, and reads nothing either of them writes - it runs last, and only when steps 1-2 succeed, as a deliberate choice not to spend a fan-out across every Prometheus job when the cheap steps already say something is wrong upstream. Anyone reordering these, or running them concurrently, needs that distinction: steps 1-2 are one unit, step 3 is separable.
-- Every step within one cycle ultimately derives its context from the same `ctx` that cycle was given — canceling that one context reaches every step still in flight, no matter how deep.
-- `run_timeout` must stay a true upper bound on a cycle's worst-case wall time, or the lease strategy's budget enforcement either kills healthy runs early or stops meaning anything. For the inventory syncer that's not just documentation — `NewSyncer` enforces it at construction, widening `run_timeout` to the sum of every enabled step's own timeout when the configured value falls short (see [Time budget](#time-budget)); adding a step, or a new independent sub-timeout, without adding it to that sum would reopen the exact gap https://github.com/nicolastakashi/prom-analytics-proxy/issues/572 fixed.
+- Every step within one `RunOnce` call ultimately derives its context from the same `ctx` `RunOnce` was given — canceling that one context reaches every step still in flight, no matter how deep.
+- `run_timeout` must stay a true upper bound on `RunOnce`'s worst-case wall time, or the lease strategy's budget enforcement either kills healthy runs early or stops meaning anything. For the inventory syncer that's not just documentation — `NewSyncer` enforces it at construction, widening `run_timeout` to the sum of every enabled step's own timeout when the configured value falls short (see [Time budget](#time-budget)); adding a step, or a new independent sub-timeout, without adding it to that sum would reopen the exact gap https://github.com/nicolastakashi/prom-analytics-proxy/issues/572 fixed.
 - Work a step runs concurrently with itself (only the inventory syncer's per-job fan-out within step 3) is still bounded per unit — concurrency changes throughput, not the timeout each unit of work gets.

--- a/docs/leader-election.md
+++ b/docs/leader-election.md
@@ -2,6 +2,8 @@
 
 `internal/leaderelection` coordinates single-leader execution of the inventory syncer and the retention worker across multiple replicas of `prom-analytics-proxy` sharing one PostgreSQL database. Only one replica runs each of these jobs at a time; the rest wait, and one of them takes over automatically if the current leader disappears. Two strategies are available, selected by `-leader-election-strategy`: `advisory-lock` (the default) and `lease`.
 
+What those two jobs actually do, how they're scheduled, and the time budget each cycle runs under is [docs/jobs.md](jobs.md)'s concern — this doc covers only who gets to run them.
+
 ## Why this exists
 
 Both the inventory syncer (`internal/inventory`) and the retention worker (`internal/retention`) periodically read and write shared state in PostgreSQL — the metrics catalog, usage summaries, and old-data cleanup. Running them from every replica simultaneously would mean duplicate work at best and races against shared rows at worst. Leader election picks exactly one replica to run each job; every other replica polls in the background, ready to take over.

--- a/docs/leader-election.md
+++ b/docs/leader-election.md
@@ -8,9 +8,11 @@ What those two jobs actually do, how they're scheduled, and the time budget each
 
 Both the inventory syncer (`internal/inventory`) and the retention worker (`internal/retention`) periodically read and write shared state in PostgreSQL — the metrics catalog, usage summaries, and old-data cleanup. Running them from every replica simultaneously would mean duplicate work at best and races against shared rows at worst. Leader election picks exactly one replica to run each job; every other replica polls in the background, ready to take over.
 
-## Why PostgreSQL only
+## Why coordination is PostgreSQL only
 
-This package is only used when `-database-provider=postgresql`. When running with SQLite, `cmd/api`'s wiring skips leader election entirely and runs the inventory syncer and retention worker directly on every replica. This isn't a gap — SQLite mode in this project is single-instance-per-file by deployment convention (each replica has its own local database file; there is no shared file for multiple processes to coordinate access to), so there's nothing for a leader-election mechanism to arbitrate.
+Both coordinating strategies below need shared state, and they only exist for `-database-provider=postgresql`: advisory locks are a PostgreSQL feature, and the `leader_leases` table is created only by the PostgreSQL migrations. That isn't a gap for SQLite — SQLite mode in this project is single-instance-per-file by deployment convention (each replica has its own local database file; there is no shared file for multiple processes to coordinate access to), so there is nothing for a leader-election mechanism to arbitrate.
+
+What SQLite gets instead is `NewSoleInstance`: an `Elector` that holds leadership unconditionally, touching no lock, no lease row and no table — which is why it needs no `*sql.DB` and works on a database whose schema has neither. Every provider therefore has an elector, so `cmd/api` wires a job exactly one way rather than scheduling it itself wherever nothing coordinates it, and the leadership metrics below exist in every deployment: a fleet-wide "no leader for this lease" panel would otherwise silently exclude every replica not using PostgreSQL.
 
 ## Strategy: advisory-lock (default)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -376,6 +377,87 @@ func LoadConfig(path string) error {
 	}
 
 	return nil
+}
+
+// Validate reports config values no consumer could act on. Range checks
+// only: whether each value is one its field can mean anything as. How
+// values relate to one another - a job's cycle budget covering the steps it
+// runs, say - depends on what that job does with them, so it belongs to the
+// package that owns the job, not here.
+//
+// Called at startup before anything acts on the config, so a value that
+// would only surface as odd runtime behaviour surfaces as a startup error
+// instead - and only for the sections this process will run, since a
+// disabled job never reads its own values and no command reads both.
+func (c *Config) Validate() error {
+	if c == nil {
+		return fmt.Errorf("config is required")
+	}
+
+	// Only what this process will actually run: a job that is switched off
+	// never reads its own section, and the ingester command reads neither.
+	// Reporting all of it at once means an operator with two typos fixes
+	// both before restarting, rather than discovering the second one then.
+	var errs []error
+	if c.Inventory.Enabled {
+		errs = append(errs, c.Inventory.Validate())
+	}
+	if c.Retention.Enabled {
+		errs = append(errs, c.Retention.Validate())
+	}
+	return errors.Join(errs...)
+}
+
+// Validate range-checks the inventory syncer's own values. A step's values
+// are checked only when that step is enabled: a disabled step never reads
+// them, so a leftover value there can't affect anything.
+func (c InventoryConfig) Validate() error {
+	type field struct {
+		name  string
+		value time.Duration
+	}
+	positive := []field{
+		{"sync_interval", c.SyncInterval},
+		{"time_window", c.TimeWindow},
+		{"run_timeout", c.RunTimeout},
+		// Never gated by a flag, so it always has to be usable.
+		{"summary_step_timeout", c.SummaryStepTimeout},
+	}
+	if c.MetadataSyncEnabled {
+		positive = append(positive, field{"metadata_step_timeout", c.MetadataStepTimeout})
+	}
+	if c.JobSyncEnabled {
+		positive = append(positive,
+			field{"job_index_label_timeout", c.JobIndexLabelTimeout},
+			field{"job_index_per_job_timeout", c.JobIndexPerJobTimeout})
+	}
+	var errs []error
+	for _, f := range positive {
+		if f.value <= 0 {
+			errs = append(errs, fmt.Errorf("inventory.%s must be positive (got: %s)", f.name, f.value))
+		}
+	}
+	// Without a worker there's nothing to pull jobs off the fan-out channel,
+	// and the step reports success having indexed nothing.
+	if c.JobSyncEnabled && c.JobIndexWorkers <= 0 {
+		errs = append(errs, fmt.Errorf("inventory.job_index_workers must be positive (got: %d)", c.JobIndexWorkers))
+	}
+	return errors.Join(errs...)
+}
+
+// Validate range-checks the retention worker's own values.
+func (c RetentionConfig) Validate() error {
+	var errs []error
+	if c.Interval <= 0 {
+		errs = append(errs, fmt.Errorf("retention.interval must be positive (got: %v)", c.Interval))
+	}
+	if c.RunTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("retention.run_timeout must be positive (got: %v)", c.RunTimeout))
+	}
+	if c.QueriesMaxAge <= 0 {
+		errs = append(errs, fmt.Errorf("retention.queries_max_age must be positive (got: %v)", c.QueriesMaxAge))
+	}
+	return errors.Join(errs...)
 }
 
 func (c *Config) IsTracingEnabled() bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,15 @@ type InventoryConfig struct {
 	SummaryStepTimeout      time.Duration `yaml:"summary_step_timeout,omitempty"`
 	// JobSyncEnabled controls whether the syncer fetches job metadata from
 	// Prometheus and populates job_index. Set to false when you want to avoid heavy job queries.
-	JobSyncEnabled        bool          `yaml:"job_sync_enabled,omitempty"`
+	JobSyncEnabled bool `yaml:"job_sync_enabled,omitempty"`
+	// JobIndexTimeout bounds the job-index step as a whole (fetching job
+	// label values and processing every job found) - JobIndexLabelTimeout
+	// and JobIndexPerJobTimeout bound individual calls within it, not the
+	// step's total duration, which otherwise scales with however many
+	// Prometheus jobs are discovered at run time. Nested inside RunTimeout,
+	// the same relationship MetadataStepTimeout has to it - see
+	// docs/jobs.md.
+	JobIndexTimeout       time.Duration `yaml:"job_index_timeout,omitempty"`
 	JobIndexLabelTimeout  time.Duration `yaml:"job_index_label_timeout,omitempty"`
 	JobIndexPerJobTimeout time.Duration `yaml:"job_index_per_job_timeout,omitempty"`
 	JobIndexWorkers       int           `yaml:"job_index_workers,omitempty"`
@@ -186,9 +194,14 @@ var DefaultConfig = &Config{
 		RunTimeout:              300 * time.Second,
 		MetadataStepTimeout:     30 * time.Second,
 		SummaryStepTimeout:      30 * time.Second,
-		JobIndexLabelTimeout:    30 * time.Second,
-		JobIndexPerJobTimeout:   30 * time.Second,
-		JobIndexWorkers:         10,
+		// With JobSyncEnabled these three step timeouts sum to RunTimeout
+		// exactly, the least it can be: raising one of them without raising
+		// RunTimeout too leaves the default config relying on NewSyncer to
+		// widen it back, warning on every startup.
+		JobIndexTimeout:       240 * time.Second,
+		JobIndexLabelTimeout:  30 * time.Second,
+		JobIndexPerJobTimeout: 30 * time.Second,
+		JobIndexWorkers:       10,
 	},
 	QueryProcessing: QueryProcessing{
 		ExtractHTTPHeaders: []string{"user-agent"},
@@ -428,6 +441,7 @@ func (c InventoryConfig) Validate() error {
 	}
 	if c.JobSyncEnabled {
 		positive = append(positive,
+			field{"job_index_timeout", c.JobIndexTimeout},
 			field{"job_index_label_timeout", c.JobIndexLabelTimeout},
 			field{"job_index_per_job_timeout", c.JobIndexPerJobTimeout})
 	}
@@ -502,6 +516,7 @@ func RegisterInventoryFlags(flagSet *flag.FlagSet) {
 	flagSet.DurationVar(&DefaultConfig.Inventory.RunTimeout, "inventory-run-timeout", DefaultConfig.Inventory.RunTimeout, "Timeout for the entire inventory sync run")
 	flagSet.DurationVar(&DefaultConfig.Inventory.MetadataStepTimeout, "inventory-metadata-timeout", DefaultConfig.Inventory.MetadataStepTimeout, "Timeout for metadata collection step")
 	flagSet.DurationVar(&DefaultConfig.Inventory.SummaryStepTimeout, "inventory-summary-timeout", DefaultConfig.Inventory.SummaryStepTimeout, "Timeout for summary refresh step")
+	flagSet.DurationVar(&DefaultConfig.Inventory.JobIndexTimeout, "inventory-job-index-timeout", DefaultConfig.Inventory.JobIndexTimeout, "Timeout for the job index step as a whole (job label fetch plus every job processed)")
 	flagSet.DurationVar(&DefaultConfig.Inventory.JobIndexLabelTimeout, "inventory-job-index-label-timeout", DefaultConfig.Inventory.JobIndexLabelTimeout, "Timeout for job label values collection")
 	flagSet.DurationVar(&DefaultConfig.Inventory.JobIndexPerJobTimeout, "inventory-job-index-per-job-timeout", DefaultConfig.Inventory.JobIndexPerJobTimeout, "Timeout for processing each individual job")
 	flagSet.IntVar(&DefaultConfig.Inventory.JobIndexWorkers, "inventory-job-index-workers", DefaultConfig.Inventory.JobIndexWorkers, "Number of worker goroutines for job index processing")
@@ -629,6 +644,7 @@ func logInventoryConfig(cfg *Config) {
 		"Inventory.MetadataStepTimeout", cfg.Inventory.MetadataStepTimeout,
 		"Inventory.SummaryStepTimeout", cfg.Inventory.SummaryStepTimeout,
 		"Inventory.JobSyncEnabled", cfg.Inventory.JobSyncEnabled,
+		"Inventory.JobIndexTimeout", cfg.Inventory.JobIndexTimeout,
 		"Inventory.JobIndexLabelTimeout", cfg.Inventory.JobIndexLabelTimeout,
 		"Inventory.JobIndexPerJobTimeout", cfg.Inventory.JobIndexPerJobTimeout,
 		"Inventory.JobIndexWorkers", cfg.Inventory.JobIndexWorkers,

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -92,6 +92,11 @@ func TestInventoryConfig_Validate(t *testing.T) {
 			wantErr: "inventory.job_index_per_job_timeout must be positive",
 		},
 		{
+			name:    "job_index_timeout zero while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.JobIndexTimeout = 0 },
+			wantErr: "inventory.job_index_timeout must be positive",
+		},
+		{
 			name:    "job_index_workers zero while its step is enabled",
 			tweak:   func(c *InventoryConfig) { c.JobIndexWorkers = 0 },
 			wantErr: "inventory.job_index_workers must be positive",
@@ -100,7 +105,7 @@ func TestInventoryConfig_Validate(t *testing.T) {
 			name: "every job-index value unusable while its step is disabled",
 			tweak: func(c *InventoryConfig) {
 				c.JobSyncEnabled = false
-				c.JobIndexLabelTimeout, c.JobIndexPerJobTimeout = 0, -time.Second
+				c.JobIndexTimeout, c.JobIndexLabelTimeout, c.JobIndexPerJobTimeout = 0, 0, -time.Second
 				c.JobIndexWorkers = 0
 			},
 		},

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,234 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validInventory and validRetention are the shipped defaults, which every
+// case below starts from so it only has to state the one field it's about.
+func validInventory() InventoryConfig {
+	c := DefaultConfig.Inventory
+	c.JobSyncEnabled = true // so the job-index step's own values are in play
+	return c
+}
+
+func validRetention() RetentionConfig {
+	c := DefaultConfig.Retention
+	c.Enabled = true
+	return c
+}
+
+func TestInventoryConfig_Validate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		tweak    func(*InventoryConfig)
+		wantErr  string   // empty means the config must be accepted
+		wantErrs []string // every message the one error must carry
+	}{
+		{name: "shipped defaults", tweak: func(*InventoryConfig) {}},
+		{
+			name:    "sync_interval zero",
+			tweak:   func(c *InventoryConfig) { c.SyncInterval = 0 },
+			wantErr: "inventory.sync_interval must be positive",
+		},
+		{
+			name:    "sync_interval negative",
+			tweak:   func(c *InventoryConfig) { c.SyncInterval = -time.Minute },
+			wantErr: "inventory.sync_interval must be positive",
+		},
+		{
+			// A window ending before it starts silently finds no usage at
+			// all, which reads as "every metric is unused".
+			name:    "time_window zero",
+			tweak:   func(c *InventoryConfig) { c.TimeWindow = 0 },
+			wantErr: "inventory.time_window must be positive",
+		},
+		{
+			name:    "run_timeout zero",
+			tweak:   func(c *InventoryConfig) { c.RunTimeout = 0 },
+			wantErr: "inventory.run_timeout must be positive",
+		},
+		{
+			name:    "run_timeout negative",
+			tweak:   func(c *InventoryConfig) { c.RunTimeout = -time.Second },
+			wantErr: "inventory.run_timeout must be positive",
+		},
+		{
+			// Never gated, so it's checked whatever else is switched off.
+			name: "summary_step_timeout zero with every other step disabled",
+			tweak: func(c *InventoryConfig) {
+				c.SummaryStepTimeout = 0
+				c.MetadataSyncEnabled, c.JobSyncEnabled = false, false
+			},
+			wantErr: "inventory.summary_step_timeout must be positive",
+		},
+		{
+			name:    "metadata_step_timeout negative while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.MetadataStepTimeout = -5 * time.Second },
+			wantErr: "inventory.metadata_step_timeout must be positive",
+		},
+		{
+			name: "metadata_step_timeout negative while its step is disabled",
+			tweak: func(c *InventoryConfig) {
+				c.MetadataSyncEnabled = false
+				c.MetadataStepTimeout = -5 * time.Second
+			},
+		},
+		{
+			// The one that would otherwise index nothing in silence: a
+			// label fetch on an already-expired context fails, and that
+			// error is treated as "no series carry a job label".
+			name:    "job_index_label_timeout zero while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.JobIndexLabelTimeout = 0 },
+			wantErr: "inventory.job_index_label_timeout must be positive",
+		},
+		{
+			name:    "job_index_per_job_timeout negative while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.JobIndexPerJobTimeout = -time.Second },
+			wantErr: "inventory.job_index_per_job_timeout must be positive",
+		},
+		{
+			name:    "job_index_workers zero while its step is enabled",
+			tweak:   func(c *InventoryConfig) { c.JobIndexWorkers = 0 },
+			wantErr: "inventory.job_index_workers must be positive",
+		},
+		{
+			name: "every job-index value unusable while its step is disabled",
+			tweak: func(c *InventoryConfig) {
+				c.JobSyncEnabled = false
+				c.JobIndexLabelTimeout, c.JobIndexPerJobTimeout = 0, -time.Second
+				c.JobIndexWorkers = 0
+			},
+		},
+		{
+			// Every bad value at once: an operator with several typos should
+			// see all of them, not one per restart.
+			name: "several unusable values",
+			tweak: func(c *InventoryConfig) {
+				c.SyncInterval, c.RunTimeout, c.SummaryStepTimeout = 0, 0, 0
+			},
+			wantErrs: []string{
+				"inventory.sync_interval must be positive",
+				"inventory.run_timeout must be positive",
+				"inventory.summary_step_timeout must be positive",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validInventory()
+			tc.tweak(&cfg)
+
+			err := cfg.Validate()
+
+			if tc.wantErr == "" && tc.wantErrs == nil {
+				assert.NoError(t, err, "a disabled step's own values can't affect anything, so they don't have to be usable")
+				return
+			}
+			require.Error(t, err)
+			if tc.wantErr != "" {
+				assert.Contains(t, err.Error(), tc.wantErr)
+			}
+			for _, want := range tc.wantErrs {
+				assert.Contains(t, err.Error(), want, "every unusable value has to be reported, not just the first")
+			}
+		})
+	}
+}
+
+func TestRetentionConfig_Validate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		tweak   func(*RetentionConfig)
+		wantErr string
+	}{
+		{name: "shipped defaults", tweak: func(*RetentionConfig) {}},
+		{
+			name:    "interval zero",
+			tweak:   func(c *RetentionConfig) { c.Interval = 0 },
+			wantErr: "retention.interval must be positive",
+		},
+		{
+			name:    "run_timeout negative",
+			tweak:   func(c *RetentionConfig) { c.RunTimeout = -time.Minute },
+			wantErr: "retention.run_timeout must be positive",
+		},
+		{
+			name:    "queries_max_age zero",
+			tweak:   func(c *RetentionConfig) { c.QueriesMaxAge = 0 },
+			wantErr: "retention.queries_max_age must be positive",
+		},
+		{
+			// Checked whether or not the worker runs: an unusable value is
+			// an operator's typo either way, and enabling the job later
+			// shouldn't be what surfaces it.
+			name: "queries_max_age zero while the job is disabled",
+			tweak: func(c *RetentionConfig) {
+				c.Enabled = false
+				c.QueriesMaxAge = 0
+			},
+			wantErr: "retention.queries_max_age must be positive",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validRetention()
+			tc.tweak(&cfg)
+
+			err := cfg.Validate()
+
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestConfig_Validate_ReportsEverySectionItRuns proves the aggregate reaches
+// both jobs' sections and reports them together, so startup can't pass on a
+// config either of them would reject, and an operator sees every problem in
+// one go.
+func TestConfig_Validate_ReportsEverySectionItRuns(t *testing.T) {
+	cfg := *DefaultConfig
+	cfg.Inventory.Enabled, cfg.Retention.Enabled = true, true
+	cfg.Inventory.SyncInterval = 0
+	cfg.Retention.QueriesMaxAge = 0
+
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inventory.sync_interval")
+	assert.Contains(t, err.Error(), "retention.queries_max_age", "both sections' problems must arrive together")
+
+	var nilCfg *Config
+	require.ErrorContains(t, nilCfg.Validate(), "config is required")
+}
+
+// TestConfig_Validate_SkipsSectionsThisProcessWontRun proves a job switched
+// off is not a reason to refuse startup: its values are never read, and the
+// ingester command reads neither section, so a config carrying a stale
+// disabled block still starts.
+func TestConfig_Validate_SkipsSectionsThisProcessWontRun(t *testing.T) {
+	cfg := *DefaultConfig
+	cfg.Inventory.Enabled, cfg.Retention.Enabled = false, false
+	cfg.Inventory.SyncInterval = 0
+	cfg.Retention.QueriesMaxAge = 0
+
+	assert.NoError(t, cfg.Validate())
+}
+
+// TestConfig_Validate_AcceptsTheShippedDefaults guards the defaults against
+// their own range rules: every default a job reads has to be usable as
+// shipped, with or without the steps that are gated off by default.
+func TestConfig_Validate_AcceptsTheShippedDefaults(t *testing.T) {
+	require.NoError(t, DefaultConfig.Validate())
+
+	withJobSync := *DefaultConfig
+	withJobSync.Inventory.JobSyncEnabled = true
+	require.NoError(t, withJobSync.Validate())
+}

--- a/internal/inventory/job_index.go
+++ b/internal/inventory/job_index.go
@@ -1,0 +1,128 @@
+package inventory
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+	"github.com/prometheus/common/model"
+)
+
+// syncJobIndex populates job_index: which metrics each Prometheus job
+// produces, used to answer job-scoped "which of this job's metrics are
+// unused" queries. Bounded as a whole by jobIndexTimeout - independent of
+// every other RunOnce step (see docs/jobs.md) - since its own duration
+// otherwise scales with however many jobs Prometheus reports at run time,
+// something no per-call timeout alone can bound.
+func (s *Syncer) syncJobIndex(ctx context.Context, tr db.TimeRange) error {
+	jobIndexCtx, cancel := context.WithTimeout(ctx, s.jobIndexTimeout)
+	defer cancel()
+
+	labelCtx, cancelLabels := context.WithTimeout(jobIndexCtx, s.jobIndexLabelTimeout)
+	defer cancelLabels()
+	jobs, _, err := s.promAPI.LabelValues(labelCtx, "job", []string{}, tr.From, tr.To)
+	if err != nil {
+		// Handle 404 gracefully - it means no series with job label exist or endpoint not supported
+		slog.Warn("failed to fetch job label values", "err", err, "msg", "job index will be empty - this is normal if no series have job labels")
+		return nil
+	}
+
+	if len(jobs) == 0 {
+		slog.Debug("no job labels found in time range", "from", tr.From, "to", tr.To)
+		return nil
+	}
+
+	slog.Info("syncing job index", "jobs_found", len(jobs), "workers", s.jobIndexWorkers, "time_range", tr)
+
+	jobChan := make(chan string, len(jobs))
+	errorChan := make(chan error, len(jobs))
+
+	var wg sync.WaitGroup
+	for i := 0; i < s.jobIndexWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for job := range jobChan {
+				err := s.processJob(jobIndexCtx, job, tr, workerID)
+				errorChan <- err
+			}
+		}(i)
+	}
+
+	jobsProcessed := 0
+	for _, jobLabel := range jobs {
+		job := string(jobLabel)
+		if job != "" {
+			jobChan <- job
+			jobsProcessed++
+		}
+	}
+	close(jobChan)
+
+	go func() {
+		wg.Wait()
+		close(errorChan)
+	}()
+
+	var successCount, failureCount int
+	for err := range errorChan {
+		if err != nil {
+			failureCount++
+		} else {
+			successCount++
+		}
+	}
+
+	slog.Info("job index sync complete",
+		"jobs_processed", jobsProcessed,
+		"successful", successCount,
+		"failed", failureCount)
+
+	if failureCount > 0 && failureCount > successCount/2 {
+		return fmt.Errorf("job index sync failed: %d failures out of %d jobs", failureCount, jobsProcessed)
+	}
+
+	return nil
+}
+
+func (s *Syncer) processJob(ctx context.Context, job string, tr db.TimeRange, workerID int) error {
+	jobCtx, cancelJob := context.WithTimeout(ctx, s.jobIndexPerJobTimeout)
+	defer cancelJob()
+
+	query := fmt.Sprintf(`group({job="%s", __name__=~".+"}) by (__name__)`, job)
+	result, _, err := s.promAPI.Query(jobCtx, query, tr.To)
+	if err != nil {
+		slog.Warn("failed to query metrics for job", "job", job, "worker", workerID, "query", query, "err", err)
+		return err
+	}
+
+	metricNames := make(map[string]struct{})
+
+	switch v := result.(type) {
+	case model.Vector:
+		for _, sample := range v {
+			if metricName, ok := sample.Metric["__name__"]; ok {
+				metricNames[string(metricName)] = struct{}{}
+			}
+		}
+	default:
+		slog.Debug("unexpected query result type", "job", job, "worker", workerID, "type", fmt.Sprintf("%T", result))
+	}
+
+	var items []db.MetricJobIndexItem
+	for name := range metricNames {
+		items = append(items, db.MetricJobIndexItem{Name: name, Job: job})
+	}
+
+	if len(items) > 0 {
+		if err := s.dbProvider.UpsertMetricsJobIndex(ctx, items); err != nil {
+			slog.Error("failed to upsert metrics for job", "job", job, "worker", workerID, "metrics", len(items), "err", err)
+			return fmt.Errorf("upsert job %s: %w", job, err)
+		}
+		slog.Debug("processed job", "job", job, "worker", workerID, "metrics", len(items))
+	}
+
+	return nil
+}

--- a/internal/inventory/job_index_test.go
+++ b/internal/inventory/job_index_test.go
@@ -1,0 +1,339 @@
+package inventory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every step timeout below is a shipped default, and runTimeout is exactly
+// their sum - the minimum NewSyncer accepts. The non-starvation tests that
+// follow run inside a synctest bubble, so they can drive that real budget
+// on a fake clock instead of a millisecond-scale imitation of it.
+const (
+	defaultMetadataStepTimeout = 30 * time.Second
+	defaultSummaryStepTimeout  = 30 * time.Second
+	defaultJobIndexTimeout     = 240 * time.Second
+	// nearItsCap is long enough to leave a later step nothing at all if the
+	// budgets were ever shared rather than independent.
+	nearItsCap = 29 * time.Second
+)
+
+// defaultBudgetSyncer builds a Syncer on the shipped default budget with
+// every step enabled, so a test only has to say which step runs close to
+// its own cap.
+func defaultBudgetSyncer(provider db.Provider, promAPI v1.API) *Syncer {
+	return &Syncer{
+		dbProvider:             provider,
+		promAPI:                promAPI,
+		timeWindow:             time.Hour,
+		metadataSyncEnabled:    true,
+		runTimeout:             defaultMetadataStepTimeout + defaultSummaryStepTimeout + defaultJobIndexTimeout,
+		metadataStepTimeout:    defaultMetadataStepTimeout,
+		summaryStepTimeout:     defaultSummaryStepTimeout,
+		jobSyncEnabled:         true,
+		jobIndexTimeout:        defaultJobIndexTimeout,
+		jobIndexLabelTimeout:   30 * time.Second,
+		jobIndexPerJobTimeout:  30 * time.Second,
+		jobIndexWorkers:        1,
+		syncDuration:           newHistogram(),
+		syncSuccess:            newCounter(),
+		syncFailure:            newCounter(),
+		catalogSummaryMismatch: newCounter(),
+	}
+}
+
+// oneJobAPI answers a single job's queries quickly, so whatever a test does
+// to the steps before job index is the only thing that can starve it.
+func oneJobAPI() *fakePromAPI {
+	return &fakePromAPI{
+		meta:       map[string][]v1.Metadata{"up": {{Type: "gauge", Help: "up metric"}}},
+		labelDelay: 5 * time.Second,
+		jobs:       []string{"job-a"},
+		queryDelay: 10 * time.Second, // label+query need 15s, well inside jobIndexTimeout
+	}
+}
+
+// jobIndexOnlySyncer builds a Syncer for driving syncJobIndex directly:
+// every timeout generous enough not to interfere, so a test that cares
+// about one of them sets just that one.
+func jobIndexOnlySyncer(provider db.Provider, promAPI v1.API) *Syncer {
+	return &Syncer{
+		dbProvider:            provider,
+		promAPI:               promAPI,
+		jobIndexTimeout:       time.Hour,
+		jobIndexLabelTimeout:  time.Hour,
+		jobIndexPerJobTimeout: time.Hour,
+		jobIndexWorkers:       1,
+	}
+}
+
+// TestSyncer_CatalogRunningCloseToItsOwnBudgetDoesNotStarveJobIndex proves
+// job index gets its own full jobIndexTimeout window regardless of how much
+// of its own metadataStepTimeout the catalog step actually used - the same
+// non-starvation guarantee every independently-budgeted step of a cycle gets.
+func TestSyncer_CatalogRunningCloseToItsOwnBudgetDoesNotStarveJobIndex(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		provider := &fakeProvider{}
+		api := oneJobAPI()
+		api.metadataDelay = nearItsCap
+
+		s := defaultBudgetSyncer(provider, api)
+		s.runOnce(context.Background())
+
+		provider.mu.Lock()
+		defer provider.mu.Unlock()
+		assert.Equal(t, 1, provider.catalogCommits, "metadata catalog step should have committed")
+		assert.Equal(t, 1, provider.summaryCalls, "summary refresh should have been attempted")
+		assert.Len(t, provider.jobIndexItems, 1,
+			"job index should get its own full jobIndexTimeout window (%s) even though the metadata "+
+				"step already used %s of its own %s budget; otherwise the job index is never populated",
+			defaultJobIndexTimeout, nearItsCap, defaultMetadataStepTimeout)
+	})
+}
+
+// TestSyncer_SlowSummaryRefreshDoesNotStarveJobIndex is the same guarantee
+// for the other step job index runs behind: a summary refresh close to its
+// own cap must leave job index its full window too, not just a catalog
+// step doing so.
+func TestSyncer_SlowSummaryRefreshDoesNotStarveJobIndex(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		provider := &fakeProvider{summaryDelay: nearItsCap}
+
+		s := defaultBudgetSyncer(provider, oneJobAPI())
+		s.runOnce(context.Background())
+
+		provider.mu.Lock()
+		defer provider.mu.Unlock()
+		assert.Equal(t, 1, provider.summaryCalls, "summary refresh should have been attempted")
+		assert.Len(t, provider.jobIndexItems, 1,
+			"job index should get its own full jobIndexTimeout window even though the summary step "+
+				"already used most of its own %s budget", defaultSummaryStepTimeout)
+	})
+}
+
+// TestSyncer_AllPrecedingStepsNearTheirOwnCapsStillLeaveJobIndexItsFullWindow
+// drives the actual worst case NewSyncer's validation protects against:
+// every enabled step before job index running close to its own cap at
+// once, with runTimeout sized to exactly their validated sum (no slack).
+func TestSyncer_AllPrecedingStepsNearTheirOwnCapsStillLeaveJobIndexItsFullWindow(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		provider := &fakeProvider{summaryDelay: nearItsCap}
+		api := oneJobAPI()
+		api.metadataDelay = nearItsCap
+
+		s := defaultBudgetSyncer(provider, api)
+		s.runOnce(context.Background())
+
+		provider.mu.Lock()
+		defer provider.mu.Unlock()
+		assert.Equal(t, 1, provider.catalogCommits)
+		assert.Equal(t, 1, provider.summaryCalls)
+		assert.Len(t, provider.jobIndexItems, 1,
+			"job index should still get its full jobIndexTimeout window even when every preceding "+
+				"step ran close to its own cap, with runTimeout sized to exactly their validated sum")
+	})
+}
+
+// TestSyncJobIndex_JobIndexTimeoutBoundsTheStepOnItsOwn proves
+// jobIndexTimeout itself - not whatever's left of some caller's own
+// context - is what bounds the job-index step: called directly with an
+// unbounded context, jobIndexTimeout alone must still cut processing off
+// partway through. Under a fake clock the cut-off point is exact: two
+// 100s jobs fit inside the 240s cap, the third does not.
+func TestSyncJobIndex_JobIndexTimeoutBoundsTheStepOnItsOwn(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		provider := &fakeProvider{}
+		api := &fakePromAPI{
+			jobs:       []string{"job-1", "job-2", "job-3", "job-4", "job-5"},
+			queryDelay: 100 * time.Second,
+		}
+
+		s := jobIndexOnlySyncer(provider, api)
+		s.jobIndexTimeout = defaultJobIndexTimeout // the only limiter this test leaves in play
+
+		_ = s.syncJobIndex(context.Background(), lastHour())
+
+		provider.mu.Lock()
+		defer provider.mu.Unlock()
+		assert.Len(t, provider.jobIndexItems, 2,
+			"jobIndexTimeout (%s) should cut the step off partway through 5 jobs at %s each, even "+
+				"with no outer context bounding it at all", s.jobIndexTimeout, api.queryDelay)
+	})
+}
+
+// TestSyncJobIndex_NoJobLabelsFound_CompletesWithoutUpserts proves an
+// empty job-label result is a normal, non-error outcome (e.g. no series
+// have a job label yet), not a failure.
+func TestSyncJobIndex_NoJobLabelsFound_CompletesWithoutUpserts(t *testing.T) {
+	provider := &fakeProvider{}
+	api := &fakePromAPI{jobs: nil}
+	s := jobIndexOnlySyncer(provider, api)
+
+	err := s.syncJobIndex(context.Background(), lastHour())
+
+	require.NoError(t, err)
+	assert.Empty(t, provider.jobIndexItems)
+}
+
+// TestSyncJobIndex_LabelValuesError_TreatedAsEmptyIndexNotFailure proves a
+// job-label-fetch error (e.g. a 404 on a Prometheus without job labels) is
+// logged and treated as an empty index, not returned as this cycle's
+// failure.
+func TestSyncJobIndex_LabelValuesError_TreatedAsEmptyIndexNotFailure(t *testing.T) {
+	provider := &fakeProvider{}
+	api := &fakePromAPI{labelErr: errors.New("upstream unavailable")}
+	s := jobIndexOnlySyncer(provider, api)
+
+	err := s.syncJobIndex(context.Background(), lastHour())
+
+	require.NoError(t, err)
+	assert.Empty(t, provider.jobIndexItems)
+}
+
+// TestSyncJobIndex_MinorityOfJobFailures_StillReturnsNilAndCommitsTheRest
+// proves the step tolerates a minority of per-job failures - each job is
+// independent, so one job's upstream error shouldn't cost the others their
+// own results.
+func TestSyncJobIndex_MinorityOfJobFailures_StillReturnsNilAndCommitsTheRest(t *testing.T) {
+	provider := &fakeProvider{}
+	api := &fakePromAPI{
+		jobs:         []string{"job-a", "job-b", "job-c", "job-d"},
+		queryErr:     errors.New("upstream unavailable"),
+		queryErrJobs: map[string]bool{"job-b": true},
+	}
+	s := jobIndexOnlySyncer(provider, api)
+
+	err := s.syncJobIndex(context.Background(), lastHour())
+
+	require.NoError(t, err, "1 failure out of 4 jobs is a minority the step should tolerate")
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	assert.Len(t, provider.jobIndexItems, 3, "the 3 succeeding jobs should still have been committed")
+}
+
+// TestSyncJobIndex_HalfOfTheJobsFailing_ReturnsError pins where tolerance
+// ends: half the jobs failing is already too many, so the threshold sits
+// below half rather than at "most of them".
+func TestSyncJobIndex_HalfOfTheJobsFailing_ReturnsError(t *testing.T) {
+	provider := &fakeProvider{}
+	api := &fakePromAPI{
+		jobs:         []string{"job-a", "job-b", "job-c", "job-d"},
+		queryErr:     errors.New("upstream unavailable"),
+		queryErrJobs: map[string]bool{"job-a": true, "job-b": true},
+	}
+	s := jobIndexOnlySyncer(provider, api)
+
+	err := s.syncJobIndex(context.Background(), lastHour())
+
+	assert.Error(t, err, "2 failures out of 4 jobs is already too many to report as success")
+}
+
+// TestSyncJobIndex_FansOutAcrossEveryWorker proves the concurrent path
+// itself: with more jobs than workers, every job is still queried exactly
+// once and every result committed, no matter which worker picked it up.
+func TestSyncJobIndex_FansOutAcrossEveryWorker(t *testing.T) {
+	jobs := []string{"job-a", "job-b", "job-c", "job-d", "job-e", "job-f", "job-g", "job-h"}
+	provider := &fakeProvider{}
+	api := &fakePromAPI{jobs: jobs}
+	s := jobIndexOnlySyncer(provider, api)
+	s.jobIndexWorkers = 4 // fewer workers than jobs, so the channel is genuinely contended
+
+	err := s.syncJobIndex(context.Background(), lastHour())
+
+	require.NoError(t, err)
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	assert.ElementsMatch(t, jobs, api.queriedJobs, "every job must be picked up exactly once across the workers")
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	assert.Len(t, provider.jobIndexItems, len(jobs))
+}
+
+// TestSyncer_JobIndexFailureStillCountsTheCycleAsSuccessful proves the job
+// index step's outcome is isolated from the cycle's: it runs last and its
+// failure is reported on its own, so it can't turn a committed catalog and
+// a refreshed summary into a failed run.
+func TestSyncer_JobIndexFailureStillCountsTheCycleAsSuccessful(t *testing.T) {
+	provider := &fakeProvider{}
+	api := &fakePromAPI{
+		meta:         map[string][]v1.Metadata{"up": {{Type: "gauge", Help: "up metric"}}},
+		jobs:         []string{"job-a", "job-b", "job-c"},
+		queryErr:     errors.New("upstream unavailable"),
+		queryErrJobs: map[string]bool{"job-a": true, "job-b": true, "job-c": true},
+	}
+
+	s := defaultBudgetSyncer(provider, api)
+
+	s.runOnce(context.Background())
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	assert.Equal(t, 1, provider.catalogCommits)
+	assert.Equal(t, 1, provider.summaryCalls)
+	assert.Empty(t, provider.jobIndexItems, "every job's query failed, so nothing was indexed")
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.syncSuccess),
+		"a failed job index step must not cost the cycle its success")
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.syncFailure))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.catalogSummaryMismatch))
+}
+
+// TestSyncJobIndex_MajorityOfJobFailures_ReturnsError proves the step
+// reports failure once too many jobs failed for the result to be worth
+// trusting silently.
+func TestSyncJobIndex_MajorityOfJobFailures_ReturnsError(t *testing.T) {
+	provider := &fakeProvider{}
+	api := &fakePromAPI{
+		jobs:         []string{"job-a", "job-b", "job-c"},
+		queryErr:     errors.New("upstream unavailable"),
+		queryErrJobs: map[string]bool{"job-a": true, "job-b": true},
+	}
+	s := jobIndexOnlySyncer(provider, api)
+
+	err := s.syncJobIndex(context.Background(), lastHour())
+
+	assert.Error(t, err, "2 failures out of 3 jobs should be reported, not silently tolerated")
+}
+
+// TestSyncJobIndex_SkipsEmptyStringJobLabel proves an empty-string job
+// label - a real value Prometheus's job-label endpoint can return - is
+// filtered out before ever being queried, rather than producing a
+// nonsensical `job=""` lookup.
+func TestSyncJobIndex_SkipsEmptyStringJobLabel(t *testing.T) {
+	provider := &fakeProvider{}
+	api := &fakePromAPI{jobs: []string{"", "job-a"}}
+	s := jobIndexOnlySyncer(provider, api)
+
+	err := s.syncJobIndex(context.Background(), lastHour())
+
+	require.NoError(t, err)
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	assert.Equal(t, []string{"job-a"}, api.queriedJobs, "the empty-string label must never reach Query")
+}
+
+// TestProcessJob_UpsertFailure_WrapsAndReturnsTheError proves a storage
+// failure while committing one job's results is reported back to the
+// caller, wrapped with which job it was for - not swallowed.
+func TestProcessJob_UpsertFailure_WrapsAndReturnsTheError(t *testing.T) {
+	provider := &fakeProvider{
+		upsertErr:       errors.New("connection reset"),
+		upsertErrForJob: "job-a",
+	}
+	api := &fakePromAPI{}
+	s := jobIndexOnlySyncer(provider, api)
+
+	err := s.processJob(context.Background(), "job-a", lastHour(), 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upsert job job-a")
+	assert.ErrorContains(t, err, "connection reset")
+}

--- a/internal/inventory/job_index_test.go
+++ b/internal/inventory/job_index_test.go
@@ -79,7 +79,7 @@ func jobIndexOnlySyncer(provider db.Provider, promAPI v1.API) *Syncer {
 // TestSyncer_CatalogRunningCloseToItsOwnBudgetDoesNotStarveJobIndex proves
 // job index gets its own full jobIndexTimeout window regardless of how much
 // of its own metadataStepTimeout the catalog step actually used - the same
-// non-starvation guarantee every independently-budgeted step of a cycle gets.
+// non-starvation guarantee every independently-budgeted RunOnce step gets.
 func TestSyncer_CatalogRunningCloseToItsOwnBudgetDoesNotStarveJobIndex(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		provider := &fakeProvider{}
@@ -87,7 +87,7 @@ func TestSyncer_CatalogRunningCloseToItsOwnBudgetDoesNotStarveJobIndex(t *testin
 		api.metadataDelay = nearItsCap
 
 		s := defaultBudgetSyncer(provider, api)
-		s.runOnce(context.Background())
+		s.RunOnce(context.Background())
 
 		provider.mu.Lock()
 		defer provider.mu.Unlock()
@@ -109,7 +109,7 @@ func TestSyncer_SlowSummaryRefreshDoesNotStarveJobIndex(t *testing.T) {
 		provider := &fakeProvider{summaryDelay: nearItsCap}
 
 		s := defaultBudgetSyncer(provider, oneJobAPI())
-		s.runOnce(context.Background())
+		s.RunOnce(context.Background())
 
 		provider.mu.Lock()
 		defer provider.mu.Unlock()
@@ -131,7 +131,7 @@ func TestSyncer_AllPrecedingStepsNearTheirOwnCapsStillLeaveJobIndexItsFullWindow
 		api.metadataDelay = nearItsCap
 
 		s := defaultBudgetSyncer(provider, api)
-		s.runOnce(context.Background())
+		s.RunOnce(context.Background())
 
 		provider.mu.Lock()
 		defer provider.mu.Unlock()
@@ -273,7 +273,7 @@ func TestSyncer_JobIndexFailureStillCountsTheCycleAsSuccessful(t *testing.T) {
 
 	s := defaultBudgetSyncer(provider, api)
 
-	s.runOnce(context.Background())
+	s.RunOnce(context.Background())
 
 	provider.mu.Lock()
 	defer provider.mu.Unlock()

--- a/internal/inventory/syncer.go
+++ b/internal/inventory/syncer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math/rand"
 	"strconv"
 	"time"
 
@@ -20,7 +19,6 @@ type Syncer struct {
 	dbProvider              db.Provider
 	promAPI                 v1.API
 	timeWindow              time.Duration
-	interval                time.Duration
 	metadataLim             string
 	metadataSyncEnabled     bool
 	metadataMetricsNameOnly bool
@@ -130,7 +128,6 @@ func NewSyncer(dbp db.Provider, upstream string, cfg *config.Config, reg prometh
 		dbProvider:              dbp,
 		promAPI:                 v1.NewAPI(client),
 		timeWindow:              cfg.Inventory.TimeWindow,
-		interval:                cfg.Inventory.SyncInterval,
 		metadataLim:             lim,
 		metadataSyncEnabled:     cfg.Inventory.MetadataSyncEnabled,
 		metadataMetricsNameOnly: cfg.Inventory.MetadataMetricsNameOnly,
@@ -168,31 +165,15 @@ func NewSyncer(dbp db.Provider, upstream string, cfg *config.Config, reg prometh
 	return s, nil
 }
 
-func (s *Syncer) RunLeaderless(ctx context.Context) {
-	s.runLoop(ctx)
-}
-
-func (s *Syncer) runLoop(ctx context.Context) {
-	ticker := time.NewTicker(s.interval + time.Duration(rand.Int63n(int64(s.interval/5))))
-	defer ticker.Stop()
-
-	s.runOnce(ctx)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			s.runOnce(ctx)
-		}
-	}
-}
-
-// runOnce runs exactly one sync cycle. cycleCtx is the single deadline every
-// step below derives from, bounded by runTimeout. Each step still nests its
-// own context.WithTimeout inside it and gets that window in full; the
-// settled sum is what makes that safe.
-func (s *Syncer) runOnce(ctx context.Context) {
+// RunOnce runs exactly one sync cycle, bounded by whatever ctx it's given -
+// scheduling and leadership are entirely the caller's concern; RunOnce
+// itself doesn't loop or know who's calling it.
+//
+// cycleCtx is the single deadline every step below derives from, bounded
+// by runTimeout. Each step still nests its own context.WithTimeout inside
+// it and gets that window in full; NewSyncer's validation of runTimeout
+// against the step sum is what makes that safe.
+func (s *Syncer) RunOnce(ctx context.Context) {
 	start := time.Now()
 	cycleCtx, cancel := context.WithTimeout(ctx, s.runTimeout)
 	defer cancel()

--- a/internal/inventory/syncer.go
+++ b/internal/inventory/syncer.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"math/rand"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
@@ -15,7 +14,6 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/common/model"
 )
 
 type Syncer struct {
@@ -31,6 +29,7 @@ type Syncer struct {
 	metadataStepTimeout   time.Duration
 	summaryStepTimeout    time.Duration
 	jobSyncEnabled        bool
+	jobIndexTimeout       time.Duration
 	jobIndexLabelTimeout  time.Duration
 	jobIndexPerJobTimeout time.Duration
 
@@ -42,13 +41,89 @@ type Syncer struct {
 	catalogSummaryMismatch prometheus.Counter
 }
 
+// A cycle's enabled steps are independent, non-overlapping budgets, so its
+// worst case is all of them in full and RunTimeout has to cover that sum;
+// the same holds one level down, where JobIndexTimeout has to cover its own
+// label fetch plus at least one job's query. Where a container is too small
+// for what it must hold, the two settled* functions below widen it and warn
+// naming the value to fix, rather than refusing to start: the operator asked
+// for those step budgets, and running with them is closer to their intent
+// than not running at all.
+// settledRunTimeout reads JobIndexTimeout as given, so a caller wanting both
+// settled has to settle that one first - as NewSyncer does.
+func settledRunTimeout(cfg config.InventoryConfig) time.Duration {
+	stepSum := cfg.SummaryStepTimeout
+	if cfg.MetadataSyncEnabled {
+		stepSum += cfg.MetadataStepTimeout
+	}
+	if cfg.JobSyncEnabled {
+		stepSum += cfg.JobIndexTimeout
+	}
+	if stepSum <= cfg.RunTimeout {
+		return cfg.RunTimeout
+	}
+	slog.Warn("inventory: run_timeout is shorter than the steps one cycle must run; raising it - set it to at least this sum in your config to silence this",
+		"configured", cfg.RunTimeout,
+		"using", stepSum,
+		"metadata_step_timeout", cfg.MetadataStepTimeout,
+		"metadata_sync_enabled", cfg.MetadataSyncEnabled,
+		"summary_step_timeout", cfg.SummaryStepTimeout,
+		"job_index_timeout", cfg.JobIndexTimeout,
+		"job_sync_enabled", cfg.JobSyncEnabled)
+	return stepSum
+}
+
+// settledJobIndexTimeout's widening feeds the step sum above, so it can
+// widen the cycle that has to contain it.
+func settledJobIndexTimeout(cfg config.InventoryConfig) time.Duration {
+	min := cfg.JobIndexLabelTimeout + cfg.JobIndexPerJobTimeout
+	if !cfg.JobSyncEnabled || cfg.JobIndexTimeout >= min {
+		return cfg.JobIndexTimeout
+	}
+	slog.Warn("inventory: job_index_timeout is too short to fetch job labels and process a single job; raising it - set it to at least this sum in your config to silence this",
+		"configured", cfg.JobIndexTimeout,
+		"using", min,
+		"job_index_label_timeout", cfg.JobIndexLabelTimeout,
+		"job_index_per_job_timeout", cfg.JobIndexPerJobTimeout)
+	return min
+}
+
+// NewSyncer builds a Syncer whose cycles run under settled timeouts (see
+// above) and rejects the config values nothing could settle - a non-positive
+// interval, no workers to fan out to.
+//
+// One caveat that outlives construction: the settled sum bounds the
+// configured worst case, not the wall clock. A step whose work overruns its
+// own context spends budget a later step was counting on, and a RunTimeout
+// equal to the sum has no slack to absorb that. It is still enough that
+// RunOnce can nest every step under one shared context - see docs/jobs.md,
+// and https://github.com/nicolastakashi/prom-analytics-proxy/issues/572 for
+// the starvation this generalizes away.
 func NewSyncer(dbp db.Provider, upstream string, cfg *config.Config, reg prometheus.Registerer) (*Syncer, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+
 	client, err := api.NewClient(api.Config{Address: upstream})
 	if err != nil {
 		return nil, err
 	}
+
+	// Range checks live with the schema (see config.InventoryConfig.Validate);
+	// startup runs them before anything acts on the config, and calling them
+	// again here is what holds for a caller that never went through startup.
+	if err := cfg.Inventory.Validate(); err != nil {
+		return nil, err
+	}
+
+	// A copy, not cfg itself: a constructor that rewrote its caller's config
+	// would surprise anyone sharing one.
+	inv := cfg.Inventory
+	inv.JobIndexTimeout = settledJobIndexTimeout(inv)
+	inv.RunTimeout = settledRunTimeout(inv)
+
 	lim := ""
-	if cfg != nil && cfg.MetadataLimit > 0 {
+	if cfg.MetadataLimit > 0 {
 		lim = strconv.FormatUint(cfg.MetadataLimit, 10)
 	}
 	s := &Syncer{
@@ -59,10 +134,11 @@ func NewSyncer(dbp db.Provider, upstream string, cfg *config.Config, reg prometh
 		metadataLim:             lim,
 		metadataSyncEnabled:     cfg.Inventory.MetadataSyncEnabled,
 		metadataMetricsNameOnly: cfg.Inventory.MetadataMetricsNameOnly,
-		runTimeout:              cfg.Inventory.RunTimeout,
+		runTimeout:              inv.RunTimeout,
 		metadataStepTimeout:     cfg.Inventory.MetadataStepTimeout,
 		summaryStepTimeout:      cfg.Inventory.SummaryStepTimeout,
 		jobSyncEnabled:          cfg.Inventory.JobSyncEnabled,
+		jobIndexTimeout:         inv.JobIndexTimeout,
 		jobIndexLabelTimeout:    cfg.Inventory.JobIndexLabelTimeout,
 		jobIndexPerJobTimeout:   cfg.Inventory.JobIndexPerJobTimeout,
 		jobIndexWorkers:         cfg.Inventory.JobIndexWorkers,
@@ -112,12 +188,16 @@ func (s *Syncer) runLoop(ctx context.Context) {
 	}
 }
 
+// runOnce runs exactly one sync cycle. cycleCtx is the single deadline every
+// step below derives from, bounded by runTimeout. Each step still nests its
+// own context.WithTimeout inside it and gets that window in full; the
+// settled sum is what makes that safe.
 func (s *Syncer) runOnce(ctx context.Context) {
 	start := time.Now()
-	runCtx, cancel := context.WithTimeout(ctx, s.runTimeout)
+	cycleCtx, cancel := context.WithTimeout(ctx, s.runTimeout)
 	defer cancel()
 
-	catalogCommitted, err := s.syncCatalogAndSummary(ctx, runCtx)
+	catalogCommitted, err := s.syncCatalogAndSummary(cycleCtx)
 	if err != nil {
 		s.syncFailure.Inc()
 		if catalogCommitted {
@@ -137,7 +217,7 @@ func (s *Syncer) runOnce(ctx context.Context) {
 
 	if s.jobSyncEnabled {
 		tr := db.TimeRange{From: time.Now().UTC().Add(-s.timeWindow), To: time.Now().UTC()}
-		if err := s.syncJobIndex(runCtx, tr); err != nil {
+		if err := s.syncJobIndex(cycleCtx, tr); err != nil {
 			slog.Error("inventory: job index", "err", err)
 		}
 	}
@@ -152,25 +232,14 @@ func (s *Syncer) runOnce(ctx context.Context) {
 // was intentionally skipped) so the caller can tell an ordinary failure
 // apart from the partial-failure case where the catalog moved forward but
 // the summary refresh didn't.
-//
-// The two steps deliberately do NOT share a single deadline: the catalog
-// step is bounded by runCtx (itself bounded by runTimeout), while the
-// summary step gets its own context.WithTimeout(baseCtx, summaryStepTimeout)
-// built directly from baseCtx. Deriving the summary step's deadline from
-// runCtx instead would let a slow-but-successful catalog step eat into
-// runCtx's remaining budget and hand the refresh less than its configured
-// timeout - or none at all - on every single run, permanently starving it
-// (see #572). Giving the refresh its own independent budget guarantees it
-// always gets a full, fair shot regardless of how long the catalog step
-// took.
-func (s *Syncer) syncCatalogAndSummary(baseCtx, runCtx context.Context) (catalogCommitted bool, err error) {
+func (s *Syncer) syncCatalogAndSummary(cycleCtx context.Context) (catalogCommitted bool, err error) {
 	if s.metadataSyncEnabled {
 		if s.metadataMetricsNameOnly {
-			if err := s.syncMetadataCatalogFromMetricNames(runCtx); err != nil {
+			if err := s.syncMetadataCatalogFromMetricNames(cycleCtx); err != nil {
 				return false, err
 			}
 		} else {
-			if err := s.syncMetadataCatalog(runCtx); err != nil {
+			if err := s.syncMetadataCatalog(cycleCtx); err != nil {
 				return false, err
 			}
 		}
@@ -178,7 +247,7 @@ func (s *Syncer) syncCatalogAndSummary(baseCtx, runCtx context.Context) (catalog
 		slog.Info("inventory: metadata sync disabled, skipping catalog population")
 	}
 
-	sumCtx, cancelSum := context.WithTimeout(baseCtx, s.summaryStepTimeout)
+	sumCtx, cancelSum := context.WithTimeout(cycleCtx, s.summaryStepTimeout)
 	defer cancelSum()
 	tr := db.TimeRange{From: time.Now().UTC().Add(-s.timeWindow), To: time.Now().UTC()}
 	if err := s.dbProvider.RefreshMetricsUsageSummary(sumCtx, tr); err != nil {
@@ -251,114 +320,5 @@ func (s *Syncer) syncMetadataCatalogFromMetricNames(ctx context.Context) error {
 		slog.Error("inventory: upsert catalog", "err", err)
 		return err
 	}
-	return nil
-}
-
-func (s *Syncer) syncJobIndex(ctx context.Context, tr db.TimeRange) error {
-	labelCtx, cancelLabels := context.WithTimeout(ctx, s.jobIndexLabelTimeout)
-	defer cancelLabels()
-	jobs, _, err := s.promAPI.LabelValues(labelCtx, "job", []string{}, tr.From, tr.To)
-	if err != nil {
-		// Handle 404 gracefully - it means no series with job label exist or endpoint not supported
-		slog.Warn("failed to fetch job label values", "err", err, "msg", "job index will be empty - this is normal if no series have job labels")
-		return nil
-	}
-
-	if len(jobs) == 0 {
-		slog.Debug("no job labels found in time range", "from", tr.From, "to", tr.To)
-		return nil
-	}
-
-	slog.Info("syncing job index", "jobs_found", len(jobs), "workers", s.jobIndexWorkers, "time_range", tr)
-
-	jobChan := make(chan string, len(jobs))
-	errorChan := make(chan error, len(jobs))
-
-	var wg sync.WaitGroup
-	for i := 0; i < s.jobIndexWorkers; i++ {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
-			for job := range jobChan {
-				err := s.processJob(ctx, job, tr, workerID)
-				errorChan <- err
-			}
-		}(i)
-	}
-
-	jobsProcessed := 0
-	for _, jobLabel := range jobs {
-		job := string(jobLabel)
-		if job != "" {
-			jobChan <- job
-			jobsProcessed++
-		}
-	}
-	close(jobChan)
-
-	go func() {
-		wg.Wait()
-		close(errorChan)
-	}()
-
-	var successCount, failureCount int
-	for err := range errorChan {
-		if err != nil {
-			failureCount++
-		} else {
-			successCount++
-		}
-	}
-
-	slog.Info("job index sync complete",
-		"jobs_processed", jobsProcessed,
-		"successful", successCount,
-		"failed", failureCount)
-
-	if failureCount > 0 && failureCount > successCount/2 {
-		return fmt.Errorf("job index sync failed: %d failures out of %d jobs", failureCount, jobsProcessed)
-	}
-
-	return nil
-}
-
-func (s *Syncer) processJob(ctx context.Context, job string, tr db.TimeRange, workerID int) error {
-	jobCtx, cancelJob := context.WithTimeout(ctx, s.jobIndexPerJobTimeout)
-	defer cancelJob()
-
-	query := fmt.Sprintf(`group({job="%s", __name__=~".+"}) by (__name__)`, job)
-	result, _, err := s.promAPI.Query(jobCtx, query, tr.To)
-	if err != nil {
-		slog.Warn("failed to query metrics for job", "job", job, "worker", workerID, "query", query, "err", err)
-		return err
-	}
-
-	metricNames := make(map[string]struct{})
-
-	// Extract metric names from the query result
-	switch v := result.(type) {
-	case model.Vector:
-		for _, sample := range v {
-			if metricName, ok := sample.Metric["__name__"]; ok {
-				metricNames[string(metricName)] = struct{}{}
-			}
-		}
-	default:
-		slog.Debug("unexpected query result type", "job", job, "worker", workerID, "type", fmt.Sprintf("%T", result))
-	}
-
-	var items []db.MetricJobIndexItem
-	for name := range metricNames {
-		items = append(items, db.MetricJobIndexItem{Name: name, Job: job})
-	}
-
-	if len(items) > 0 {
-		if err := s.dbProvider.UpsertMetricsJobIndex(ctx, items); err != nil {
-			slog.Error("failed to upsert metrics for job", "job", job, "worker", workerID, "metrics", len(items), "err", err)
-			return fmt.Errorf("upsert job %s: %w", job, err)
-		}
-		slog.Debug("processed job", "job", job, "worker", workerID, "metrics", len(items))
-	}
-
 	return nil
 }

--- a/internal/inventory/syncer_test.go
+++ b/internal/inventory/syncer_test.go
@@ -62,7 +62,7 @@ func TestSyncer_SlowMetadataStepDoesNotPermanentlyStarveSummaryRefresh(t *testin
 			provider.summarySucceeded = false
 			provider.mu.Unlock()
 
-			s.runOnce(context.Background())
+			s.RunOnce(context.Background())
 
 			provider.mu.Lock()
 			commits, calls, succeeded := provider.catalogCommits, provider.summaryCalls, provider.summarySucceeded
@@ -105,7 +105,7 @@ func TestSyncer_SummaryFailureAfterCatalogCommitEmitsMismatchMetric(t *testing.T
 		catalogSummaryMismatch: newCounter(),
 	}
 
-	s.runOnce(context.Background())
+	s.RunOnce(context.Background())
 
 	assert.Equal(t, 1, provider.catalogCommits, "catalog step should have committed")
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.syncFailure), "generic failure counter should still increment")
@@ -135,7 +135,7 @@ func TestSyncer_MetadataFailureDoesNotEmitMismatchMetric(t *testing.T) {
 		catalogSummaryMismatch: newCounter(),
 	}
 
-	s.runOnce(context.Background())
+	s.RunOnce(context.Background())
 
 	assert.Equal(t, 0, provider.catalogCommits, "catalog step should not have committed")
 	assert.Equal(t, 0, provider.summaryCalls, "summary refresh should not even be attempted")
@@ -165,7 +165,7 @@ func TestSyncer_DisabledMetadataSyncStillRefreshesTheSummary(t *testing.T) {
 		catalogSummaryMismatch: newCounter(),
 	}
 
-	s.runOnce(context.Background())
+	s.RunOnce(context.Background())
 
 	assert.Equal(t, 0, provider.catalogCommits, "the catalog step is skipped entirely in this mode")
 	assert.Equal(t, 1, provider.summaryCalls, "the summary refresh is never gated by metadata_sync_enabled")
@@ -199,7 +199,7 @@ func TestSyncer_SummaryFailureWithMetadataSyncDisabledStillEmitsMismatchMetric(t
 		catalogSummaryMismatch: newCounter(),
 	}
 
-	s.runOnce(context.Background())
+	s.RunOnce(context.Background())
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.syncFailure))
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.catalogSummaryMismatch))

--- a/internal/inventory/syncer_test.go
+++ b/internal/inventory/syncer_test.go
@@ -3,140 +3,80 @@ package inventory
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// fakeMetadataAPI is a minimal v1.API stand-in. Embedding the (nil) interface
-// means any method we don't override panics if called - fine, since these
-// tests only ever exercise Metadata.
-type fakeMetadataAPI struct {
-	v1.API
-	delay time.Duration
-	meta  map[string][]v1.Metadata
-	err   error
-}
-
-func (f *fakeMetadataAPI) Metadata(ctx context.Context, _ string, _ string) (map[string][]v1.Metadata, error) {
-	if f.err != nil {
-		return nil, f.err
-	}
-	select {
-	case <-time.After(f.delay):
-		return f.meta, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-}
-
-// fakeInventoryProvider is a minimal db.Provider stand-in that only tracks
-// the two calls the syncer's catalog+summary path makes.
-type fakeInventoryProvider struct {
-	db.Provider
-
-	mu sync.Mutex
-
-	catalogCommits int
-
-	summaryCalls     int
-	summaryWork      time.Duration // how long a real refresh would take
-	summarySucceeded bool
-}
-
-func (f *fakeInventoryProvider) UpsertMetricsCatalog(_ context.Context, _ []db.MetricCatalogItem) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.catalogCommits++
-	return nil
-}
-
-func (f *fakeInventoryProvider) RefreshMetricsUsageSummary(ctx context.Context, _ db.TimeRange) error {
-	f.mu.Lock()
-	f.summaryCalls++
-	f.mu.Unlock()
-
-	select {
-	case <-time.After(f.summaryWork):
-		f.mu.Lock()
-		f.summarySucceeded = true
-		f.mu.Unlock()
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-func newCounter() prometheus.Counter {
-	return prometheus.NewCounter(prometheus.CounterOpts{Name: "test_counter"})
-}
-
-func newHistogram() prometheus.Histogram {
-	return prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_histogram"})
-}
-
 // TestSyncer_SlowMetadataStepDoesNotPermanentlyStarveSummaryRefresh reproduces
-// https://github.com/nicolastakashi/prom-analytics-proxy/issues/572: the
-// metadata-catalog step and the usage-summary refresh share a single
-// run-timeout budget. A metadata step that (legitimately, within its own
-// per-step timeout) takes long enough leaves the summary step less time than
-// its own configured summaryStepTimeout - or none at all - every single run,
-// so the newly-catalogued metrics never get their placeholder summary rows
-// refreshed with real usage data. This is a deterministic race, not a flaky
-// one: the same shortfall recurs on every run, so nothing about "just retry
-// on the next scheduled sync" fixes it.
+// https://github.com/nicolastakashi/prom-analytics-proxy/issues/572: a
+// metadata step that (legitimately, within its own per-step timeout) runs
+// close to that timeout must still leave the summary step its own full,
+// independent window - not whatever happens to be left of a shared budget -
+// or newly-catalogued metrics never get their placeholder summary rows
+// refreshed with real usage data. The timeouts are the shipped defaults and
+// runTimeout is exactly their sum, so this pins the validated sum as
+// actually sufficient at the budget operators really run - the synctest
+// bubble's clock is what makes those durations free to use.
 func TestSyncer_SlowMetadataStepDoesNotPermanentlyStarveSummaryRefresh(t *testing.T) {
-	provider := &fakeInventoryProvider{
-		summaryWork: 40 * time.Millisecond,
-	}
-	api := &fakeMetadataAPI{
-		delay: 60 * time.Millisecond,
-		meta:  map[string][]v1.Metadata{"up": {{Type: "gauge", Help: "up metric"}}},
-	}
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			metadataStepTimeout = 30 * time.Second
+			summaryStepTimeout  = 30 * time.Second
+		)
+		provider := &fakeProvider{
+			summaryDelay: 25 * time.Second,
+		}
+		api := &fakePromAPI{
+			metadataDelay: 29 * time.Second, // close to metadataStepTimeout's own cap, but still within it
+			meta:          map[string][]v1.Metadata{"up": {{Type: "gauge", Help: "up metric"}}},
+		}
 
-	s := &Syncer{
-		dbProvider:              provider,
-		promAPI:                 api,
-		timeWindow:              time.Hour,
-		metadataSyncEnabled:     true,
-		metadataMetricsNameOnly: false,
-		runTimeout:              80 * time.Millisecond, // shared budget: barely more than the metadata step alone needs
-		metadataStepTimeout:     time.Second,           // generous on its own; runTimeout is the real limiter
-		summaryStepTimeout:      50 * time.Millisecond, // > summaryWork, so summary should always have enough time of its own
-		syncDuration:            newHistogram(),
-		syncSuccess:             newCounter(),
-		syncFailure:             newCounter(),
-		catalogSummaryMismatch:  newCounter(),
-	}
+		s := &Syncer{
+			dbProvider:              provider,
+			promAPI:                 api,
+			timeWindow:              time.Hour,
+			metadataSyncEnabled:     true,
+			metadataMetricsNameOnly: false,
+			runTimeout:              metadataStepTimeout + summaryStepTimeout, // exactly the validated minimum, no slack
+			metadataStepTimeout:     metadataStepTimeout,
+			summaryStepTimeout:      summaryStepTimeout, // > summaryDelay, so summary should always have enough time of its own
+			syncDuration:            newHistogram(),
+			syncSuccess:             newCounter(),
+			syncFailure:             newCounter(),
+			catalogSummaryMismatch:  newCounter(),
+		}
 
-	// Run twice: a fix must not merely get lucky once, it must hold up on
-	// every run since the metadata step's duration here is fixed and always
-	// eats the same share of any shared budget.
-	for i := 0; i < 2; i++ {
-		provider.mu.Lock()
-		provider.summarySucceeded = false
-		provider.mu.Unlock()
+		// Run twice: a fix must not merely get lucky once, it must hold up on
+		// every run since the metadata step's duration here is fixed and always
+		// eats the same share of any shared budget.
+		for i := 0; i < 2; i++ {
+			provider.mu.Lock()
+			provider.summarySucceeded = false
+			provider.mu.Unlock()
 
-		s.runOnce(context.Background())
+			s.runOnce(context.Background())
 
-		provider.mu.Lock()
-		commits, calls, succeeded := provider.catalogCommits, provider.summaryCalls, provider.summarySucceeded
-		provider.mu.Unlock()
+			provider.mu.Lock()
+			commits, calls, succeeded := provider.catalogCommits, provider.summaryCalls, provider.summarySucceeded
+			provider.mu.Unlock()
 
-		assert.Equalf(t, i+1, commits, "run %d: metadata catalog step should have committed", i+1)
-		assert.Equalf(t, i+1, calls, "run %d: summary refresh should have been attempted", i+1)
-		assert.Truef(t, succeeded,
-			"run %d: usage-summary refresh should complete within its own summaryStepTimeout "+
-				"(%s) even though the metadata step already used most of the shared run timeout "+
-				"(%s); otherwise newly-catalogued metrics are permanently stranded at placeholder "+
-				"values", i+1, s.summaryStepTimeout, s.runTimeout)
-	}
+			assert.Equalf(t, i+1, commits, "run %d: metadata catalog step should have committed", i+1)
+			assert.Equalf(t, i+1, calls, "run %d: summary refresh should have been attempted", i+1)
+			assert.Truef(t, succeeded,
+				"run %d: usage-summary refresh should complete within its own summaryStepTimeout "+
+					"(%s) even though the metadata step already used most of the shared run timeout "+
+					"(%s); otherwise newly-catalogued metrics are permanently stranded at placeholder "+
+					"values", i+1, s.summaryStepTimeout, s.runTimeout)
+		}
+	})
 }
 
 // TestSyncer_SummaryFailureAfterCatalogCommitEmitsMismatchMetric asserts the
@@ -146,10 +86,10 @@ func TestSyncer_SlowMetadataStepDoesNotPermanentlyStarveSummaryRefresh(t *testin
 // via the dedicated catalogSummaryMismatch counter and a distinct log line,
 // not folded into the generic failure counter alone.
 func TestSyncer_SummaryFailureAfterCatalogCommitEmitsMismatchMetric(t *testing.T) {
-	provider := &fakeInventoryProvider{
-		summaryWork: time.Hour, // never completes within the step timeout
+	provider := &fakeProvider{
+		summaryDelay: time.Hour, // never completes within the step timeout
 	}
-	api := &fakeMetadataAPI{meta: map[string][]v1.Metadata{"up": {{Type: "gauge", Help: "up metric"}}}}
+	api := &fakePromAPI{meta: map[string][]v1.Metadata{"up": {{Type: "gauge", Help: "up metric"}}}}
 
 	s := &Syncer{
 		dbProvider:             provider,
@@ -178,8 +118,8 @@ func TestSyncer_SummaryFailureAfterCatalogCommitEmitsMismatchMetric(t *testing.T
 // metadata-step failure (nothing committed) is NOT misreported as the
 // catalog/summary partial-failure case.
 func TestSyncer_MetadataFailureDoesNotEmitMismatchMetric(t *testing.T) {
-	provider := &fakeInventoryProvider{}
-	api := &fakeMetadataAPI{err: errors.New("upstream unavailable")}
+	provider := &fakeProvider{}
+	api := &fakePromAPI{metadataErr: errors.New("upstream unavailable")}
 
 	s := &Syncer{
 		dbProvider:             provider,
@@ -202,4 +142,231 @@ func TestSyncer_MetadataFailureDoesNotEmitMismatchMetric(t *testing.T) {
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.syncFailure))
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.catalogSummaryMismatch),
 		"a plain metadata-step failure is not the catalog/summary partial-failure case")
+}
+
+// TestSyncer_DisabledMetadataSyncStillRefreshesTheSummary asserts the
+// catalog step being switched off skips it rather than failing the cycle:
+// the summary refresh still runs, and the cycle still counts as a success.
+func TestSyncer_DisabledMetadataSyncStillRefreshesTheSummary(t *testing.T) {
+	provider := &fakeProvider{}
+	api := &fakePromAPI{metadataErr: errors.New("must never be called")}
+
+	s := &Syncer{
+		dbProvider:             provider,
+		promAPI:                api,
+		timeWindow:             time.Hour,
+		metadataSyncEnabled:    false,
+		runTimeout:             time.Second,
+		metadataStepTimeout:    time.Second,
+		summaryStepTimeout:     time.Second,
+		syncDuration:           newHistogram(),
+		syncSuccess:            newCounter(),
+		syncFailure:            newCounter(),
+		catalogSummaryMismatch: newCounter(),
+	}
+
+	s.runOnce(context.Background())
+
+	assert.Equal(t, 0, provider.catalogCommits, "the catalog step is skipped entirely in this mode")
+	assert.Equal(t, 1, provider.summaryCalls, "the summary refresh is never gated by metadata_sync_enabled")
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.syncSuccess))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.syncFailure))
+}
+
+// TestSyncer_SummaryFailureWithMetadataSyncDisabledStillEmitsMismatchMetric
+// asserts a skipped catalog step counts as committed for mismatch
+// reporting: in this mode the OTLP ingester populates the catalog instead,
+// so a failed summary refresh strands its newly-ingested metrics at
+// placeholder values exactly as it would after this job's own catalog
+// write.
+func TestSyncer_SummaryFailureWithMetadataSyncDisabledStillEmitsMismatchMetric(t *testing.T) {
+	provider := &fakeProvider{
+		summaryDelay: time.Hour, // never completes within the step timeout
+	}
+	api := &fakePromAPI{metadataErr: errors.New("must never be called")}
+
+	s := &Syncer{
+		dbProvider:             provider,
+		promAPI:                api,
+		timeWindow:             time.Hour,
+		metadataSyncEnabled:    false,
+		runTimeout:             time.Second,
+		metadataStepTimeout:    time.Second,
+		summaryStepTimeout:     10 * time.Millisecond,
+		syncDuration:           newHistogram(),
+		syncSuccess:            newCounter(),
+		syncFailure:            newCounter(),
+		catalogSummaryMismatch: newCounter(),
+	}
+
+	s.runOnce(context.Background())
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.syncFailure))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.catalogSummaryMismatch))
+}
+
+// baseInventoryConfig has every step enabled, each step timeout set to a
+// distinct value so a test can tell at a glance which one a given
+// assertion is about, and RunTimeout sized exactly to their sum - the
+// minimum NewSyncer's validation accepts.
+func baseInventoryConfig() *config.Config {
+	return &config.Config{
+		Inventory: config.InventoryConfig{
+			Enabled:               true,
+			MetadataSyncEnabled:   true,
+			JobSyncEnabled:        true,
+			SyncInterval:          10 * time.Minute,
+			TimeWindow:            time.Hour,
+			RunTimeout:            200 * time.Millisecond, // = 100 + 50 + 50
+			MetadataStepTimeout:   100 * time.Millisecond,
+			SummaryStepTimeout:    50 * time.Millisecond,
+			JobIndexTimeout:       50 * time.Millisecond,
+			JobIndexLabelTimeout:  10 * time.Millisecond,
+			JobIndexPerJobTimeout: 10 * time.Millisecond,
+			JobIndexWorkers:       1,
+		},
+	}
+}
+
+// TestNewSyncer_ConfigValidation covers what NewSyncer's construction gate
+// does with a config, as opposed to what each value has to be on its own -
+// those range rules live with the schema, and config's own tests cover them
+// field by field. What matters here is that NewSyncer surfaces them at all,
+// and that the rules it owns itself hold: which steps count toward the
+// cycle, and which values a disabled step gets to ignore.
+func TestNewSyncer_ConfigValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		tweak   func(*config.InventoryConfig)
+		wantErr string // empty means the config must be accepted
+	}{
+		{
+			name:  "run_timeout exactly the step sum",
+			tweak: func(*config.InventoryConfig) {},
+		},
+		{
+			name:    "sync_interval zero",
+			tweak:   func(c *config.InventoryConfig) { c.SyncInterval = 0 },
+			wantErr: "sync_interval must be positive",
+		},
+		{
+			name:    "job_index_workers zero",
+			tweak:   func(c *config.InventoryConfig) { c.JobIndexWorkers = 0 },
+			wantErr: "job_index_workers must be positive",
+		},
+		{
+			// A disabled step never runs, so none of its own values have to
+			// be usable: this one value is at once too small for the step's
+			// own sub-budgets and, if it still counted toward the sum, too
+			// large for run_timeout - so every check that would reject it
+			// has to be skipped for this config to construct.
+			name: "job sync disabled, its every value unusable",
+			tweak: func(c *config.InventoryConfig) {
+				c.JobSyncEnabled = false
+				c.JobIndexTimeout = time.Millisecond
+				c.JobIndexWorkers = 0
+				c.RunTimeout = c.MetadataStepTimeout + c.SummaryStepTimeout
+			},
+		},
+		{
+			name: "metadata sync disabled, its step timeout unusable",
+			tweak: func(c *config.InventoryConfig) {
+				c.MetadataSyncEnabled = false
+				c.MetadataStepTimeout = time.Hour // would blow the budget if it still counted
+				c.RunTimeout = c.SummaryStepTimeout + c.JobIndexTimeout
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseInventoryConfig()
+			tc.tweak(&cfg.Inventory)
+
+			s, err := NewSyncer(&fakeProvider{}, "http://upstream", cfg, prometheus.NewRegistry())
+
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				assert.NotNil(t, s)
+				return
+			}
+			assert.Error(t, err)
+			assert.Nil(t, s)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestNewSyncer_AcceptsTheShippedDefaults guards the defaults against their
+// own validation: run_timeout's default is exactly the sum of the default
+// step timeouts, so lowering one default, or raising another, makes the
+// out-of-the-box config NewSyncer has to widen (and warn about) before it
+// can run - with or without the job index step, the only one gated off by
+// default.
+func TestNewSyncer_AcceptsTheShippedDefaults(t *testing.T) {
+	for _, jobSync := range []bool{false, true} {
+		cfg := *config.DefaultConfig
+		cfg.Inventory.JobSyncEnabled = jobSync
+
+		s, err := NewSyncer(&fakeProvider{}, "http://upstream", &cfg, prometheus.NewRegistry())
+		require.NoError(t, err, "shipped defaults with job_sync_enabled=%v must construct", jobSync)
+		assert.Equal(t, cfg.Inventory.RunTimeout, s.runTimeout, "the shipped defaults need no widening")
+	}
+}
+
+// TestNewSyncer_AcceptsJobIndexTimeoutExactlyEqualToItsOwnSubBudgets pins
+// the smallest job-index budget that needs no widening: enough for the
+// label fetch plus one job's query.
+func TestNewSyncer_AcceptsJobIndexTimeoutExactlyEqualToItsOwnSubBudgets(t *testing.T) {
+	cfg := baseInventoryConfig()
+	cfg.Inventory.JobIndexTimeout = cfg.Inventory.JobIndexLabelTimeout + cfg.Inventory.JobIndexPerJobTimeout
+	cfg.Inventory.RunTimeout = cfg.Inventory.MetadataStepTimeout + cfg.Inventory.SummaryStepTimeout + cfg.Inventory.JobIndexTimeout
+
+	s, err := NewSyncer(&fakeProvider{}, "http://upstream", cfg, prometheus.NewRegistry())
+	require.NoError(t, err)
+	assert.Equal(t, cfg.Inventory.JobIndexTimeout, s.jobIndexTimeout, "a budget that already fits must be left alone")
+	assert.Equal(t, cfg.Inventory.RunTimeout, s.runTimeout, "a cycle budget that already fits must be left alone")
+}
+
+// TestNewSyncer_WidensRunTimeoutToCoverItsSteps proves a cycle budget too
+// short for the steps it must run is raised to fit rather than refused:
+// the operator gets the step budgets they configured, and a warning naming
+// what to fix, instead of a process that won't start.
+func TestNewSyncer_WidensRunTimeoutToCoverItsSteps(t *testing.T) {
+	for _, configured := range []time.Duration{199 * time.Millisecond, time.Millisecond} {
+		cfg := baseInventoryConfig()
+		stepSum := cfg.Inventory.MetadataStepTimeout + cfg.Inventory.SummaryStepTimeout + cfg.Inventory.JobIndexTimeout
+		cfg.Inventory.RunTimeout = configured
+
+		s, err := NewSyncer(&fakeProvider{}, "http://upstream", cfg, prometheus.NewRegistry())
+
+		require.NoError(t, err, "a positive run_timeout below the sum should be widened, not rejected (%s)", configured)
+		assert.Equal(t, stepSum, s.runTimeout,
+			"run_timeout %s covers none of the steps; the cycle must run on their sum instead", configured)
+	}
+}
+
+// TestNewSyncer_WidensJobIndexTimeoutToCoverItsSubBudgets is the same
+// guarantee one level down, and pins that widening the inner budget also
+// widens the cycle that has to contain it.
+func TestNewSyncer_WidensJobIndexTimeoutToCoverItsSubBudgets(t *testing.T) {
+	cfg := baseInventoryConfig()
+	cfg.Inventory.JobIndexTimeout = cfg.Inventory.JobIndexLabelTimeout // enough for the labels, nothing left for a job
+	// A cycle sized to the steps as configured, so widening the step below
+	// leaves it too small and it has to be widened in turn.
+	cfg.Inventory.RunTimeout = cfg.Inventory.MetadataStepTimeout + cfg.Inventory.SummaryStepTimeout + cfg.Inventory.JobIndexTimeout
+
+	s, err := NewSyncer(&fakeProvider{}, "http://upstream", cfg, prometheus.NewRegistry())
+
+	require.NoError(t, err)
+	wantJobIndex := cfg.Inventory.JobIndexLabelTimeout + cfg.Inventory.JobIndexPerJobTimeout
+	assert.Equal(t, wantJobIndex, s.jobIndexTimeout, "the step must be able to index at least one job")
+	assert.Equal(t, cfg.Inventory.MetadataStepTimeout+cfg.Inventory.SummaryStepTimeout+wantJobIndex, s.runTimeout,
+		"the cycle must cover the widened step, not the narrower one it was sized for")
+}
+
+func TestNewSyncer_RejectsNilConfig(t *testing.T) {
+	s, err := NewSyncer(&fakeProvider{}, "http://upstream", nil, prometheus.NewRegistry())
+
+	assert.Error(t, err)
+	assert.Nil(t, s)
+	assert.Contains(t, err.Error(), "config is required")
 }

--- a/internal/inventory/testhelpers_test.go
+++ b/internal/inventory/testhelpers_test.go
@@ -1,0 +1,166 @@
+package inventory
+
+import (
+	"context"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+)
+
+// The two collaborators every test in this package drives a Syncer through,
+// faked once here rather than per concern: a Syncer's catalog, summary and
+// job-index work all go through the same Prometheus API and the same storage
+// provider, so a fake per test file would be two things to keep in step
+// with db.Provider and v1.API instead of one.
+
+// fakePromAPI is a minimal v1.API stand-in. Embedding the (nil) interface
+// means any method a test's code path doesn't use panics if called - which
+// is what a test wants, rather than a silent zero value. Every call can be
+// made slow (to exercise a step's timeout) or made to fail.
+type fakePromAPI struct {
+	v1.API
+
+	metadataDelay time.Duration
+	metadataErr   error
+	meta          map[string][]v1.Metadata
+
+	labelDelay time.Duration
+	jobs       []string
+	labelErr   error
+
+	queryDelay time.Duration
+	// queryErr, if set, is returned instead of a normal result for every
+	// job named in queryErrJobs - every other job still succeeds.
+	queryErr     error
+	queryErrJobs map[string]bool
+
+	mu          sync.Mutex
+	queriedJobs []string // jobs Query was actually called for, in call order
+}
+
+func (f *fakePromAPI) Metadata(ctx context.Context, _ string, _ string) (map[string][]v1.Metadata, error) {
+	if f.metadataErr != nil {
+		return nil, f.metadataErr
+	}
+	select {
+	case <-time.After(f.metadataDelay):
+		return f.meta, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (f *fakePromAPI) LabelValues(ctx context.Context, _ string, _ []string, _, _ time.Time, _ ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+	select {
+	case <-time.After(f.labelDelay):
+		if f.labelErr != nil {
+			return nil, nil, f.labelErr
+		}
+		values := make(model.LabelValues, len(f.jobs))
+		for i, j := range f.jobs {
+			values[i] = model.LabelValue(j)
+		}
+		return values, nil, nil
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+}
+
+// jobFromQueryRe pulls the job name back out of the PromQL processJob
+// builds, so this fake can respond per-job without a separate lookup keyed
+// some other way.
+var jobFromQueryRe = regexp.MustCompile(`job="([^"]*)"`)
+
+func (f *fakePromAPI) Query(ctx context.Context, query string, _ time.Time, _ ...v1.Option) (model.Value, v1.Warnings, error) {
+	select {
+	case <-time.After(f.queryDelay):
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+
+	job := ""
+	if m := jobFromQueryRe.FindStringSubmatch(query); len(m) == 2 {
+		job = m[1]
+	}
+	f.mu.Lock()
+	f.queriedJobs = append(f.queriedJobs, job)
+	f.mu.Unlock()
+
+	if f.queryErr != nil && f.queryErrJobs[job] {
+		return nil, nil, f.queryErr
+	}
+	return model.Vector{{Metric: model.Metric{"__name__": "up"}}}, nil, nil
+}
+
+// fakeProvider records what a cycle actually committed - catalog, summary
+// and job index - so a test can tell a step that ran from one that was
+// skipped or cut short.
+type fakeProvider struct {
+	db.Provider
+
+	mu sync.Mutex
+
+	catalogCommits int
+
+	summaryDelay     time.Duration // how long a real refresh would take
+	summaryCalls     int
+	summarySucceeded bool
+
+	jobIndexItems []db.MetricJobIndexItem
+	// upsertErr, if set, is returned instead of succeeding for the one job
+	// named upsertErrForJob - every other job's upsert still succeeds.
+	upsertErr       error
+	upsertErrForJob string
+}
+
+func (f *fakeProvider) UpsertMetricsCatalog(_ context.Context, _ []db.MetricCatalogItem) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.catalogCommits++
+	return nil
+}
+
+func (f *fakeProvider) RefreshMetricsUsageSummary(ctx context.Context, _ db.TimeRange) error {
+	f.mu.Lock()
+	f.summaryCalls++
+	f.mu.Unlock()
+
+	select {
+	case <-time.After(f.summaryDelay):
+		f.mu.Lock()
+		f.summarySucceeded = true
+		f.mu.Unlock()
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (f *fakeProvider) UpsertMetricsJobIndex(_ context.Context, items []db.MetricJobIndexItem) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.upsertErr != nil && len(items) > 0 && items[0].Job == f.upsertErrForJob {
+		return f.upsertErr
+	}
+	f.jobIndexItems = append(f.jobIndexItems, items...)
+	return nil
+}
+
+// lastHour is the lookback window these tests pass to syncJobIndex; the
+// fakes never read it, so any window will do.
+func lastHour() db.TimeRange {
+	return db.TimeRange{From: time.Now().Add(-time.Hour), To: time.Now()}
+}
+
+func newCounter() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{Name: "test_counter"})
+}
+
+func newHistogram() prometheus.Histogram {
+	return prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_histogram"})
+}

--- a/internal/leaderelection/advisory.go
+++ b/internal/leaderelection/advisory.go
@@ -89,26 +89,26 @@ func newAdvisoryLockStrategy(db connGetter) *advisoryLockStrategy {
 	return &advisoryLockStrategy{db: db, livenessInterval: defaultLivenessInterval}
 }
 
-func (s *advisoryLockStrategy) acquireOrHold(ctx context.Context, name string) (context.Context, func(), bool, error) {
+func (s *advisoryLockStrategy) acquireOrHold(ctx context.Context, name string) (acquisition, bool, error) {
 	key := lockKeyFor(name)
 
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return nil, nil, false, err
+		return acquisition{}, false, err
 	}
 
 	var got bool
 	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", key).Scan(&got); err != nil {
 		_ = conn.Close()
-		return nil, nil, false, err
+		return acquisition{}, false, err
 	}
 	if !got {
 		_ = conn.Close()
-		return nil, nil, false, nil
+		return acquisition{}, false, nil
 	}
 
 	leaderCtx, release := newHeldLease(ctx, &pqAdvisoryConn{c: conn}, key, name, s.livenessInterval)
-	return leaderCtx, release, true, nil
+	return acquisition{leaderCtx: leaderCtx, release: release}, true, nil
 }
 
 // newHeldLease builds the leaderCtx/release pair for a lock already held on

--- a/internal/leaderelection/advisory_leak_test.go
+++ b/internal/leaderelection/advisory_leak_test.go
@@ -28,14 +28,15 @@ func TestAdvisoryStrategy_RepeatedOperations_DoNotLeakConnections(t *testing.T) 
 		loser := newAdvisoryLockStrategy(db)
 
 		ctx := context.Background()
-		_, release, ok, err := winner.acquireOrHold(ctx, "leak-contention-test")
+		acq, ok, err := winner.acquireOrHold(ctx, "leak-contention-test")
+		release := acq.release
 		require.NoError(t, err) // release() below would nil-panic on failure to acquire
 		require.True(t, ok)
 		defer release()
 
 		const attempts = 50
 		for i := 0; i < attempts; i++ {
-			_, _, ok, err := loser.acquireOrHold(ctx, "leak-contention-test")
+			_, ok, err := loser.acquireOrHold(ctx, "leak-contention-test")
 			assert.NoError(t, err)
 			assert.False(t, ok, "still held by winner")
 		}
@@ -56,7 +57,8 @@ func TestAdvisoryStrategy_RepeatedOperations_DoNotLeakConnections(t *testing.T) 
 
 		const cycles = 50
 		for i := 0; i < cycles; i++ {
-			_, release, ok, err := strat.acquireOrHold(ctx, "leak-cycle-test")
+			acq, ok, err := strat.acquireOrHold(ctx, "leak-cycle-test")
+			release := acq.release
 			require.NoError(t, err) // release() below would nil-panic on failure to acquire
 			require.True(t, ok)
 			release()

--- a/internal/leaderelection/advisory_release_test.go
+++ b/internal/leaderelection/advisory_release_test.go
@@ -23,7 +23,8 @@ func TestAdvisoryStrategy_ReleasesLockExplicitly_NotJustViaConnClose(t *testing.
 	strat := newAdvisoryLockStrategy(db)
 
 	ctx := context.Background()
-	_, release, ok, err := strat.acquireOrHold(ctx, "release-test")
+	acq, ok, err := strat.acquireOrHold(ctx, "release-test")
+	release := acq.release
 	require.NoError(t, err) // release() below would nil-panic on failure to acquire
 	require.True(t, ok)
 

--- a/internal/leaderelection/advisory_strategy_test.go
+++ b/internal/leaderelection/advisory_strategy_test.go
@@ -55,7 +55,8 @@ func TestAdvisoryStrategy_MutualExclusion_ConcurrentGoroutines(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for ctx.Err() == nil {
-				_, release, ok, err := strat.acquireOrHold(ctx, "mutex-test")
+				acq, ok, err := strat.acquireOrHold(ctx, "mutex-test")
+				release := acq.release
 				if err != nil {
 					// ctx expiring mid-attempt right at the test's own
 					// deadline is expected shutdown noise, not a failure of

--- a/internal/leaderelection/elector.go
+++ b/internal/leaderelection/elector.go
@@ -54,7 +54,7 @@ func (e *elector) Run(ctx context.Context, name string, fn func(context.Context)
 			return nil
 		}
 
-		leaderCtx, release, ok, err := e.strat.acquireOrHold(ctx, name)
+		acq, ok, err := e.strat.acquireOrHold(ctx, name)
 		if err != nil {
 			// Must never cause a silent, permanent return — the only event
 			// allowed to stop this loop is ctx being canceled — but must
@@ -86,7 +86,7 @@ func (e *elector) Run(ctx context.Context, name string, fn func(context.Context)
 		e.m.isLeader.WithLabelValues(name).Set(1)
 		e.m.transitions.WithLabelValues(name, "leader").Inc()
 
-		runAndRelease(leaderCtx, fn, release, name)
+		runAndRelease(acq, fn, name)
 
 		e.m.isLeader.WithLabelValues(name).Set(0)
 		e.m.transitions.WithLabelValues(name, "follower").Inc()
@@ -104,15 +104,15 @@ func (e *elector) Run(ctx context.Context, name string, fn func(context.Context)
 // panic is logged and re-raised, not swallowed — deferred calls still run
 // to completion during that re-panic's unwind, so release() executes
 // before it escapes this function.
-func runAndRelease(leaderCtx context.Context, fn func(context.Context), release func(), name string) {
-	defer release()
+func runAndRelease(acq acquisition, fn func(context.Context), name string) {
+	defer acq.release()
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("leader-elected fn panicked; releasing lock before repanicking", "lease", name, "panic", r)
 			panic(r)
 		}
 	}()
-	fn(leaderCtx)
+	fn(acq.leaderCtx)
 }
 
 // sleep waits for d or ctx cancellation, whichever comes first, reporting

--- a/internal/leaderelection/elector_backoff_test.go
+++ b/internal/leaderelection/elector_backoff_test.go
@@ -23,11 +23,11 @@ type recordingStrategy struct {
 	returnErr error
 }
 
-func (s *recordingStrategy) acquireOrHold(ctx context.Context, name string) (context.Context, func(), bool, error) {
+func (s *recordingStrategy) acquireOrHold(ctx context.Context, name string) (acquisition, bool, error) {
 	s.mu.Lock()
 	s.times = append(s.times, time.Now())
 	s.mu.Unlock()
-	return nil, nil, false, s.returnErr
+	return acquisition{}, false, s.returnErr
 }
 
 func (s *recordingStrategy) snapshot() []time.Time {
@@ -128,7 +128,7 @@ type failThenSucceedOnceStrategy struct {
 	succeeded          bool
 }
 
-func (s *failThenSucceedOnceStrategy) acquireOrHold(ctx context.Context, _ string) (context.Context, func(), bool, error) {
+func (s *failThenSucceedOnceStrategy) acquireOrHold(ctx context.Context, _ string) (acquisition, bool, error) {
 	s.mu.Lock()
 	s.times = append(s.times, time.Now())
 	s.attempts++
@@ -141,9 +141,9 @@ func (s *failThenSucceedOnceStrategy) acquireOrHold(ctx context.Context, _ strin
 		s.succeeded = true
 		s.mu.Unlock()
 		leaderCtx, cancel := context.WithCancel(ctx)
-		return leaderCtx, cancel, true, nil
+		return acquisition{leaderCtx: leaderCtx, release: cancel}, true, nil
 	}
-	return nil, nil, false, errors.New("simulated error")
+	return acquisition{}, false, errors.New("simulated error")
 }
 
 func (s *failThenSucceedOnceStrategy) snapshot() []time.Time {

--- a/internal/leaderelection/leaderelection.go
+++ b/internal/leaderelection/leaderelection.go
@@ -1,11 +1,16 @@
-// Package leaderelection provides single-leader coordination across multiple
-// replicas of this process sharing a PostgreSQL database. It exists as its
-// own package (rather than living inside internal/inventory, which is where
-// this logic used to live) because leader election is infrastructure shared
-// by the inventory syncer and the retention worker — neither owns it.
+// Package leaderelection decides which replica of this process may run a
+// given periodic job. It exists as its own package (rather than living
+// inside internal/inventory, which is where this logic used to live) because
+// leader election is infrastructure shared by the inventory syncer and the
+// retention worker — neither owns it.
 //
-// See docs/leader-election.md for why this exists, why it's PostgreSQL-only,
-// and the design rationale behind the advisory-lock strategy.
+// Coordination between replicas needs shared state, and both strategies that
+// provide it are PostgreSQL-only. Where there is nothing to coordinate —
+// SQLite, one database file per replica — NewSoleInstance holds leadership
+// outright, so every caller gets an Elector and none has to special-case the
+// provider it runs on.
+//
+// See docs/leader-election.md for the design rationale behind each strategy.
 package leaderelection
 
 import "context"

--- a/internal/leaderelection/lease.go
+++ b/internal/leaderelection/lease.go
@@ -79,13 +79,13 @@ func newLeaseStrategy(db *sql.DB, ttl, renewInterval time.Duration) *leaseStrate
 	return &leaseStrategy{db: db, ttl: ttl, renewInterval: renewInterval, holderID: uuid.NewString()}
 }
 
-func (s *leaseStrategy) acquireOrHold(ctx context.Context, name string) (context.Context, func(), bool, error) {
+func (s *leaseStrategy) acquireOrHold(ctx context.Context, name string) (acquisition, bool, error) {
 	_, ok, err := s.tryAcquireOrRenew(ctx, name)
 	if err != nil {
-		return nil, nil, false, err
+		return acquisition{}, false, err
 	}
 	if !ok {
-		return nil, nil, false, nil
+		return acquisition{}, false, nil
 	}
 
 	// Leadership acquired. A background watchdog renews on renewInterval
@@ -108,7 +108,7 @@ func (s *leaseStrategy) acquireOrHold(ctx context.Context, name string) (context
 			slog.Warn("releasing lease failed; next holder will wait out the TTL", "lease", name, "err", err)
 		}
 	}
-	return leaderCtx, release, true, nil
+	return acquisition{leaderCtx: leaderCtx, release: release}, true, nil
 }
 
 // leaseRenewer is the seam watchdog needs to attempt a renewal — a

--- a/internal/leaderelection/lease_failover_test.go
+++ b/internal/leaderelection/lease_failover_test.go
@@ -32,17 +32,17 @@ func TestLeaseStrategy_FailoverAfterUngracefulDeath(t *testing.T) {
 	holderB := newLeaseStrategy(db, ttl, noRenewal)
 
 	ctx := context.Background()
-	_, _, ok, err := holderA.acquireOrHold(ctx, "failover-test")
+	_, ok, err := holderA.acquireOrHold(ctx, "failover-test")
 	assert.NoError(t, err)
 	assert.True(t, ok)
 	// holderA "dies" here: no further acquireOrHold or release calls.
 
-	_, _, ok, err = holderB.acquireOrHold(ctx, "failover-test")
+	_, ok, err = holderB.acquireOrHold(ctx, "failover-test")
 	assert.NoError(t, err)
 	assert.False(t, ok, "the lease must not transfer before the TTL elapses")
 
 	assert.Eventually(t, func() bool {
-		_, _, ok, err := holderB.acquireOrHold(ctx, "failover-test")
+		_, ok, err := holderB.acquireOrHold(ctx, "failover-test")
 		return err == nil && ok
 	}, ttl*4, 10*time.Millisecond, "holder B should acquire the lease shortly after holder A's TTL expires")
 }

--- a/internal/leaderelection/lease_renewal_test.go
+++ b/internal/leaderelection/lease_renewal_test.go
@@ -64,7 +64,7 @@ func TestElector_Run_HoldsLeadershipAcrossMultipleRenewalTicks(t *testing.T) {
 		default:
 		}
 
-		_, _, ok, err := rival.acquireOrHold(context.Background(), "sustained-renewal-test")
+		_, ok, err := rival.acquireOrHold(context.Background(), "sustained-renewal-test")
 		assert.NoError(t, err)
 		assert.False(t, ok, "the lease must still be held by the original holder throughout the hold window")
 

--- a/internal/leaderelection/lease_test.go
+++ b/internal/leaderelection/lease_test.go
@@ -22,7 +22,9 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 	t.Run("AcquireWhenFree_Succeeds", func(t *testing.T) {
 		strat := newLeaseStrategy(db, time.Second, noRenewal)
 
-		_, release, ok, err := strat.acquireOrHold(context.Background(), "lifecycle-test")
+		acq, ok, err := strat.acquireOrHold(context.Background(), "lifecycle-test")
+
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok)
 		defer release()
@@ -41,7 +43,9 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		leaderCtx, release, ok, err := strat.acquireOrHold(ctx, "canceled-ctx-test")
+		acq, ok, err := strat.acquireOrHold(ctx, "canceled-ctx-test")
+
+		leaderCtx, release := acq.leaderCtx, acq.release
 		assert.Error(t, err)
 		assert.False(t, ok)
 		assert.Nil(t, leaderCtx)
@@ -52,12 +56,14 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		holderA := newLeaseStrategy(db, time.Second, noRenewal)
 		holderB := newLeaseStrategy(db, time.Second, noRenewal)
 
-		_, release, ok, err := holderA.acquireOrHold(context.Background(), "contended-test")
+		acq, ok, err := holderA.acquireOrHold(context.Background(), "contended-test")
+
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok)
 		defer release()
 
-		_, _, ok, err = holderB.acquireOrHold(context.Background(), "contended-test")
+		_, ok, err = holderB.acquireOrHold(context.Background(), "contended-test")
 		assert.NoError(t, err)
 		assert.False(t, ok, "a second holder must not acquire a lease still held by someone else")
 	})
@@ -66,7 +72,7 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		holderA := newLeaseStrategy(db, 50*time.Millisecond, noRenewal)
 		holderB := newLeaseStrategy(db, time.Second, noRenewal)
 
-		_, _, ok, err := holderA.acquireOrHold(context.Background(), "expiry-test")
+		_, ok, err := holderA.acquireOrHold(context.Background(), "expiry-test")
 		assert.NoError(t, err)
 		assert.True(t, ok)
 		// holderA never renews again, and noRenewal keeps its watchdog
@@ -75,7 +81,9 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 
-		_, release, ok, err := holderB.acquireOrHold(context.Background(), "expiry-test")
+		acq, ok, err := holderB.acquireOrHold(context.Background(), "expiry-test")
+
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok, "a lease must become acquirable again once it has expired")
 		defer release()
@@ -85,7 +93,8 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		holderA := newLeaseStrategy(db, time.Second, noRenewal)
 
 		ctx := context.Background()
-		_, release, ok, err := holderA.acquireOrHold(ctx, "renew-test")
+		acq, ok, err := holderA.acquireOrHold(ctx, "renew-test")
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok)
 		defer release()
@@ -93,7 +102,8 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		tokenAfterAcquire, expiresAfterAcquire := queryLease(t, db, "renew-test")
 
 		time.Sleep(10 * time.Millisecond)
-		_, release2, ok, err := holderA.acquireOrHold(ctx, "renew-test")
+		acq2, ok, err := holderA.acquireOrHold(ctx, "renew-test")
+		release2 := acq2.release
 		require.NoError(t, err)
 		require.True(t, ok)
 		defer release2()
@@ -115,13 +125,15 @@ func TestLeaseStrategy_Lifecycle(t *testing.T) {
 		holderA := newLeaseStrategy(db, time.Minute, noRenewal)
 		holderB := newLeaseStrategy(db, time.Minute, noRenewal)
 
-		_, release, ok, err := holderA.acquireOrHold(context.Background(), "handoff-test")
+		acq, ok, err := holderA.acquireOrHold(context.Background(), "handoff-test")
+
+		release := acq.release
 		require.NoError(t, err)
 		require.True(t, ok)
 
 		release()
 
-		_, _, ok, err = holderB.acquireOrHold(context.Background(), "handoff-test")
+		_, ok, err = holderB.acquireOrHold(context.Background(), "handoff-test")
 		assert.NoError(t, err)
 		assert.True(t, ok, "a graceful release must let another holder acquire immediately, without waiting out the TTL")
 	})
@@ -146,7 +158,9 @@ func TestLeaseStrategy_Release_LogsWarningWhenExpiryUpdateFails(t *testing.T) {
 	db := newTestPostgresDB(t)
 	strat := newLeaseStrategy(db, time.Second, noRenewal)
 
-	_, release, ok, err := strat.acquireOrHold(context.Background(), "release-error-test")
+	acq, ok, err := strat.acquireOrHold(context.Background(), "release-error-test")
+
+	release := acq.release
 	require.NoError(t, err)
 	require.True(t, ok)
 

--- a/internal/leaderelection/sole_instance.go
+++ b/internal/leaderelection/sole_instance.go
@@ -1,0 +1,29 @@
+package leaderelection
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// NewSoleInstance returns an Elector for a deployment where this process is
+// the only one that could run the job at all - SQLite mode, one database file
+// per replica, nothing to contend over. It holds leadership from the first
+// attempt for as long as its caller's context lives, so every provider has an
+// elector and no caller has to special-case the one that doesn't. See
+// docs/leader-election.md for what that buys beyond the branch it removes.
+func NewSoleInstance(reg prometheus.Registerer) Elector {
+	return newElector(soleInstanceStrategy{}, backoffConfig{}, reg)
+}
+
+// soleInstanceStrategy grants leadership without asking anything, because
+// there is nothing to ask: no lock, no lease row, no table - which is why
+// NewSoleInstance needs no *sql.DB, unlike New.
+type soleInstanceStrategy struct{}
+
+func (soleInstanceStrategy) acquireOrHold(ctx context.Context, _ string) (acquisition, bool, error) {
+	// release is the cancel alone: no lock to hand back, and canceling is
+	// what ends leaderCtx when leadership ends.
+	leaderCtx, cancel := context.WithCancel(ctx)
+	return acquisition{leaderCtx: leaderCtx, release: cancel}, true, nil
+}

--- a/internal/leaderelection/sole_instance_test.go
+++ b/internal/leaderelection/sole_instance_test.go
@@ -1,0 +1,100 @@
+package leaderelection
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSoleInstance_HoldsLeadershipUntilItsContextEnds proves the whole
+// contract this Elector exists for: fn runs on the first attempt, with no
+// contention to wait out and nothing to acquire, until the caller's context
+// ends - at which point Run returns nil, the same as any other Elector
+// stopping for that reason.
+func TestSoleInstance_HoldsLeadershipUntilItsContextEnds(t *testing.T) {
+	el := NewSoleInstance(prometheus.NewRegistry())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	running := make(chan context.Context, 1)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- el.Run(ctx, "sole-instance-test", func(fnCtx context.Context) {
+			running <- fnCtx
+			<-fnCtx.Done()
+		})
+	}()
+
+	var fnCtx context.Context
+	select {
+	case fnCtx = <-running:
+	case <-time.After(time.Second):
+		t.Fatal("fn never ran: a sole instance must win leadership on its first attempt, without waiting for anything")
+	}
+	assert.NoError(t, fnCtx.Err(), "fn must run on a live leadership context")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		assert.NoError(t, err, "Run must return nil once its context ends, like every other Elector")
+	case <-time.After(time.Second):
+		t.Fatal("Run never returned after its context was canceled")
+	}
+	assert.Error(t, fnCtx.Err(), "leadership must end when the caller's context does")
+}
+
+// TestSoleInstance_ReportsLeadershipInMetrics proves a deployment with
+// nothing to elect still exports the leadership series - the point of
+// routing it through an Elector at all, rather than calling the job
+// directly. A fleet-wide "no leader for this lease" panel has to see these
+// replicas too.
+func TestSoleInstance_ReportsLeadershipInMetrics(t *testing.T) {
+	el := NewSoleInstance(prometheus.NewRegistry())
+	e, ok := el.(*elector)
+	require.True(t, ok, "NewSoleInstance must build on the shared elector, which is what owns these metrics")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	held := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = el.Run(ctx, "sole-metrics-test", func(fnCtx context.Context) {
+			close(held)
+			<-fnCtx.Done()
+		})
+	}()
+	<-held
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(e.m.isLeader.WithLabelValues("sole-metrics-test")),
+		"a sole instance is the leader, and has to say so")
+	assert.Equal(t, float64(1), testutil.ToFloat64(e.m.transitions.WithLabelValues("sole-metrics-test", "leader")))
+
+	cancel()
+	<-done
+	assert.Equal(t, float64(0), testutil.ToFloat64(e.m.isLeader.WithLabelValues("sole-metrics-test")),
+		"and has to stop saying so once it steps down")
+}
+
+// TestSoleInstance_ReacquiresWithoutBackoffUntilItsContextEnds proves
+// leadership isn't a one-shot grant: fn returning early (a job loop that
+// exits on its own) leaves Run free to hand leadership straight back,
+// since there is never anything to contend with.
+func TestSoleInstance_ReacquiresWithoutBackoffUntilItsContextEnds(t *testing.T) {
+	el := NewSoleInstance(prometheus.NewRegistry())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runs := 0
+	require.NoError(t, el.Run(ctx, "sole-reacquire-test", func(context.Context) {
+		runs++
+		if runs == 3 {
+			cancel()
+		}
+	}))
+	assert.Equal(t, 3, runs, "each return must be followed by another term until the caller's context ends")
+}

--- a/internal/leaderelection/strategy.go
+++ b/internal/leaderelection/strategy.go
@@ -14,11 +14,21 @@ type strategy interface {
 	//     caller backs off and retries — err is logged, never returned up
 	//     through Elector.Run. No error from acquireOrHold may ever cause
 	//     a silent, permanent stop; only ctx cancellation may.
-	//   - ok=true: caller now holds leadership. leaderCtx is derived from
-	//     ctx and MUST be canceled — by release(), or internally by the
-	//     strategy the moment leadership is lost — the instant leadership
-	//     ends, even mid-fn. release() must be safe to call exactly once
-	//     and must physically release the underlying lock/lease itself,
-	//     never relying on connection-pool GC to do so eventually.
-	acquireOrHold(ctx context.Context, name string) (leaderCtx context.Context, release func(), ok bool, err error)
+	//   - ok=true: caller now holds leadership, described by the returned
+	//     acquisition.
+	acquireOrHold(ctx context.Context, name string) (acquisition, bool, error)
+}
+
+// acquisition is one term of leadership as the strategy that granted it
+// describes it. Its zero value is what a strategy returns when it didn't
+// win, alongside ok=false.
+type acquisition struct {
+	// leaderCtx is derived from the ctx passed to acquireOrHold and MUST be
+	// canceled — by release, or internally by the strategy the moment
+	// leadership is lost — the instant leadership ends, even mid-fn.
+	leaderCtx context.Context
+	// release must be safe to call exactly once and must physically release
+	// the underlying lock or lease itself, never relying on connection-pool
+	// GC to do so eventually.
+	release func()
 }

--- a/internal/leaderelection/testhelpers_test.go
+++ b/internal/leaderelection/testhelpers_test.go
@@ -106,13 +106,13 @@ type releaseTrackingStrategy struct {
 	released atomic.Bool
 }
 
-func (s *releaseTrackingStrategy) acquireOrHold(ctx context.Context, _ string) (context.Context, func(), bool, error) {
+func (s *releaseTrackingStrategy) acquireOrHold(ctx context.Context, _ string) (acquisition, bool, error) {
 	leaderCtx, cancel := context.WithCancel(ctx)
 	release := func() {
 		cancel()
 		s.released.Store(true)
 	}
-	return leaderCtx, release, true, nil
+	return acquisition{leaderCtx: leaderCtx, release: release}, true, nil
 }
 
 // recordingHandler is a hand-written slog.Handler fake that records every

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math/rand"
 	"time"
 
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
@@ -15,7 +14,6 @@ import (
 
 type Worker struct {
 	dbProvider    db.Provider
-	interval      time.Duration
 	runTimeout    time.Duration
 	queriesMaxAge time.Duration
 
@@ -27,16 +25,11 @@ func NewWorker(store db.Provider, cfg *config.Config, reg prometheus.Registerer)
 		return nil, fmt.Errorf("config is required")
 	}
 
-	if cfg.Retention.Interval <= 0 {
-		return nil, fmt.Errorf("retention.interval must be positive (got: %v)", cfg.Retention.Interval)
-	}
-
-	if cfg.Retention.RunTimeout <= 0 {
-		return nil, fmt.Errorf("retention.run_timeout must be positive (got: %v)", cfg.Retention.RunTimeout)
-	}
-
-	if cfg.Retention.QueriesMaxAge <= 0 {
-		return nil, fmt.Errorf("retention.queries_max_age must be positive (got: %v)", cfg.Retention.QueriesMaxAge)
+	// Range checks live with the schema (see config.RetentionConfig.Validate);
+	// startup runs them before anything acts on the config, and calling them
+	// again here is what holds for a caller that never went through startup.
+	if err := cfg.Retention.Validate(); err != nil {
+		return nil, err
 	}
 
 	if reg == nil {
@@ -45,7 +38,6 @@ func NewWorker(store db.Provider, cfg *config.Config, reg prometheus.Registerer)
 
 	w := &Worker{
 		dbProvider:    store,
-		interval:      cfg.Retention.Interval,
 		runTimeout:    cfg.Retention.RunTimeout,
 		queriesMaxAge: cfg.Retention.QueriesMaxAge,
 	}
@@ -59,33 +51,10 @@ func NewWorker(store db.Provider, cfg *config.Config, reg prometheus.Registerer)
 	return w, nil
 }
 
-func (w *Worker) RunLeaderless(ctx context.Context) {
-	w.runLoop(ctx)
-}
-
-func (w *Worker) runLoop(ctx context.Context) {
-	// Calculate jitter as 20% of interval, with a minimum of 1 nanosecond to avoid panic
-	jitterBase := w.interval / 5
-	if jitterBase == 0 {
-		jitterBase = 1
-	}
-	jitter := time.Duration(rand.Int63n(int64(jitterBase)))
-	ticker := time.NewTicker(w.interval + jitter)
-	defer ticker.Stop()
-
-	w.runOnce(ctx)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			w.runOnce(ctx)
-		}
-	}
-}
-
-func (w *Worker) runOnce(ctx context.Context) {
+// RunOnce runs exactly one cleanup cycle, bounded by whatever ctx it's
+// given - scheduling and leadership are entirely the caller's concern;
+// RunOnce itself doesn't loop or know who's calling it.
+func (w *Worker) RunOnce(ctx context.Context) {
 	start := time.Now()
 	runCtx, cancel := context.WithTimeout(ctx, w.runTimeout)
 	defer cancel()

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -2,19 +2,22 @@ package retention
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
 
-	"github.com/nicolastakashi/prom-analytics-proxy/api/models"
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/config"
 	"github.com/nicolastakashi/prom-analytics-proxy/internal/db"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
+// fakeProvider is a minimal db.Provider stand-in. Embedding the (nil)
+// interface means any method this worker doesn't use panics if called -
+// which is what a test wants, rather than a silent zero value.
 type fakeProvider struct {
+	db.Provider
+
 	deleteCalls   []time.Time
 	deleteResults []int64
 	deleteErrors  []error
@@ -40,73 +43,10 @@ func (f *fakeProvider) DeleteQueriesBefore(ctx context.Context, cutoff time.Time
 	return result, nil
 }
 
-func (f *fakeProvider) WithDB(func(*sql.DB))                                            {}
-func (f *fakeProvider) Insert(context.Context, []db.Query) error                        { return nil }
-func (f *fakeProvider) InsertRulesUsage(context.Context, []db.RulesUsage) error         { return nil }
-func (f *fakeProvider) InsertDashboardUsage(context.Context, []db.DashboardUsage) error { return nil }
-func (f *fakeProvider) GetSeriesMetadata(context.Context, db.SeriesMetadataParams) (db.PagedResult, error) {
-	return db.PagedResult{}, nil
-}
-func (f *fakeProvider) UpsertMetricsCatalog(context.Context, []db.MetricCatalogItem) error {
-	return nil
-}
-func (f *fakeProvider) RefreshMetricsUsageSummary(context.Context, db.TimeRange) error { return nil }
-func (f *fakeProvider) UpsertMetricsJobIndex(context.Context, []db.MetricJobIndexItem) error {
-	return nil
-}
-func (f *fakeProvider) ListJobs(context.Context) ([]string, error) { return nil, nil }
-func (f *fakeProvider) GetQueryTypes(context.Context, db.TimeRange, string) (*db.QueryTypesResult, error) {
-	return nil, nil
-}
-func (f *fakeProvider) GetAverageDuration(context.Context, db.TimeRange, string) (*db.AverageDurationResult, error) {
-	return nil, nil
-}
-func (f *fakeProvider) GetQueryRate(context.Context, db.TimeRange, string, string) (*db.QueryRateResult, error) {
-	return nil, nil
-}
-func (f *fakeProvider) GetQueriesBySerieName(context.Context, db.QueriesBySerieNameParams) (db.PagedResult, error) {
-	return db.PagedResult{}, nil
-}
-func (f *fakeProvider) GetQueryStatusDistribution(context.Context, db.TimeRange, string) ([]db.QueryStatusDistributionResult, error) {
-	return nil, nil
-}
-func (f *fakeProvider) GetQueryLatencyTrends(context.Context, db.TimeRange, string, string) ([]db.QueryLatencyTrendsResult, error) {
-	return nil, nil
-}
-func (f *fakeProvider) GetQueryThroughputAnalysis(context.Context, db.TimeRange) ([]db.QueryThroughputAnalysisResult, error) {
-	return nil, nil
-}
-func (f *fakeProvider) GetQueryErrorAnalysis(context.Context, db.TimeRange, string) ([]db.QueryErrorAnalysisResult, error) {
-	return nil, nil
-}
-func (f *fakeProvider) GetQueryTimeRangeDistribution(context.Context, db.TimeRange, string) ([]db.QueryTimeRangeDistributionResult, error) {
-	return nil, nil
-}
-func (f *fakeProvider) GetQueryExpressions(context.Context, db.QueryExpressionsParams) (db.PagedResult, error) {
-	return db.PagedResult{}, nil
-}
-func (f *fakeProvider) GetQueryExecutions(context.Context, db.QueryExecutionsParams) (db.PagedResult, error) {
-	return db.PagedResult{}, nil
-}
-func (f *fakeProvider) GetMetricStatistics(context.Context, string, db.TimeRange) (db.MetricUsageStatics, error) {
-	return db.MetricUsageStatics{}, nil
-}
-func (f *fakeProvider) GetMetricQueryPerformanceStatistics(context.Context, string, db.TimeRange) (db.MetricQueryPerformanceStatistics, error) {
-	return db.MetricQueryPerformanceStatistics{}, nil
-}
-func (f *fakeProvider) GetRulesUsage(context.Context, db.RulesUsageParams) (db.PagedResult, error) {
-	return db.PagedResult{}, nil
-}
-func (f *fakeProvider) GetDashboardUsage(context.Context, db.DashboardUsageParams) (db.PagedResult, error) {
-	return db.PagedResult{}, nil
-}
-func (f *fakeProvider) GetSeriesMetadataByNames(context.Context, []string, string) ([]models.MetricMetadata, error) {
-	return nil, nil
-}
-func (f *fakeProvider) Close() error { return nil }
-
-func TestNewWorker(t *testing.T) {
-	cfg := &config.Config{
+// baseRetentionConfig is a valid config every constructor test starts from,
+// so each one only has to state the single field it's about.
+func baseRetentionConfig() *config.Config {
+	return &config.Config{
 		Retention: config.RetentionConfig{
 			Enabled:       true,
 			Interval:      1 * time.Hour,
@@ -114,152 +54,91 @@ func TestNewWorker(t *testing.T) {
 			QueriesMaxAge: 30 * 24 * time.Hour,
 		},
 	}
+}
+
+func TestNewWorker(t *testing.T) {
+	cfg := baseRetentionConfig()
 
 	fakeProv := &fakeProvider{}
 
 	w, err := NewWorker(fakeProv, cfg, prometheus.NewRegistry())
 	assert.NoError(t, err)
 	assert.NotNil(t, w)
-	assert.Equal(t, cfg.Retention.Interval, w.interval)
 	assert.Equal(t, cfg.Retention.RunTimeout, w.runTimeout)
 	assert.Equal(t, cfg.Retention.QueriesMaxAge, w.queriesMaxAge)
 }
 
-func TestNewWorker_RejectsZeroQueriesMaxAge(t *testing.T) {
-	cfg := &config.Config{
-		Retention: config.RetentionConfig{
-			Enabled:       true,
-			Interval:      1 * time.Hour,
-			RunTimeout:    5 * time.Minute,
-			QueriesMaxAge: 0,
+// TestNewWorker_ConfigValidation covers the mechanical half of NewWorker's
+// construction gate: every value it requires to be positive. The two cases
+// whose reasoning needs explaining stay separate tests below.
+func TestNewWorker_ConfigValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		tweak   func(*config.RetentionConfig)
+		wantErr string
+	}{
+		{
+			name:    "interval zero",
+			tweak:   func(c *config.RetentionConfig) { c.Interval = 0 },
+			wantErr: "interval must be positive",
 		},
+		{
+			name:    "interval negative",
+			tweak:   func(c *config.RetentionConfig) { c.Interval = -time.Hour },
+			wantErr: "interval must be positive",
+		},
+		{
+			name:    "run_timeout zero",
+			tweak:   func(c *config.RetentionConfig) { c.RunTimeout = 0 },
+			wantErr: "run_timeout must be positive",
+		},
+		{
+			name:    "run_timeout negative",
+			tweak:   func(c *config.RetentionConfig) { c.RunTimeout = -time.Minute },
+			wantErr: "run_timeout must be positive",
+		},
+		{
+			name:    "queries_max_age zero",
+			tweak:   func(c *config.RetentionConfig) { c.QueriesMaxAge = 0 },
+			wantErr: "queries_max_age must be positive",
+		},
+		{
+			name:    "queries_max_age negative",
+			tweak:   func(c *config.RetentionConfig) { c.QueriesMaxAge = -time.Hour },
+			wantErr: "queries_max_age must be positive",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseRetentionConfig()
+			tc.tweak(&cfg.Retention)
+
+			w, err := NewWorker(&fakeProvider{}, cfg, prometheus.NewRegistry())
+
+			assert.Error(t, err)
+			assert.Nil(t, w)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
 	}
-
-	fakeProv := &fakeProvider{}
-
-	w, err := NewWorker(fakeProv, cfg, prometheus.NewRegistry())
-	assert.Error(t, err)
-	assert.Nil(t, w)
-	assert.Contains(t, err.Error(), "queries_max_age must be positive")
 }
 
-func TestNewWorker_RejectsNegativeQueriesMaxAge(t *testing.T) {
-	cfg := &config.Config{
-		Retention: config.RetentionConfig{
-			Enabled:       true,
-			Interval:      1 * time.Hour,
-			RunTimeout:    5 * time.Minute,
-			QueriesMaxAge: -1 * time.Hour,
-		},
-	}
+func TestNewWorker_AcceptsIntervalTooSmallToJitter(t *testing.T) {
+	cfg := baseRetentionConfig()
+	cfg.Retention.Interval = 4 * time.Nanosecond
 
 	fakeProv := &fakeProvider{}
 
 	w, err := NewWorker(fakeProv, cfg, prometheus.NewRegistry())
-	assert.Error(t, err)
-	assert.Nil(t, w)
-	assert.Contains(t, err.Error(), "queries_max_age must be positive")
-}
-
-func TestNewWorker_RejectsZeroInterval(t *testing.T) {
-	cfg := &config.Config{
-		Retention: config.RetentionConfig{
-			Enabled:       true,
-			Interval:      0,
-			RunTimeout:    5 * time.Minute,
-			QueriesMaxAge: 30 * 24 * time.Hour,
-		},
-	}
-
-	fakeProv := &fakeProvider{}
-
-	w, err := NewWorker(fakeProv, cfg, prometheus.NewRegistry())
-	assert.Error(t, err)
-	assert.Nil(t, w)
-	assert.Contains(t, err.Error(), "interval must be positive")
-}
-
-func TestNewWorker_RejectsNegativeInterval(t *testing.T) {
-	cfg := &config.Config{
-		Retention: config.RetentionConfig{
-			Enabled:       true,
-			Interval:      -1 * time.Hour,
-			RunTimeout:    5 * time.Minute,
-			QueriesMaxAge: 30 * 24 * time.Hour,
-		},
-	}
-
-	fakeProv := &fakeProvider{}
-
-	w, err := NewWorker(fakeProv, cfg, prometheus.NewRegistry())
-	assert.Error(t, err)
-	assert.Nil(t, w)
-	assert.Contains(t, err.Error(), "interval must be positive")
-}
-
-func TestNewWorker_RejectsZeroRunTimeout(t *testing.T) {
-	cfg := &config.Config{
-		Retention: config.RetentionConfig{
-			Enabled:       true,
-			Interval:      1 * time.Hour,
-			RunTimeout:    0,
-			QueriesMaxAge: 30 * 24 * time.Hour,
-		},
-	}
-
-	fakeProv := &fakeProvider{}
-
-	w, err := NewWorker(fakeProv, cfg, prometheus.NewRegistry())
-	assert.Error(t, err)
-	assert.Nil(t, w)
-	assert.Contains(t, err.Error(), "run_timeout must be positive")
-}
-
-func TestNewWorker_RejectsNegativeRunTimeout(t *testing.T) {
-	cfg := &config.Config{
-		Retention: config.RetentionConfig{
-			Enabled:       true,
-			Interval:      1 * time.Hour,
-			RunTimeout:    -1 * time.Minute,
-			QueriesMaxAge: 30 * 24 * time.Hour,
-		},
-	}
-
-	fakeProv := &fakeProvider{}
-
-	w, err := NewWorker(fakeProv, cfg, prometheus.NewRegistry())
-	assert.Error(t, err)
-	assert.Nil(t, w)
-	assert.Contains(t, err.Error(), "run_timeout must be positive")
-}
-
-func TestNewWorker_RejectsIntervalLessThan5Nanoseconds(t *testing.T) {
-	cfg := &config.Config{
-		Retention: config.RetentionConfig{
-			Enabled:       true,
-			Interval:      4 * time.Nanosecond,
-			RunTimeout:    5 * time.Minute,
-			QueriesMaxAge: 30 * 24 * time.Hour,
-		},
-	}
-
-	fakeProv := &fakeProvider{}
-
-	w, err := NewWorker(fakeProv, cfg, prometheus.NewRegistry())
-	// This should still pass validation since interval > 0, but runLoop should handle it defensively
+	// Positive is all this validation guarantees: coping with an interval
+	// too small for 20% of it to be a whole nanosecond is the scheduler's
+	// job, not a reason to reject the config.
 	assert.NoError(t, err)
 	assert.NotNil(t, w)
 }
 
 func TestNewWorker_RejectsZeroQueriesMaxAgeEvenWhenDisabled(t *testing.T) {
-	cfg := &config.Config{
-		Retention: config.RetentionConfig{
-			Enabled:       false,
-			Interval:      1 * time.Hour,
-			RunTimeout:    5 * time.Minute,
-			QueriesMaxAge: 0,
-		},
-	}
+	cfg := baseRetentionConfig()
+	cfg.Retention.Enabled = false
+	cfg.Retention.QueriesMaxAge = 0
 
 	fakeProv := &fakeProvider{}
 
@@ -269,7 +148,7 @@ func TestNewWorker_RejectsZeroQueriesMaxAgeEvenWhenDisabled(t *testing.T) {
 	assert.Contains(t, err.Error(), "queries_max_age must be positive")
 }
 
-func TestWorker_runOnce(t *testing.T) {
+func TestWorker_RunOnce(t *testing.T) {
 	fakeProv := &fakeProvider{
 		deleteResults: []int64{42},
 		deleteErrors:  []error{nil},
@@ -277,7 +156,6 @@ func TestWorker_runOnce(t *testing.T) {
 
 	w := &Worker{
 		dbProvider:    fakeProv,
-		interval:      1 * time.Hour,
 		runTimeout:    5 * time.Minute,
 		queriesMaxAge: 30 * 24 * time.Hour,
 		runDuration:   prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_duration"}, []string{"status"}),
@@ -286,7 +164,7 @@ func TestWorker_runOnce(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	w.runOnce(ctx)
+	w.RunOnce(ctx)
 
 	assert.Len(t, fakeProv.deleteCalls, 1, "DeleteQueriesBefore should be called once")
 
@@ -299,7 +177,7 @@ func TestWorker_runOnce(t *testing.T) {
 	assert.Less(t, diff, 1*time.Second, "cutoff should be approximately now - queriesMaxAge")
 }
 
-func TestWorker_runOnce_Error(t *testing.T) {
+func TestWorker_RunOnce_Error(t *testing.T) {
 	fakeProv := &fakeProvider{
 		deleteResults: []int64{0},
 		deleteErrors:  []error{errors.New("database error")},
@@ -307,7 +185,6 @@ func TestWorker_runOnce_Error(t *testing.T) {
 
 	w := &Worker{
 		dbProvider:    fakeProv,
-		interval:      1 * time.Hour,
 		runTimeout:    5 * time.Minute,
 		queriesMaxAge: 30 * 24 * time.Hour,
 		runDuration:   prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_duration"}, []string{"status"}),
@@ -316,17 +193,16 @@ func TestWorker_runOnce_Error(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	w.runOnce(ctx)
+	w.RunOnce(ctx)
 
 	assert.Len(t, fakeProv.deleteCalls, 1, "DeleteQueriesBefore should be called once")
 }
 
-func TestWorker_runOnce_SkipsDeletionWhenQueriesMaxAgeIsZero(t *testing.T) {
+func TestWorker_RunOnce_SkipsDeletionWhenQueriesMaxAgeIsZero(t *testing.T) {
 	fakeProv := &fakeProvider{}
 
 	w := &Worker{
 		dbProvider:    fakeProv,
-		interval:      1 * time.Hour,
 		runTimeout:    5 * time.Minute,
 		queriesMaxAge: 0,
 		runDuration:   prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_duration"}, []string{"status"}),
@@ -335,17 +211,16 @@ func TestWorker_runOnce_SkipsDeletionWhenQueriesMaxAgeIsZero(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	w.runOnce(ctx)
+	w.RunOnce(ctx)
 
 	assert.Len(t, fakeProv.deleteCalls, 0, "DeleteQueriesBefore should not be called when queriesMaxAge is zero")
 }
 
-func TestWorker_runOnce_SkipsDeletionWhenQueriesMaxAgeIsNegative(t *testing.T) {
+func TestWorker_RunOnce_SkipsDeletionWhenQueriesMaxAgeIsNegative(t *testing.T) {
 	fakeProv := &fakeProvider{}
 
 	w := &Worker{
 		dbProvider:    fakeProv,
-		interval:      1 * time.Hour,
 		runTimeout:    5 * time.Minute,
 		queriesMaxAge: -1 * time.Hour,
 		runDuration:   prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_duration"}, []string{"status"}),
@@ -354,42 +229,7 @@ func TestWorker_runOnce_SkipsDeletionWhenQueriesMaxAgeIsNegative(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	w.runOnce(ctx)
+	w.RunOnce(ctx)
 
 	assert.Len(t, fakeProv.deleteCalls, 0, "DeleteQueriesBefore should not be called when queriesMaxAge is negative")
-}
-
-func TestWorker_runLoop_HandlesSmallInterval(t *testing.T) {
-	fakeProv := &fakeProvider{
-		deleteResults: []int64{0},
-		deleteErrors:  []error{nil},
-	}
-
-	w := &Worker{
-		dbProvider:    fakeProv,
-		interval:      4 * time.Nanosecond, // Less than 5ns, which would cause w.interval/5 to be 0
-		runTimeout:    5 * time.Minute,
-		queriesMaxAge: 30 * 24 * time.Hour,
-		runDuration:   prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_duration"}, []string{"status"}),
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-
-	// This should not panic even with a very small interval
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		w.runLoop(ctx)
-	}()
-
-	select {
-	case <-done:
-		// runLoop exited normally (due to context cancellation)
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("runLoop should have exited within timeout")
-	}
-
-	// Verify that runOnce was called at least once
-	assert.GreaterOrEqual(t, len(fakeProv.deleteCalls), 1, "runOnce should have been called at least once")
 }

--- a/main.go
+++ b/main.go
@@ -114,6 +114,14 @@ func main() {
 		}
 	}
 	config.LogConfig(cmd)
+	// Before anything acts on the config: a value no consumer could use is
+	// an operator's typo, and this is the last point at which saying so
+	// costs nothing - past here, startup opens the database and runs
+	// migrations.
+	if err := config.DefaultConfig.Validate(); err != nil {
+		slog.Error("invalid configuration", "err", err)
+		os.Exit(1)
+	}
 	configureGoMemLimit(logger, config.DefaultConfig.MemoryLimit)
 	var shutdown func()
 	if config.DefaultConfig.IsTracingEnabled() {


### PR DESCRIPTION
Depends on #611 and #614.

Wiring a job asked which database provider it was running on and then did one of two different things: run it under an `Elector`, or schedule it directly with no elector at all. The second path existed only because SQLite has nothing to elect, and it cost a provider argument, an elector argument that had to be nil on exactly one path, and a branch in the one function that is supposed to make both jobs look alike.

`NewSoleInstance` closes that from the other side: an `Elector` that holds leadership unconditionally, for a deployment where this replica is the only one that could run the job anyway. It touches no lock, no lease row and no table — which is why it takes no `*sql.DB`, and why it works on SQLite, whose migrations create no `leader_leases` table at all. Leadership now has one answer for every provider, so `addPeriodicJob` takes an `Elector` and schedules one way.

Two things follow that are worth having on their own. The leadership metrics now exist in every deployment rather than only under PostgreSQL, so a fleet-wide "no leader for this lease" panel stops silently excluding replicas. And a job that panics goes through the same release-then-repanic path everywhere, instead of only where an elector happened to be involved.

One behavioural difference this does introduce: an elector hands leadership to nobody if its context is already canceled, where the direct path ran one cycle regardless. That only shows up in a process shutting down as it starts, and the tests wait for a cycle rather than racing it.
